### PR TITLE
Open all code examples by default

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -23,7 +23,7 @@ export const parameters = {
     },
   },
   docs: {
-    source: { state: 'open' }
+    source: { state: 'open' },
   },
   options: {
     method: 'alphabetical',


### PR DESCRIPTION
All code examples in storybook will now be open by default

<img width="1110" alt="Screenshot 2021-10-28 at 19 32 42" src="https://user-images.githubusercontent.com/6078361/139306081-0e4b5501-a339-4ce5-ac94-4e3419bc1224.png">

