### PR TITLE
Corrected attribute on `uui-avatar` example

### DIFF
--- a/packages/uui-avatar/README.md
+++ b/packages/uui-avatar/README.md
@@ -37,5 +37,6 @@ The component is available via CDN. This means it can be added to your applicati
 ## Usage
 
 ```html
-<uui-avatar title="First Last"></uui-avatar> <uui-avatar src="..."></uui-avatar>
+<uui-avatar title="First Last"></uui-avatar>
+<uui-avatar img-src="..."></uui-avatar>
 ```


### PR DESCRIPTION
## Description

I'd noticed that the example of the [`<uui-avatar>` component](https://github.com/umbraco/Umbraco.UI/tree/dev/packages/uui-avatar) uses `src` instead of `img-src`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

Following an example of how to use the [`<uui-avatar>` component](https://github.com/umbraco/Umbraco.UI/tree/dev/packages/uui-avatar), I noticed that the README's example uses the `src` attribute, but that didn't work, and saw on Storybook that the attribute is `img-src` instead.

## Checklist

- [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
