### PR TITLE
Feature/format ts config with prettier

### DIFF
--- a/packages/uui-action-bar/tsconfig.json
+++ b/packages/uui-action-bar/tsconfig.json
@@ -12,6 +12,9 @@
   "references": [
     {
       "path": "../uui-base"
+    },
+    {
+      "path": "../uui-button-group"
     }
   ]
 }

--- a/packages/uui-avatar-group/tsconfig.json
+++ b/packages/uui-avatar-group/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-avatar/tsconfig.json
+++ b/packages/uui-avatar/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-badge/tsconfig.json
+++ b/packages/uui-badge/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-base/tsconfig.json
+++ b/packages/uui-base/tsconfig.json
@@ -7,12 +7,7 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": []
 }

--- a/packages/uui-box/tsconfig.json
+++ b/packages/uui-box/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-breadcrumbs/tsconfig.json
+++ b/packages/uui-breadcrumbs/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-button-group/tsconfig.json
+++ b/packages/uui-button-group/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-button/tsconfig.json
+++ b/packages/uui-button/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-checkbox/tsconfig.json
+++ b/packages/uui-checkbox/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-input/tsconfig.json
+++ b/packages/uui-input/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-keyboard-shortcut/tsconfig.json
+++ b/packages/uui-keyboard-shortcut/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-loader-bar/tsconfig.json
+++ b/packages/uui-loader-bar/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-loader-circle/tsconfig.json
+++ b/packages/uui-loader-circle/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-loader/tsconfig.json
+++ b/packages/uui-loader/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-radio/tsconfig.json
+++ b/packages/uui-radio/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-slider/tsconfig.json
+++ b/packages/uui-slider/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-table/tsconfig.json
+++ b/packages/uui-table/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-tabs/tsconfig.json
+++ b/packages/uui-tabs/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-tag/tsconfig.json
+++ b/packages/uui-tag/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-textarea/tsconfig.json
+++ b/packages/uui-textarea/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/packages/uui-toggle/tsconfig.json
+++ b/packages/uui-toggle/tsconfig.json
@@ -7,13 +7,8 @@
     "rootDir": "./lib",
     "composite": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "./**/*.test.ts",
-    "./**/*.story.ts"
-  ],
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./**/*.story.ts"],
   "references": [
     {
       "path": "../uui-base"

--- a/scripts/generate-ts-config.js
+++ b/scripts/generate-ts-config.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const path = require('path');
 const fs = require('fs');
+const prettier = require('prettier');
 const {
   packageDirectoryNames,
   packagesRoot,
@@ -51,10 +52,10 @@ const generatePackageTSConfig = () => {
       const tsConfig = { ...tsConfigBase, references };
       const tsconfigPath = path.join(packageDirectory, 'tsconfig.json');
 
-      fs.writeFileSync(
-        tsconfigPath,
-        TSCONFIG_COMMENT + JSON.stringify(tsConfig, null, '  ')
-      );
+      const content = TSCONFIG_COMMENT + JSON.stringify(tsConfig, null, '  ');
+      const formattedContent = prettier.format(content, { parser: 'json' });
+
+      fs.writeFileSync(tsconfigPath, formattedContent);
 
       console.log(`Generated tsconfig for ${packageJSONData.name}`);
     }


### PR DESCRIPTION
## Description

Sometimes husky complains if you want to commit a local version of a tsconfig file that after formatting with husky only includes whitespace.

This PR adds prettier formatting to the tsconfig files before they are written to disc so formatting aligns with husky.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
