### PR TITLE
Enable more custom styling of uui-input

### DIFF
--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -25,6 +25,17 @@ export type InputType =
  * @fires UUIInputEvent#change on change
  * @fires InputEvent#input on input
  * @fires KeyboardEvent#keyup on keyup
+ * @cssprop --uui-input-height - overwrite the input height
+ * @cssprop --uui-input-padding-y - overwrite the input padding top and bottom (y-axis)
+ * @cssprop --uui-input-padding-x - overwrite the input padding left and right (x-axis)
+ * @cssprop --uui-input-font-size - overwrite the input font size
+ * @cssprop --uui-input-background-color - overwrite the input background color
+ * @cssprop --uui-input-border-color - overwrite the input border color
+ * @cssprop --uui-input-border-color-hover - overwrite the input border color on hover
+ * @cssprop --uui-input-border-color-focus - overwrite the input border color on focus
+ * @cssprop --uui-input-border-color-invalid - overwrite the input border color on invalid or error
+ * @cssprop  --uui-input-background-color-disabled - overwrite the input background color on disabled
+ *
  */
 export class UUIInputElement extends LabelMixin('input label', LitElement) {
   static styles = [
@@ -34,10 +45,11 @@ export class UUIInputElement extends LabelMixin('input label', LitElement) {
       }
       input {
         display: inline-block;
-        height: var(--uui-size-11);
-        padding: var(--uui-size-1) var(--uui-size-2);
+        height: var(--uui-input-height, var(--uui-size-11));
+        padding: var(--uui-input-padding-y, var(--uui-size-1))
+          var(--uui-input-padding-x, var(--uui-size-2));
         font-family: inherit;
-        font-size: 15px;
+        font-size: var(--uui-input-font-size, 15px);
         color: inherit;
         border-radius: 0;
         box-sizing: border-box;
@@ -63,7 +75,10 @@ export class UUIInputElement extends LabelMixin('input label', LitElement) {
         );
       }
       :host([invalid]) {
-        border-color: var(--uui-color-danger-background);
+        border-color: var(
+          --uui-input-border-color-invalid,
+          var(--uui-look-danger-border)
+        );
       }
 
       :host([type='color']) {
@@ -106,11 +121,13 @@ export class UUIInputElement extends LabelMixin('input label', LitElement) {
       }
 
       :host([error]) input {
-        border: 1px solid var(--uui-look-danger-border);
+        border: 1px solid
+          var(--uui-input-border-color-invalid, var(--uui-look-danger-border));
       }
 
       :host([error]) input[disabled] {
-        border: 1px solid var(--uui-look-danger-border);
+        border: 1px solid
+          var(--uui-input-border-color-invalid, var(--uui-look-danger-border));
       }
     `,
   ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds following custom properties to the uui-input component:

-  --uui-input-height - overwrite the input height
-  --uui-input-padding-y - overwrite the input padding top and bottom (y-axis)
-  --uui-input-padding-x - overwrite the input padding left and right (x-axis)
-  --uui-input-font-size - overwrite the input font size

it also adds missing documentation for other custom properties:

-  --uui-input-background-color - overwrite the input background color
-  --uui-input-border-color - overwrite the input border color
-  --uui-input-border-color-hover - overwrite the input border color on hover
-  --uui-input-border-color-focus - overwrite the input border color on focus
-  --uui-input-border-color-invalid - overwrite the input border color on invalid or error
-  --uui-input-background-color-disabled - overwrite the input background color on disabled

 

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context
It should be possible to style padding, height, and font size from the outside of the shadow dom.
<!--- Why is this change required? What problem does it solve? -->



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
