### PR TITLE
add --uui-button-font-size custom property

### DIFF
--- a/packages/uui-button/lib/uui-button.element.ts
+++ b/packages/uui-button/lib/uui-button.element.ts
@@ -26,6 +26,7 @@ export type UUIButtonType = 'submit' | 'button' | 'reset';
  *  @cssprop --uui-button-border-width - overwrite the border width
  *  @cssprop --uui-button-border-radius - overwrite the border radius
  *  @cssprop --uui-button-font-weight - overwrite the font weight
+ *  @cssprop --uui-button-font-size - overwrite the font size
  *  @cssprop --uui-button-background-color - overwrite the background color
  *  @cssprop --uui-button-background-color-hover - overwrite the background color for hover state
  *  @cssprop --uui-button-background-color-disabled - overwrite the background color for disabled state
@@ -100,7 +101,7 @@ export class UUIButtonElement extends LabelMixin('', LitElement) {
           --uui-button-font-weight,
           var(--uui-interface-font-weight)
         );
-        font-size: inherit;
+        font-size: var(--uui-button-font-size, inherit);
         font-family: inherit;
 
         background-color: var(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a `--uui-button-font-size` custom property that allows changing font size for many buttons in nested shadow dom trees
<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
