### PR TITLE
Don't squeeze avatar

### DIFF
--- a/packages/uui-avatar/lib/uui-avatar.element.ts
+++ b/packages/uui-avatar/lib/uui-avatar.element.ts
@@ -13,6 +13,7 @@ export class UUIAvatarElement extends LitElement {
         display: inline-flex;
         align-items: center;
         justify-content: center;
+        flex-shrink: 0;
         position: relative;
         overflow: hidden;
         border-radius: 50%;


### PR DESCRIPTION
## Description

I noticed in the advanced table example using `<uui-avatar>` that this was squeezed on smaller screen sizes.

**Before**

![image](https://user-images.githubusercontent.com/2919859/152112078-40375952-a394-4655-b95b-05993be027fc.png)

**After**

![image](https://user-images.githubusercontent.com/2919859/152112026-ab0934a0-407b-4fd9-9f98-11af06300c62.png)


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
