### PR TITLE
Remove UMD bundles from individual packages

### DIFF
--- a/packages/rollup-package.config.js
+++ b/packages/rollup-package.config.js
@@ -83,7 +83,7 @@ export const UUIProdConfig = ({
   entryPoints = [],
   cssFiles = [],
   bundle,
-  namespace = 'uui',
+  namespace = '',
 }) => {
   const cssFilesConfig = createCSSFilesConfig(cssFiles);
   const esModulesConfig = createEsModulesConfig(entryPoints);

--- a/packages/uui-action-bar/README.md
+++ b/packages/uui-action-bar/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIActionBarElement` base class as a type and/or f
 import { UUIActionBarElement } from '@umbraco-ui/uui-action-bar';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-action-bar@latest/dist/uui-action-bar.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-action-bar@X.X.X/dist/uui-action-bar.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-action-bar/package.json
+++ b/packages/uui-action-bar/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-action-bar.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-action-bar/package.json
+++ b/packages/uui-action-bar/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-action-bar/rollup.config.js
+++ b/packages/uui-action-bar/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-avatar-group/README.md
+++ b/packages/uui-avatar-group/README.md
@@ -22,18 +22,6 @@ When looking to leverage the `UUIAvatarGroupElement` base class as a type and/or
 import { UUIAvatarGroupElement } from '@umbraco-ui/uui-avatar-group';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-avatar-group@latest/dist/uui-avatar-group.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-avatar-group@X.X.X/dist/uui-avatar-group.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-avatar-group/package.json
+++ b/packages/uui-avatar-group/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-avatar-group.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-avatar-group/package.json
+++ b/packages/uui-avatar-group/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-avatar-group/rollup.config.js
+++ b/packages/uui-avatar-group/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-avatar/README.md
+++ b/packages/uui-avatar/README.md
@@ -22,18 +22,6 @@ When looking to leverage the `UUIAvatarElement` base class as a type and/or for 
 import { UUIAvatarElement } from '@umbraco-ui/uui-avatar';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-avatar@latest/dist/uui-avatar.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-avatar@X.X.X/dist/uui-avatar.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-avatar/package.json
+++ b/packages/uui-avatar/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-avatar.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-avatar/package.json
+++ b/packages/uui-avatar/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-avatar/rollup.config.js
+++ b/packages/uui-avatar/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-badge/README.md
+++ b/packages/uui-badge/README.md
@@ -22,18 +22,6 @@ When looking to leverage the `UUIBadgeElement` base class as a type and/or for e
 import { UUIBadgeElement } from '@umbraco-ui/uui-badge';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-badge@latest/dist/uui-badge.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-badge@X.X.X/dist/uui-badge.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-badge/package.json
+++ b/packages/uui-badge/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-badge.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-badge/package.json
+++ b/packages/uui-badge/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-badge/rollup.config.js
+++ b/packages/uui-badge/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-base/lib/events/UUISelectableEvent.ts
+++ b/packages/uui-base/lib/events/UUISelectableEvent.ts
@@ -1,4 +1,4 @@
-import { UUIEvent } from '@umbraco-ui/uui-base/lib/events';
+import { UUIEvent } from '../events';
 import { SelectableMixinInterface } from '../mixins';
 
 export class UUISelectableEvent extends UUIEvent<{}, SelectableMixinInterface> {

--- a/packages/uui-base/lib/events/UUISelectableEvent.ts
+++ b/packages/uui-base/lib/events/UUISelectableEvent.ts
@@ -1,5 +1,5 @@
-import { UUIEvent } from '../events';
 import { SelectableMixinInterface } from '../mixins';
+import { UUIEvent } from './UUIEvent';
 
 export class UUISelectableEvent extends UUIEvent<{}, SelectableMixinInterface> {
   public static readonly SELECTED = 'selected';

--- a/packages/uui-base/package.json
+++ b/packages/uui-base/package.json
@@ -20,7 +20,6 @@
   },
   "main": "./lib/index.js",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js"
   ],

--- a/packages/uui-base/package.json
+++ b/packages/uui-base/package.json
@@ -18,7 +18,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-base.min.js",
+  "main": "./lib/index.js",
   "files": [
     "dist",
     "lib/**/*.d.ts",

--- a/packages/uui-boolean-input/README.md
+++ b/packages/uui-boolean-input/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIBooleanInputElement` base class as a type and/o
 import { UUIBooleanInputElement } from '@umbraco-ui/uui-boolean-input';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-boolean-input@latest/dist/uui-boolean-input.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-boolean-input@X.X.X/dist/uui-boolean-input.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-boolean-input/package.json
+++ b/packages/uui-boolean-input/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-boolean-input.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-boolean-input/package.json
+++ b/packages/uui-boolean-input/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-boolean-input/rollup.config.js
+++ b/packages/uui-boolean-input/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-box/README.md
+++ b/packages/uui-box/README.md
@@ -22,18 +22,6 @@ When looking to leverage the `UUIBoxElement` base class as a type and/or for ext
 import { UUIBoxElement } from '@umbraco-ui/uui-box';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-box@latest/dist/uui-box.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-box@X.X.X/dist/uui-box.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-box/package.json
+++ b/packages/uui-box/package.json
@@ -18,7 +18,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-box.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-box/package.json
+++ b/packages/uui-box/package.json
@@ -23,7 +23,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-box/rollup.config.js
+++ b/packages/uui-box/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-breadcrumbs/README.md
+++ b/packages/uui-breadcrumbs/README.md
@@ -25,18 +25,6 @@ import {
 } from '@umbraco-ui/uui-breadcrumbs';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-breadcrumbs@latest/dist/uui-breadcrumbs.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-breadcrumbs@X.X.X/dist/uui-breadcrumbs.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-breadcrumbs/package.json
+++ b/packages/uui-breadcrumbs/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-breadcrumbs.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-breadcrumbs/package.json
+++ b/packages/uui-breadcrumbs/package.json
@@ -26,7 +26,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-breadcrumbs/rollup.config.js
+++ b/packages/uui-breadcrumbs/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-button-group/README.md
+++ b/packages/uui-button-group/README.md
@@ -22,18 +22,6 @@ When looking to leverage the `UUIButtonGroupElement` base class as a type and/or
 import { UUIButtonGroupElement } from '@umbraco-ui/uui-button-group';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-button-group@latest/dist/uui-button-group.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-button-group@X.X.X/dist/uui-button-group.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-button-group/package.json
+++ b/packages/uui-button-group/package.json
@@ -25,7 +25,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-button-group/package.json
+++ b/packages/uui-button-group/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-button-group.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-button-group/rollup.config.js
+++ b/packages/uui-button-group/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-button-inline-create/README.md
+++ b/packages/uui-button-inline-create/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIButtonInlineCreateElement` base class as a type
 import { UUIButtonInlineCreateElement } from '@umbraco-ui/uui-button-inline-create';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-button-inline-create@latest/dist/uui-button-inline-create.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-button-inline-create@X.X.X/dist/uui-button-inline-create.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-button-inline-create/package.json
+++ b/packages/uui-button-inline-create/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-button-inline-create.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-button-inline-create/package.json
+++ b/packages/uui-button-inline-create/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-button-inline-create/rollup.config.js
+++ b/packages/uui-button-inline-create/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-button/README.md
+++ b/packages/uui-button/README.md
@@ -22,18 +22,6 @@ When looking to leverage the `UUIButtonElement` base class as a type and/or for 
 import { UUIButtonElement } from '@umbraco-ui/uui-button';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-button@latest/dist/uui-button.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-button@X.X.X/dist/uui-button.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-button/package.json
+++ b/packages/uui-button/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-button.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-button/package.json
+++ b/packages/uui-button/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-button/rollup.config.js
+++ b/packages/uui-button/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-card-content-node/README.md
+++ b/packages/uui-card-content-node/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUICardContentNodeElement` base class as a type an
 import { UUICardContentNodeElement } from '@umbraco-ui/uui-card-content-node';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-card-content-node@latest/dist/uui-card-content-node.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-card-content-node@X.X.X/dist/uui-card-content-node.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-card-content-node/package.json
+++ b/packages/uui-card-content-node/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-card-content-node.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-card-content-node/package.json
+++ b/packages/uui-card-content-node/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-card-content-node/rollup.config.js
+++ b/packages/uui-card-content-node/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-card-media/README.md
+++ b/packages/uui-card-media/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUICardMediaElement` base class as a type and/or f
 import { UUICardMediaElement } from '@umbraco-ui/uui-card-media';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-card-media@latest/dist/uui-card-media.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-card-media@X.X.X/dist/uui-card-media.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-card-media/package.json
+++ b/packages/uui-card-media/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-card-media.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-card-media/package.json
+++ b/packages/uui-card-media/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-card-media/rollup.config.js
+++ b/packages/uui-card-media/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-card-user/package.json
+++ b/packages/uui-card-user/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/index.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-card-user/package.json
+++ b/packages/uui-card-user/package.json
@@ -25,7 +25,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-card-user/rollup.config.js
+++ b/packages/uui-card-user/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundles: ['index'],
 });

--- a/packages/uui-card/package.json
+++ b/packages/uui-card/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/index.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-card/package.json
+++ b/packages/uui-card/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-caret/README.md
+++ b/packages/uui-caret/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUICaretElement` base class as a type and/or for e
 import { UUICaretElement } from '@umbraco-ui/uui-caret';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-caret@latest/dist/uui-caret.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-caret@X.X.X/dist/uui-caret.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-caret/package.json
+++ b/packages/uui-caret/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-caret/package.json
+++ b/packages/uui-caret/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-caret.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-caret/rollup.config.js
+++ b/packages/uui-caret/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-checkbox/README.md
+++ b/packages/uui-checkbox/README.md
@@ -22,18 +22,6 @@ When looking to leverage the `UUICheckboxElement` base class as a type and/or fo
 import { UUICheckboxElement } from '@umbraco-ui/uui-checkbox';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-checkbox@latest/dist/uui-checkbox.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-checkbox@X.X.X/dist/uui-checkbox.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-checkbox/package.json
+++ b/packages/uui-checkbox/package.json
@@ -27,7 +27,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-checkbox/package.json
+++ b/packages/uui-checkbox/package.json
@@ -22,7 +22,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-checkbox.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-checkbox/rollup.config.js
+++ b/packages/uui-checkbox/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-css/package.json
+++ b/packages/uui-css/package.json
@@ -22,13 +22,11 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
-  "customElements": "custom-elements.json",
   "files": [
     "assets",
     "dist",
     "lib/**/*.d.ts",
-    "lib/**/*.js",
-    "custom-elements.json"
+    "lib/**/*.js"
   ],
   "dependencies": {
     "lit": "^2.0.0"

--- a/packages/uui-css/package.json
+++ b/packages/uui-css/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-css.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-css/rollup.config.js
+++ b/packages/uui-css/rollup.config.js
@@ -4,5 +4,4 @@ export default UUIProdConfig({
   namespace: 'UUICSS',
   entryPoints: ['index'],
   cssFiles: ['uui-root', 'uui-text'],
-  bundle: 'index',
 });

--- a/packages/uui-dialog/README.md
+++ b/packages/uui-dialog/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIDialogElement` base class as a type and/or for 
 import { UUIDialogElement } from '@umbraco-ui/uui-dialog';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-dialog@latest/dist/uui-dialog.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-dialog@X.X.X/dist/uui-dialog.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-dialog/package.json
+++ b/packages/uui-dialog/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-dialog.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-dialog/package.json
+++ b/packages/uui-dialog/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-dialog/rollup.config.js
+++ b/packages/uui-dialog/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-icon-registry-essential/README.md
+++ b/packages/uui-icon-registry-essential/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIIconRegistryEssentialElement` base class as a t
 import { UUIIconRegistryEssentialElement } from '@umbraco-ui/uui-icon-registry-essential';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-icon-registry-essential@latest/dist/uui-icon-registry-essential.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-icon-registry-essential@X.X.X/dist/uui-icon-registry-essential.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-icon-registry-essential/package.json
+++ b/packages/uui-icon-registry-essential/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-icon-registry-essential.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-icon-registry-essential/package.json
+++ b/packages/uui-icon-registry-essential/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-icon-registry-essential/rollup.config.js
+++ b/packages/uui-icon-registry-essential/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index', 'svgs/index'],
-  bundle: 'index',
 });

--- a/packages/uui-icon-registry/README.md
+++ b/packages/uui-icon-registry/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIIconRegistryElement` base class as a type and/o
 import { UUIIconRegistryElement } from '@umbraco-ui/uui-icon-registry';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-icon-registry@latest/dist/uui-icon-registry.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-icon-registry@X.X.X/dist/uui-icon-registry.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-icon-registry/package.json
+++ b/packages/uui-icon-registry/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-icon-registry.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-icon-registry/package.json
+++ b/packages/uui-icon-registry/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-icon-registry/rollup.config.js
+++ b/packages/uui-icon-registry/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-icon/README.md
+++ b/packages/uui-icon/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIIconElement` base class as a type and/or for ex
 import { UUIIconElement } from '@umbraco-ui/uui-icon';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-icon@latest/dist/uui-icon.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-icon@X.X.X/dist/uui-icon.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-icon/package.json
+++ b/packages/uui-icon/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-icon.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-icon/package.json
+++ b/packages/uui-icon/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-icon/rollup.config.js
+++ b/packages/uui-icon/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-input-password/README.md
+++ b/packages/uui-input-password/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIInputPasswordElement` base class as a type and/
 import { UUIInputPasswordElement } from '@umbraco-ui/uui-input-password';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-input-password@latest/dist/uui-input-password.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-input-password@X.X.X/dist/uui-input-password.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-input-password/package.json
+++ b/packages/uui-input-password/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-input-password.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-input-password/package.json
+++ b/packages/uui-input-password/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-input-password/rollup.config.js
+++ b/packages/uui-input-password/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-input/README.md
+++ b/packages/uui-input/README.md
@@ -22,18 +22,6 @@ When looking to leverage the `UUIInputElement` base class as a type and/or for e
 import { UUIInputElement } from '@umbraco-ui/uui-input';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-input@latest/dist/uui-input.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-input@X.X.X/dist/uui-input.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-input/package.json
+++ b/packages/uui-input/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-input.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-input/package.json
+++ b/packages/uui-input/package.json
@@ -25,7 +25,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-input/rollup.config.js
+++ b/packages/uui-input/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-keyboard-shortcut/README.md
+++ b/packages/uui-keyboard-shortcut/README.md
@@ -22,18 +22,6 @@ When looking to leverage the `UUIKeyboardShortcutElement` base class as a type a
 import { UUIKeyboardShortcutElement } from '@umbraco-ui/uui-keyboard-shortcut';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-keyboard-shortcut@latest/dist/uui-keyboard-shortcut.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-keyboard-shortcut@X.X.X/dist/uui-keyboard-shortcut.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-keyboard-shortcut/package.json
+++ b/packages/uui-keyboard-shortcut/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-keyboard-shortcut.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-keyboard-shortcut/package.json
+++ b/packages/uui-keyboard-shortcut/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-keyboard-shortcut/rollup.config.js
+++ b/packages/uui-keyboard-shortcut/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-label/README.md
+++ b/packages/uui-label/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUILabelElement` base class as a type and/or for e
 import { UUILabelElement } from '@umbraco-ui/uui-label';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-label@latest/dist/uui-label.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-label@X.X.X/dist/uui-label.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-label/package.json
+++ b/packages/uui-label/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-label.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-label/package.json
+++ b/packages/uui-label/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-label/rollup.config.js
+++ b/packages/uui-label/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-loader-bar/README.md
+++ b/packages/uui-loader-bar/README.md
@@ -22,18 +22,6 @@ When looking to leverage the `UUILoaderBarElement` base class as a type and/or f
 import { UUILoaderBarElement } from '@umbraco-ui/uui-loader-bar';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-loader-bar@latest/dist/uui-loader-bar.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-loader-bar@X.X.X/dist/uui-loader-bar.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-loader-bar/package.json
+++ b/packages/uui-loader-bar/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-loader-bar.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-loader-bar/package.json
+++ b/packages/uui-loader-bar/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-loader-bar/rollup.config.js
+++ b/packages/uui-loader-bar/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-loader-circle/README.md
+++ b/packages/uui-loader-circle/README.md
@@ -22,18 +22,6 @@ When looking to leverage the `UUILoaderCircleElement` base class as a type and/o
 import { UUILoaderCircleElement } from '@umbraco-ui/uui-loader-circle';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-loader-circle@latest/dist/uui-loader-circle.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-loader-circle@X.X.X/dist/uui-loader-circle.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-loader-circle/package.json
+++ b/packages/uui-loader-circle/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-loader-circle.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-loader-circle/package.json
+++ b/packages/uui-loader-circle/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-loader-circle/rollup.config.js
+++ b/packages/uui-loader-circle/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-loader/README.md
+++ b/packages/uui-loader/README.md
@@ -22,18 +22,6 @@ When looking to leverage the `UUILoaderElement` base class as a type and/or for 
 import { UUILoaderElement } from '@umbraco-ui/uui-loader';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-loader@latest/dist/uui-loader.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-loader@X.X.X/dist/uui-loader.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-loader/package.json
+++ b/packages/uui-loader/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-loader.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-loader/package.json
+++ b/packages/uui-loader/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-loader/rollup.config.js
+++ b/packages/uui-loader/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-menu-item/README.md
+++ b/packages/uui-menu-item/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIMenuItemElement` base class as a type and/or fo
 import { UUIMenuItemElement } from '@umbraco-ui/uui-menu-item';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-menu-item@latest/dist/uui-menu-item.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-menu-item@X.X.X/dist/uui-menu-item.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-menu-item/package.json
+++ b/packages/uui-menu-item/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-menu-item.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-menu-item/package.json
+++ b/packages/uui-menu-item/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-menu-item/rollup.config.js
+++ b/packages/uui-menu-item/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-pagination/README.md
+++ b/packages/uui-pagination/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIPaginationElement` base class as a type and/or 
 import { UUIPaginationElement } from '@umbraco-ui/uui-pagination';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-pagination@latest/dist/uui-pagination.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-pagination@X.X.X/dist/uui-pagination.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-pagination/package.json
+++ b/packages/uui-pagination/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-pagination.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-pagination/package.json
+++ b/packages/uui-pagination/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-pagination/rollup.config.js
+++ b/packages/uui-pagination/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-progress-bar/README.md
+++ b/packages/uui-progress-bar/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIProgressBarElement` base class as a type and/or
 import { UUIProgressBarElement } from '@umbraco-ui/uui-progress-bar';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-progress-bar@latest/dist/uui-progress-bar.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-progress-bar@X.X.X/dist/uui-progress-bar.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-progress-bar/package.json
+++ b/packages/uui-progress-bar/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-progress-bar.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-progress-bar/package.json
+++ b/packages/uui-progress-bar/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-progress-bar/rollup.config.js
+++ b/packages/uui-progress-bar/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-radio/README.md
+++ b/packages/uui-radio/README.md
@@ -23,18 +23,6 @@ import { UUIRadioGroupElement } from '@umbraco-ui/uui-radio';
 import { UUIRadioElement } from '@umbraco-ui/uui-radio';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-radio@latest/dist/uui-radio.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-radio@X.X.X/dist/uui-radio.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-radio/package.json
+++ b/packages/uui-radio/package.json
@@ -22,7 +22,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-radio.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-radio/package.json
+++ b/packages/uui-radio/package.json
@@ -27,7 +27,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-radio/rollup.config.js
+++ b/packages/uui-radio/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-ref-list/README.md
+++ b/packages/uui-ref-list/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIRefListElement` base class as a type and/or for
 import { UUIRefListElement } from '@umbraco-ui/uui-ref-list';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-ref-list@latest/dist/uui-ref-list.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-ref-list@X.X.X/dist/uui-ref-list.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-ref-list/package.json
+++ b/packages/uui-ref-list/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-ref-list.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-ref-list/package.json
+++ b/packages/uui-ref-list/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-ref-list/rollup.config.js
+++ b/packages/uui-ref-list/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-ref-node-data-type/README.md
+++ b/packages/uui-ref-node-data-type/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIRefNodeDataTypeElement` base class as a type an
 import { UUIRefNodeDataTypeElement } from '@umbraco-ui/uui-ref-node-data-type';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-ref-node-data-type@latest/dist/uui-ref-node-data-type.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-ref-node-data-type@X.X.X/dist/uui-ref-node-data-type.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-ref-node-data-type/package.json
+++ b/packages/uui-ref-node-data-type/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-ref-node-data-type.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-ref-node-data-type/package.json
+++ b/packages/uui-ref-node-data-type/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-ref-node-data-type/rollup.config.js
+++ b/packages/uui-ref-node-data-type/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-ref-node-document-type/README.md
+++ b/packages/uui-ref-node-document-type/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIRefNodeDocumentTypeElement` base class as a typ
 import { UUIRefNodeDocumentTypeElement } from '@umbraco-ui/uui-ref-node-document-type';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-ref-node-document-type@latest/dist/uui-ref-node-document-type.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-ref-node-document-type@X.X.X/dist/uui-ref-node-document-type.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-ref-node-document-type/package.json
+++ b/packages/uui-ref-node-document-type/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-ref-node-document-type.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-ref-node-document-type/package.json
+++ b/packages/uui-ref-node-document-type/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-ref-node-document-type/rollup.config.js
+++ b/packages/uui-ref-node-document-type/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-ref-node-form/README.md
+++ b/packages/uui-ref-node-form/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIRefNodeFormElement` base class as a type and/or
 import { UUIRefNodeFormElement } from '@umbraco-ui/uui-ref-node-form';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-ref-node-form@latest/dist/uui-ref-node-form.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-ref-node-form@X.X.X/dist/uui-ref-node-form.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-ref-node-form/package.json
+++ b/packages/uui-ref-node-form/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-ref-node-form.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-ref-node-form/package.json
+++ b/packages/uui-ref-node-form/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-ref-node-form/rollup.config.js
+++ b/packages/uui-ref-node-form/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-ref-node-member/README.md
+++ b/packages/uui-ref-node-member/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIRefNodeMemberElement` base class as a type and/
 import { UUIRefNodeMemberElement } from '@umbraco-ui/uui-ref-node-member';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-ref-node-member@latest/dist/uui-ref-node-member.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-ref-node-member@X.X.X/dist/uui-ref-node-member.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-ref-node-member/package.json
+++ b/packages/uui-ref-node-member/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-ref-node-member.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-ref-node-member/package.json
+++ b/packages/uui-ref-node-member/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-ref-node-member/rollup.config.js
+++ b/packages/uui-ref-node-member/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-ref-node-package/README.md
+++ b/packages/uui-ref-node-package/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIRefNodePackageElement` base class as a type and
 import { UUIRefNodePackageElement } from '@umbraco-ui/uui-ref-node-package';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-ref-node-package@latest/dist/uui-ref-node-package.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-ref-node-package@X.X.X/dist/uui-ref-node-package.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-ref-node-package/package.json
+++ b/packages/uui-ref-node-package/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-ref-node-package.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-ref-node-package/package.json
+++ b/packages/uui-ref-node-package/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-ref-node-package/rollup.config.js
+++ b/packages/uui-ref-node-package/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-ref-node-user/README.md
+++ b/packages/uui-ref-node-user/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIRefNodeUserElement` base class as a type and/or
 import { UUIRefNodeUserElement } from '@umbraco-ui/uui-ref-node-user';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-ref-node-user@latest/dist/uui-ref-node-user.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-ref-node-user@X.X.X/dist/uui-ref-node-user.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-ref-node-user/package.json
+++ b/packages/uui-ref-node-user/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-ref-node-user.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-ref-node-user/package.json
+++ b/packages/uui-ref-node-user/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-ref-node-user/rollup.config.js
+++ b/packages/uui-ref-node-user/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-ref-node/README.md
+++ b/packages/uui-ref-node/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIRefNodeElement` base class as a type and/or for
 import { UUIRefNodeElement } from '@umbraco-ui/uui-ref-node';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-ref-node@latest/dist/uui-ref-node.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-ref-node@X.X.X/dist/uui-ref-node.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-ref-node/package.json
+++ b/packages/uui-ref-node/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-ref-node.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-ref-node/package.json
+++ b/packages/uui-ref-node/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-ref-node/rollup.config.js
+++ b/packages/uui-ref-node/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-ref/package.json
+++ b/packages/uui-ref/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-ref.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-ref/package.json
+++ b/packages/uui-ref/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-scroll-container/README.md
+++ b/packages/uui-scroll-container/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIScrollContainerElement` base class as a type an
 import { UUIScrollContainerElement } from '@umbraco-ui/uui-scroll-container';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-scroll-container@latest/dist/uui-scroll-container.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-scroll-container@X.X.X/dist/uui-scroll-container.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-scroll-container/package.json
+++ b/packages/uui-scroll-container/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-scroll-container.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-scroll-container/package.json
+++ b/packages/uui-scroll-container/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-scroll-container/rollup.config.js
+++ b/packages/uui-scroll-container/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-select/README.md
+++ b/packages/uui-select/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUISelectElement` base class as a type and/or for 
 import { UUISelectElement } from '@umbraco-ui/uui-select';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-select@latest/dist/uui-select.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-select@X.X.X/dist/uui-select.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-select/package.json
+++ b/packages/uui-select/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-select.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-select/package.json
+++ b/packages/uui-select/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-select/rollup.config.js
+++ b/packages/uui-select/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-slider/README.md
+++ b/packages/uui-slider/README.md
@@ -22,18 +22,6 @@ When looking to leverage the `UUISliderElement` base class as a type and/or for 
 import { UUISliderElement } from '@umbraco-ui/uui-slider';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-slider@latest/dist/uui-slider.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-slider@X.X.X/dist/uui-slider.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-slider/package.json
+++ b/packages/uui-slider/package.json
@@ -25,7 +25,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-slider/package.json
+++ b/packages/uui-slider/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-slider.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-slider/rollup.config.js
+++ b/packages/uui-slider/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-symbol-expand/README.md
+++ b/packages/uui-symbol-expand/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUISymbolExpandElement` base class as a type and/o
 import { UUISymbolExpandElement } from '@umbraco-ui/uui-symbol-expand';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-symbol-expand@latest/dist/uui-symbol-expand.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-symbol-expand@X.X.X/dist/uui-symbol-expand.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-symbol-expand/package.json
+++ b/packages/uui-symbol-expand/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-symbol-expand.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-symbol-expand/package.json
+++ b/packages/uui-symbol-expand/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-symbol-expand/rollup.config.js
+++ b/packages/uui-symbol-expand/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-symbol-file/package.json
+++ b/packages/uui-symbol-file/package.json
@@ -27,7 +27,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-symbol-file/package.json
+++ b/packages/uui-symbol-file/package.json
@@ -22,7 +22,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/index.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-symbol-file/rollup.config.js
+++ b/packages/uui-symbol-file/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundles: ['index'],
 });

--- a/packages/uui-symbol-folder/package.json
+++ b/packages/uui-symbol-folder/package.json
@@ -27,7 +27,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-symbol-folder/package.json
+++ b/packages/uui-symbol-folder/package.json
@@ -22,7 +22,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/index.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-symbol-folder/rollup.config.js
+++ b/packages/uui-symbol-folder/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundles: ['index'],
 });

--- a/packages/uui-symbol-more/README.md
+++ b/packages/uui-symbol-more/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUISymbolMoreElement` base class as a type and/or 
 import { UUISymbolMoreElement } from '@umbraco-ui/uui-symbol-more';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-symbol-more@latest/dist/uui-symbol-more.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-symbol-more@X.X.X/dist/uui-symbol-more.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-symbol-more/package.json
+++ b/packages/uui-symbol-more/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-symbol-more.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-symbol-more/package.json
+++ b/packages/uui-symbol-more/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-symbol-more/rollup.config.js
+++ b/packages/uui-symbol-more/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-symbol-sort/README.md
+++ b/packages/uui-symbol-sort/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUISymbolSortElement` base class as a type and/or 
 import { UUISymbolSortElement } from '@umbraco-ui/uui-symbol-sort';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-symbol-sort@latest/dist/uui-symbol-sort.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-symbol-sort@X.X.X/dist/uui-symbol-sort.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-symbol-sort/package.json
+++ b/packages/uui-symbol-sort/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-symbol-sort.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-symbol-sort/package.json
+++ b/packages/uui-symbol-sort/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-symbol-sort/rollup.config.js
+++ b/packages/uui-symbol-sort/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-table/README.md
+++ b/packages/uui-table/README.md
@@ -29,18 +29,6 @@ import {
 } from '@umbraco-ui/uui-table';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-table@latest/dist/uui-table.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-table@X.X.X/dist/uui-table.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-table/package.json
+++ b/packages/uui-table/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-table.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-table/package.json
+++ b/packages/uui-table/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-table/rollup.config.js
+++ b/packages/uui-table/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-tabs/README.md
+++ b/packages/uui-tabs/README.md
@@ -22,18 +22,6 @@ When looking to leverage the `UUITabGroupElement`, `UUITabElement` base class as
 import { UUITabGroupElement, UUITabElement } from '@umbraco-ui/uui-tabs';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-tabs@latest/dist/uui-tabs.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-tabs@X.X.X/dist/uui-tabs.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-tabs/package.json
+++ b/packages/uui-tabs/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-tabs.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-tabs/package.json
+++ b/packages/uui-tabs/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-tabs/rollup.config.js
+++ b/packages/uui-tabs/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-tag/README.md
+++ b/packages/uui-tag/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUITagElement` base class as a type and/or for ext
 import { UUITagElement } from '@umbraco-ui/uui-tag';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-tag@latest/dist/uui-tag.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-tag@X.X.X/dist/uui-tag.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-tag/package.json
+++ b/packages/uui-tag/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-tag.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-tag/package.json
+++ b/packages/uui-tag/package.json
@@ -25,7 +25,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-tag/rollup.config.js
+++ b/packages/uui-tag/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-textarea/README.md
+++ b/packages/uui-textarea/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUITextareaElement` base class as a type and/or fo
 import { UUITextareaElement } from '@umbraco-ui/uui-textarea';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-textarea@latest/dist/uui-textarea.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-textarea@X.X.X/dist/uui-textarea.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-textarea/package.json
+++ b/packages/uui-textarea/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-textarea.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-textarea/package.json
+++ b/packages/uui-textarea/package.json
@@ -25,7 +25,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-textarea/rollup.config.js
+++ b/packages/uui-textarea/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-toast-notification-container/README.md
+++ b/packages/uui-toast-notification-container/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIToastNotificationContainerElement` base class a
 import { UUIToastNotificationContainerElement } from '@umbraco-ui/uui-toast-notification-container';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-toast-notification-container@latest/dist/uui-toast-notification-container.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-toast-notification-container@X.X.X/dist/uui-toast-notification-container.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-toast-notification-container/package.json
+++ b/packages/uui-toast-notification-container/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-toast-notification-container.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-toast-notification-container/package.json
+++ b/packages/uui-toast-notification-container/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-toast-notification-container/rollup.config.js
+++ b/packages/uui-toast-notification-container/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-toast-notification-layout/README.md
+++ b/packages/uui-toast-notification-layout/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIToastNotificationLayoutElement` base class as a
 import { UUIToastNotificationLayoutElement } from '@umbraco-ui/uui-toast-notification-layout';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-toast-notification-layout@latest/dist/uui-toast-notification-layout.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-toast-notification-layout@X.X.X/dist/uui-toast-notification-layout.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-toast-notification-layout/package.json
+++ b/packages/uui-toast-notification-layout/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-toast-notification-layout.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-toast-notification-layout/package.json
+++ b/packages/uui-toast-notification-layout/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-toast-notification-layout/rollup.config.js
+++ b/packages/uui-toast-notification-layout/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-toast-notification/README.md
+++ b/packages/uui-toast-notification/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIToastNotificationElement` base class as a type 
 import { UUIToastNotificationElement } from '@umbraco-ui/uui-toast-notification';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-toast-notification@latest/dist/uui-toast-notification.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-toast-notification@X.X.X/dist/uui-toast-notification.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-toast-notification/package.json
+++ b/packages/uui-toast-notification/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-toast-notification.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-toast-notification/package.json
+++ b/packages/uui-toast-notification/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-toast-notification/rollup.config.js
+++ b/packages/uui-toast-notification/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui-toggle/README.md
+++ b/packages/uui-toggle/README.md
@@ -24,18 +24,6 @@ When looking to leverage the `UUIToggleElement` base class as a type and/or for 
 import { UUIToggleElement } from '@umbraco-ui/uui-toggle';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-toggle@latest/dist/uui-toggle.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/uui-toggle@X.X.X/dist/uui-toggle.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/packages/uui-toggle/package.json
+++ b/packages/uui-toggle/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/umbraco/Umbraco.UI/issues"
   },
-  "main": "./dist/uui-toggle.min.js",
+  "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",

--- a/packages/uui-toggle/package.json
+++ b/packages/uui-toggle/package.json
@@ -24,7 +24,6 @@
   "types": "./lib/index.d.ts",
   "customElements": "custom-elements.json",
   "files": [
-    "dist",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "custom-elements.json"

--- a/packages/uui-toggle/rollup.config.js
+++ b/packages/uui-toggle/rollup.config.js
@@ -2,5 +2,4 @@ import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
   entryPoints: ['index'],
-  bundle: 'index',
 });

--- a/packages/uui/lib/index.ts
+++ b/packages/uui/lib/index.ts
@@ -10,6 +10,7 @@ import '@umbraco-ui/uui-button/lib';
 import '@umbraco-ui/uui-card-content-node/lib';
 import '@umbraco-ui/uui-card-media/lib';
 import '@umbraco-ui/uui-card-user/lib';
+import '@umbraco-ui/uui-card/lib';
 import '@umbraco-ui/uui-caret/lib';
 import '@umbraco-ui/uui-checkbox/lib';
 import '@umbraco-ui/uui-dialog/lib';
@@ -33,6 +34,7 @@ import '@umbraco-ui/uui-ref-node-member/lib';
 import '@umbraco-ui/uui-ref-node-package/lib';
 import '@umbraco-ui/uui-ref-node-user/lib';
 import '@umbraco-ui/uui-ref-node/lib';
+import '@umbraco-ui/uui-ref/lib';
 import '@umbraco-ui/uui-scroll-container/lib';
 import '@umbraco-ui/uui-select/lib';
 import '@umbraco-ui/uui-slider/lib';
@@ -50,6 +52,4 @@ import '@umbraco-ui/uui-toast-notification-layout/lib';
 import '@umbraco-ui/uui-toast-notification/lib';
 import '@umbraco-ui/uui-toggle/lib';
 
-// import '@umbraco-ui/uui-card/lib'; // TODO: We need to solve exports
 // import '@umbraco-ui/uui-css/lib'; // TODO: figure out how we include this
-// import '@umbraco-ui/uui-ref/lib'; // TODO: We need to solve exports

--- a/packages/uui/package.json
+++ b/packages/uui/package.json
@@ -23,6 +23,11 @@
   "main": "./dist/uui.min.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
+  "exports": {
+    "import": "./lib/index.js",
+    "require": "./dist/uui.min.js"
+  },
   "customElements": "custom-elements.json",
   "files": [
     "dist",
@@ -90,9 +95,9 @@
     "@umbraco-ui/uui-toggle": "0.0.17"
   },
   "scripts": {
-    "build": "npm run analyze && tsc --build --force && rollup -c rollup.config.js",
+    "build": "npm run analyze && tsc --build && rollup -c rollup.config.js",
     "clean": "tsc --build --clean && rimraf dist lib/*.js lib/**/*.js custom-elements.json",
-    "analyze": "web-component-analyzer **/*.element.ts --outFile custom-elements.json"
+    "analyze": "web-component-analyzer lib/index.ts --outFile custom-elements.json"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/uui/package.json
+++ b/packages/uui/package.json
@@ -97,7 +97,7 @@
   "scripts": {
     "build": "npm run analyze && tsc --build && rollup -c rollup.config.js",
     "clean": "tsc --build --clean && rimraf dist lib/*.js lib/**/*.js custom-elements.json",
-    "analyze": "web-component-analyzer lib/index.ts --outFile custom-elements.json"
+    "analyze": "web-component-analyzer ../**/*.element.ts --outFile custom-elements.json"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/uui/rollup.config.js
+++ b/packages/uui/rollup.config.js
@@ -3,4 +3,5 @@ import { UUIProdConfig } from '../rollup-package.config';
 export default UUIProdConfig({
   entryPoints: ['index'],
   bundle: 'index',
+  namespace: 'uui',
 });

--- a/templates/plop-templates/README.md.hbs
+++ b/templates/plop-templates/README.md.hbs
@@ -24,18 +24,6 @@ When looking to leverage the `{{className name}}` base class as a type and/or fo
 import { {{className name}} } from '@umbraco-ui/{{> tagnamePartial}}/lib';
 ```
 
-### CDN
-
-The component is available via CDN. This means it can be added to your application without the need of any bundler configuration. Here is how to use it with jsDelivr.
-
-```html
-<!-- Latest Version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/{{> tagnamePartial}}@latest/dist/{{> tagnamePartial}}.min.js"></script>
-
-<!-- Specific version -->
-<script src="https://cdn.jsdelivr.net/npm/@umbraco-ui/{{> tagnamePartial}}@X.X.X/dist/{{> tagnamePartial}}.min.js"></script>
-```
-
 ## Usage
 
 ```html

--- a/templates/plop-templates/rollup.config.hbs
+++ b/templates/plop-templates/rollup.config.hbs
@@ -1,6 +1,5 @@
 import { UUIProdConfig } from '../rollup-package.config';
 
 export default UUIProdConfig({
-  entryPoints: ['index'],
-  bundle: 'index',
+  entryPoints: ['index']
 });


### PR DESCRIPTION
## Description

We want to remove all UMD bundle generations from individual packages, since they are only used for CDN hosting, and we estimate that people using a CDN is only for "hacking" purposes and should just use the "uui" package, which will still be shipped as UMD on a CDN.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
