### PR TITLE
Add type:module to all packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,7 @@ tsconfig.tsbuildinfo
 
 
 custom-elements.json
-/packages/uui-css/custom-properties.js
-/packages/uui-css/custom-properties.module.js
+/packages/uui-css/custom-properties.*
 storybook-static
 debug.log
 out-css

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -27,6 +27,7 @@ module.exports = {
       config.optimizeDeps.include.push('lit/directives/style-map.js');
       config.optimizeDeps.include.push('lit/directives/if-defined.js');
       config.optimizeDeps.include.push('lit/directives/unsafe-html.js');
+      config.optimizeDeps.include.push('element-internals-polyfill');
     }
 
     return config;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lerna-fix": "lerna exec -- node ../../scripts/lerna-fix.mjs",
     "lerna:modify-package": "lerna exec -- node ../../scripts/modify-pkgjson.mjs",
     "postinstall": "npm run bootstrap",
-    "bootstrap": "lerna run --scope @umbraco-ui/uui-css build && node ./scripts/generate-ts-config.js",
+    "bootstrap": "lerna run --scope @umbraco-ui/uui-css clean && lerna run --scope @umbraco-ui/uui-css build && node ./scripts/generate-ts-config.js",
     "prepare": "husky install",
     "new-package": "plop && npm i",
     "pack-all": "npm run build:prod && node ./scripts/pack-packages.js",

--- a/packages/uui-action-bar/package.json
+++ b/packages/uui-action-bar/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-avatar-group/package.json
+++ b/packages/uui-avatar-group/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-avatar/package.json
+++ b/packages/uui-avatar/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-badge/package.json
+++ b/packages/uui-badge/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-boolean-input/package.json
+++ b/packages/uui-boolean-input/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-box/package.json
+++ b/packages/uui-box/package.json
@@ -21,6 +21,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-breadcrumbs/package.json
+++ b/packages/uui-breadcrumbs/package.json
@@ -24,6 +24,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-button-group/package.json
+++ b/packages/uui-button-group/package.json
@@ -23,6 +23,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-button-inline-create/package.json
+++ b/packages/uui-button-inline-create/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-button/package.json
+++ b/packages/uui-button/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-card-content-node/package.json
+++ b/packages/uui-card-content-node/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-card-media/package.json
+++ b/packages/uui-card-media/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-card-user/package.json
+++ b/packages/uui-card-user/package.json
@@ -23,6 +23,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-card/package.json
+++ b/packages/uui-card/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-caret/package.json
+++ b/packages/uui-caret/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-checkbox/package.json
+++ b/packages/uui-checkbox/package.json
@@ -25,6 +25,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-css/package.json
+++ b/packages/uui-css/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "files": [
     "assets",
     "dist",
@@ -35,7 +36,7 @@
     "build": "npm run build:cssprops && npm run build:rootcss && tsc --build --force && rollup -c rollup.config.js",
     "build:cssprops": "postcss lib/custom-properties.css --base lib/ --dir dist && npm run custom-properties-cache",
     "build:rootcss": "postcss lib/uui-css.css --base lib/ --dir dist",
-    "clean": "tsc --build --clean && rimraf dist lib/*.js lib/**/*.js custom-elements.json custom-properties.js custom-properties.module.js",
+    "clean": "tsc --build --clean && rimraf dist lib/*.js lib/**/*.js custom-elements.json custom-properties.*",
     "analyze": "web-component-analyzer **/*.element.ts --outFile custom-elements.json",
     "custom-properties-cache": "node ./scripts/update-custom-properties-cache.mjs"
   },

--- a/packages/uui-css/scripts/cache-custom-properties.mjs
+++ b/packages/uui-css/scripts/cache-custom-properties.mjs
@@ -1,6 +1,6 @@
-import postcss from 'postcss';
 import * as fs from 'fs/promises';
 import path from 'path';
+import postcss from 'postcss';
 import postcssCustomProperties from 'postcss-custom-properties';
 import * as postCssValueParser from 'postcss-values-parser';
 
@@ -37,7 +37,7 @@ export const CacheCustomProperties = async masterCSSPath => {
 
     try {
       await fs.writeFile(
-        './custom-properties.js',
+        './custom-properties.cjs',
         `module.exports = ${json};`,
         'utf8'
       );

--- a/packages/uui-dialog/package.json
+++ b/packages/uui-dialog/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-form/package.json
+++ b/packages/uui-form/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-icon-registry-essential/package.json
+++ b/packages/uui-icon-registry-essential/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-icon-registry/package.json
+++ b/packages/uui-icon-registry/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-icon/package.json
+++ b/packages/uui-icon/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-input-password/package.json
+++ b/packages/uui-input-password/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-input/package.json
+++ b/packages/uui-input/package.json
@@ -23,6 +23,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-keyboard-shortcut/package.json
+++ b/packages/uui-keyboard-shortcut/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-label/package.json
+++ b/packages/uui-label/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-loader-bar/package.json
+++ b/packages/uui-loader-bar/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-loader-circle/package.json
+++ b/packages/uui-loader-circle/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-loader/package.json
+++ b/packages/uui-loader/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-menu-item/package.json
+++ b/packages/uui-menu-item/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-pagination/package.json
+++ b/packages/uui-pagination/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-progress-bar/package.json
+++ b/packages/uui-progress-bar/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-radio/package.json
+++ b/packages/uui-radio/package.json
@@ -25,6 +25,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-ref-list/package.json
+++ b/packages/uui-ref-list/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-ref-node-data-type/package.json
+++ b/packages/uui-ref-node-data-type/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-ref-node-document-type/package.json
+++ b/packages/uui-ref-node-document-type/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-ref-node-form/package.json
+++ b/packages/uui-ref-node-form/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-ref-node-member/package.json
+++ b/packages/uui-ref-node-member/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-ref-node-package/package.json
+++ b/packages/uui-ref-node-package/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-ref-node-user/package.json
+++ b/packages/uui-ref-node-user/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-ref-node/package.json
+++ b/packages/uui-ref-node/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-ref/package.json
+++ b/packages/uui-ref/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-scroll-container/package.json
+++ b/packages/uui-scroll-container/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-select/package.json
+++ b/packages/uui-select/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-slider/package.json
+++ b/packages/uui-slider/package.json
@@ -23,6 +23,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-symbol-expand/package.json
+++ b/packages/uui-symbol-expand/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-symbol-file/package.json
+++ b/packages/uui-symbol-file/package.json
@@ -25,6 +25,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-symbol-folder/package.json
+++ b/packages/uui-symbol-folder/package.json
@@ -25,6 +25,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-symbol-more/package.json
+++ b/packages/uui-symbol-more/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-symbol-sort/package.json
+++ b/packages/uui-symbol-sort/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-table/package.json
+++ b/packages/uui-table/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-tabs/package.json
+++ b/packages/uui-tabs/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-tag/package.json
+++ b/packages/uui-tag/package.json
@@ -23,6 +23,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-textarea/package.json
+++ b/packages/uui-textarea/package.json
@@ -23,6 +23,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-toast-notification-container/package.json
+++ b/packages/uui-toast-notification-container/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-toast-notification-layout/package.json
+++ b/packages/uui-toast-notification-layout/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-toast-notification/package.json
+++ b/packages/uui-toast-notification/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui-toggle/package.json
+++ b/packages/uui-toggle/package.json
@@ -22,6 +22,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "type": "module",
   "customElements": "custom-elements.json",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/uui/package.json
+++ b/packages/uui/package.json
@@ -23,7 +23,6 @@
   "main": "./dist/uui.min.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
-  "type": "module",
   "exports": {
     "import": "./lib/index.js",
     "require": "./dist/uui.min.js"

--- a/scripts/vite.processLitCSSPlugin.js
+++ b/scripts/vite.processLitCSSPlugin.js
@@ -11,7 +11,7 @@ const postcssConfig = require('postcss-load-config');
 
 // @ts-ignore-start
 // eslint-disable-next-line -- // @typescript-eslint/ban-ts-comment // @ts-ignore
-const customProperties = require('../packages/uui-css/custom-properties.js'); // eslint-disable-line
+const customProperties = require('../packages/uui-css/custom-properties.cjs'); // eslint-disable-line
 // @ts-ignore-end
 
 const options = {


### PR DESCRIPTION
## Description

Change all packages to add `"type": "module"` to their respective package.json files since now all they do is export an es module only. The sole exception is the "uui" package which exports both an UMD bundle and an ES module that references the other packages.

This change also means that custom-properties.js has been renamed to custom-properties.cjs so especially Storybook knows that it's still a CommonJS file.

Fixes [AB#17161](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/17161)
