### PR TITLE
add aspect-ratio property to avatar host element

### DIFF
--- a/packages/uui-avatar/lib/uui-avatar.element.ts
+++ b/packages/uui-avatar/lib/uui-avatar.element.ts
@@ -25,7 +25,7 @@ export class UUIAvatarElement extends LitElement {
         height: calc(2em + 4px);
         user-select: none;
         /* box-sizing: border-box; */
-
+        aspect-ratio: 1;
         background-color: var(--uui-color-spanish-pink);
         color: var(--uui-color-space-cadet);
       }


### PR DESCRIPTION
Adds an `aspect-ratio: 1` property to `uui-avatar`.
Fixes #139

## Description

Prevents squeezing the avatar circle when the parent container is narrow. 
`aspect-ratio` is now accepted in all latest versions of modern browsers 🥳 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
