### PR TITLE
Feature/ab 16938 select form associated

### DIFF
--- a/packages/uui-boolean-input/lib/uui-boolean-input.test.ts
+++ b/packages/uui-boolean-input/lib/uui-boolean-input.test.ts
@@ -1,16 +1,18 @@
 /* eslint-disable lit/no-invalid-html */
 /* eslint-disable lit/binding-positions */
+import '.';
+
 import {
   defineCE,
   elementUpdated,
-  html,
-  fixture,
   expect,
+  fixture,
+  html,
   unsafeStatic,
 } from '@open-wc/testing';
-import { UUIBooleanInputElement } from './uui-boolean-input.element';
-import '.';
 import { html as litHTMLLiteral } from 'lit';
+
+import { UUIBooleanInputElement } from './uui-boolean-input.element';
 
 const tagName = defineCE(
   class BooleanInputTestElement extends UUIBooleanInputElement {
@@ -56,10 +58,6 @@ describe('UUIBooleanInputElement', () => {
   it('can be checked', () => {
     element.checked = true;
     expect(element.checked).to.be.equal(true);
-  });
-
-  it('contains a native input', async () => {
-    await expect(input).to.exist;
   });
 
   it('if disabled, disables the native input', async () => {

--- a/packages/uui-select/lib/uui-select.element.ts
+++ b/packages/uui-select/lib/uui-select.element.ts
@@ -1,6 +1,8 @@
-import { css, html, LitElement } from 'lit';
+import { FormControlMixin } from '@umbraco-ui/uui-base/lib/mixins';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
-import { property, state } from 'lit/decorators.js';
+import { css, html, LitElement } from 'lit';
+import { property, query, state } from 'lit/decorators.js';
+
 import { UUISelectEvent } from './UUISelectEvent';
 
 // TODO: Dont set a global interface, we should expose a 'local' interface.
@@ -184,12 +186,8 @@ export class UUISelectElement extends LitElement {
   @state()
   private _disabledGroups: string[] = [];
 
-  /**
-   * This is a static class field indicating that the element is can be used inside a native form and participate in its events. It may require a polyfill, check support here https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/attachInternals.  Read more about form controls here https://web.dev/more-capable-form-controls/
-   * @type {boolean}
-   */
-  static readonly formAssociated = true;
-  readonly _internals;
+  @query('#native')
+  protected _input!: HTMLSelectElement;
 
   constructor() {
     super();
@@ -207,13 +205,13 @@ export class UUISelectElement extends LitElement {
    * This method enables <label for="..."> to focus the select
    */
   focus() {
-    (this.shadowRoot?.querySelector('#native') as any).focus();
+    this._input.focus();
   }
   /**
    * This method enables <label for="..."> to open the select
    */
   click() {
-    (this.shadowRoot?.querySelector('#native') as any).click();
+    this._input.click();
   }
 
   connectedCallback() {

--- a/packages/uui-select/lib/uui-select.element.ts
+++ b/packages/uui-select/lib/uui-select.element.ts
@@ -22,10 +22,9 @@ declare global {
  * @element uui-select
  * @fires change - when the user changes value
  */
-// TODO: Implement FormControlMixin
 // TODO: Consider if this should use child items instead of an array.
 @defineElement('uui-select')
-export class UUISelectElement extends LitElement {
+export class UUISelectElement extends FormControlMixin(LitElement) {
   static styles = [
     css`
       :host {
@@ -135,15 +134,6 @@ export class UUISelectElement extends LitElement {
   error = false;
 
   /**
-   * This is the name property of the uui-checkbox or the uui-toggle component. It reflects the behaviour of the native input type="checkbox" element and its name attribute.
-   * @type {string}
-   * @attr
-   */
-  @property({ type: String })
-  name = '';
-
-  private _value = '';
-  /**
    * This is a value property of the uui-checkbox or the uui-toggle component. The default value of this property is 'on'. It reflects the behaviour of the native input type="checkbox" element and its value attribute.
    * @type {string}
    * @attr
@@ -155,10 +145,7 @@ export class UUISelectElement extends LitElement {
   }
 
   set value(newVal) {
-    const oldValue = this._value;
-    this._value = newVal;
-    this._internals.setFormValue(this.name !== '' ? this._value : null);
-    this.requestUpdate('value', oldValue);
+    super.value = newVal;
   }
 
   /**
@@ -191,7 +178,6 @@ export class UUISelectElement extends LitElement {
 
   constructor() {
     super();
-    this._internals = (this as any).attachInternals();
 
     this.addEventListener('mousedown', () => {
       this.style.setProperty('--uui-show-focus-outline', '0');
@@ -252,6 +238,10 @@ export class UUISelectElement extends LitElement {
         composed: false,
       })
     );
+  }
+
+  protected getFormElement(): HTMLElement {
+    return this._input;
   }
 
   private _renderOption(

--- a/packages/uui-select/lib/uui-select.test.ts
+++ b/packages/uui-select/lib/uui-select.test.ts
@@ -1,6 +1,8 @@
-import { html, fixture, expect, elementUpdated } from '@open-wc/testing';
-import { UUISelectElement } from './uui-select.element';
 import '.';
+
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+
+import { UUISelectElement } from './uui-select.element';
 
 const options: Array<Option> = [
   { name: 'Carrot', value: 'orange' },
@@ -13,15 +15,27 @@ const options: Array<Option> = [
 
 describe('UUISelectElement', () => {
   let element: UUISelectElement;
+  let input: HTMLSelectElement | null | undefined;
 
   beforeEach(async () => {
     element = await fixture(
       html`<uui-select label="foo" name="bar" .options=${options}></uui-select>`
     );
+    input = element.shadowRoot?.querySelector('#native');
   });
 
   it('passes the a11y audit', async () => {
     await expect(element).shadowDom.to.be.accessible();
+  });
+
+  it('input exists', () => {
+    expect(input).to.exist;
+  });
+
+  it('if disabled, disables the native input', async () => {
+    element.disabled = true;
+    await elementUpdated(element);
+    expect(input?.disabled).to.equal(true);
   });
 
   describe('methods', () => {
@@ -55,24 +69,90 @@ describe('UUISelect in Form', () => {
     select = element.shadowRoot?.querySelector('select') as HTMLSelectElement;
   });
 
-  it('value is correct', async () => {
-    await expect(element.value).to.be.equal('orange');
+  it('value is correct', () => {
+    expect(element.value).to.be.equal('orange');
   });
 
-  it('form output', async () => {
+  it('form output', () => {
     const formData = new FormData(formElement);
-    await expect(formData.get('bar')).to.be.equal('orange');
+    expect(formData.get('bar')).to.be.equal('orange');
   });
 
-  it('change value and check output', async () => {
+  it('change value and check output', () => {
     element.value = 'purple';
     const formData = new FormData(formElement);
-    await expect(formData.get('bar')).to.be.equal('purple');
+    expect(formData.get('bar')).to.be.equal('purple');
   });
 
   it('can be disabled', async () => {
     element.disabled = true;
     await elementUpdated(element);
     expect(select.disabled).to.be.true;
+  });
+
+  describe('validation', () => {
+    let formElement: HTMLFormElement;
+    let element: HTMLSelectElement;
+    beforeEach(async () => {
+      formElement = await fixture(
+        html`<form>
+          <uui-select
+            label="test label"
+            name="test"
+            .options=${options}></uui-select>
+        </form>`
+      );
+      element = formElement.firstChild as HTMLSelectElement;
+    });
+
+    describe('required', () => {
+      beforeEach(async () => {
+        element.setAttribute('required', 'true');
+        await elementUpdated(element);
+      });
+
+      it('sets element to invalid when value is empty', () => {
+        expect(element.checkValidity()).to.be.false;
+      });
+
+      it('sets element to valid when it has a value', async () => {
+        element.value = options[0].value;
+        await elementUpdated(element);
+        expect(element.checkValidity()).to.be.true;
+      });
+
+      it('sets the form to valid when it has a value', async () => {
+        element.value = options[0].value;
+        await elementUpdated(element);
+        expect(formElement.checkValidity()).to.be.true;
+      });
+    });
+
+    describe('custom error', () => {
+      beforeEach(async () => {
+        element.setAttribute('error', 'true');
+        await elementUpdated(element);
+      });
+
+      it('sets element to invalid when it has a custom error attribute', () => {
+        expect(element.checkValidity()).to.be.false;
+      });
+
+      it('sets element to valid when it doesnt have a custom error attribute', async () => {
+        element.removeAttribute('error');
+        await elementUpdated(element);
+        expect(element.checkValidity()).to.be.true;
+      });
+
+      it('sets the form to invalid when value is empty', () => {
+        expect(formElement.checkValidity()).to.be.false;
+      });
+
+      it('sets the form to valid when it doesnt have a custom error attribute', async () => {
+        element.removeAttribute('error');
+        await elementUpdated(element);
+        expect(formElement.checkValidity()).to.be.true;
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

uui-select now extends from FormControlMixin rather than creating its own logic for form. This also adds additional tests taken from uui-boolean-input to test form validation and custom error messages.

Fixes AB#16938

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Motivation and context

We do not want duplicate business logic throughout the packages.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
