### PR TITLE
Add support for unknown elements

### DIFF
--- a/packages/uui-avatar-group/lib/uui-avatar-group.element.ts
+++ b/packages/uui-avatar-group/lib/uui-avatar-group.element.ts
@@ -32,8 +32,7 @@ export class UUIAvatarGroupElement extends LitElement {
   ];
 
   @queryAssignedElements({
-    slot: undefined,
-    selector: 'uui-avatar',
+    selector: 'uui-avatar, [uui-avatar]',
     flatten: true,
   })
   private _avatarNodes?: UUIAvatarElement[];

--- a/packages/uui-breadcrumbs/lib/uui-breadcrumbs.element.ts
+++ b/packages/uui-breadcrumbs/lib/uui-breadcrumbs.element.ts
@@ -1,5 +1,7 @@
-import { css, html, LitElement } from 'lit';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { css, html, LitElement } from 'lit';
+import { queryAssignedElements } from 'lit/decorators.js';
+
 import { UUIBreadcrumbItemElement } from './uui-breadcrumb-item.element';
 
 /**
@@ -27,6 +29,16 @@ export class UUIBreadcrumbsElement extends LitElement {
     `,
   ];
 
+  @queryAssignedElements({
+    flatten: true,
+    selector: 'uui-breadcrumb-item, [role=listitem]',
+  })
+  private slotNodes!: HTMLElement[];
+
+  private elementIsBreadcrumbItem(el: unknown): el is UUIBreadcrumbItemElement {
+    return el instanceof UUIBreadcrumbItemElement;
+  }
+
   connectedCallback() {
     super.connectedCallback();
     this.setAttribute('aria-label', 'breadcrumb');
@@ -34,14 +46,13 @@ export class UUIBreadcrumbsElement extends LitElement {
   }
 
   handleSlotChange() {
-    const breadcrumbNodes = this.querySelectorAll('uui-breadcrumb-item');
-    const breadcrumbs = Array.from(
-      breadcrumbNodes
-    ) as UUIBreadcrumbItemElement[];
+    if (this.slotNodes.length > 0) {
+      const lastItem = this.slotNodes[this.slotNodes.length - 1];
+      lastItem.setAttribute('aria-current', 'page');
 
-    if (breadcrumbs?.length > 0) {
-      breadcrumbs[breadcrumbs.length - 1].lastItem = true;
-      breadcrumbs[breadcrumbs.length - 1].setAttribute('aria-current', 'page');
+      if (this.elementIsBreadcrumbItem(lastItem)) {
+        lastItem.lastItem = true;
+      }
     }
   }
 

--- a/packages/uui-breadcrumbs/lib/uui-breadcrumbs.element.ts
+++ b/packages/uui-breadcrumbs/lib/uui-breadcrumbs.element.ts
@@ -31,7 +31,7 @@ export class UUIBreadcrumbsElement extends LitElement {
 
   @queryAssignedElements({
     flatten: true,
-    selector: 'uui-breadcrumb-item, [role=listitem]',
+    selector: 'uui-breadcrumb-item, [uui-breadcrumb-item], [role=listitem]',
   })
   private slotNodes!: HTMLElement[];
 

--- a/packages/uui-breadcrumbs/lib/uui-breadcrumbs.test.ts
+++ b/packages/uui-breadcrumbs/lib/uui-breadcrumbs.test.ts
@@ -1,7 +1,9 @@
-import { html, fixture, expect } from '@open-wc/testing';
+import '.';
+
+import { expect, fixture, html } from '@open-wc/testing';
+
 import { UUIBreadcrumbItemElement } from './uui-breadcrumb-item.element';
 import { UUIBreadcrumbsElement } from './uui-breadcrumbs.element';
-import '.';
 
 describe('UuiBreadcrumbs', () => {
   let element: UUIBreadcrumbsElement;
@@ -26,9 +28,10 @@ describe('UuiBreadcrumbs', () => {
     const slot = element.shadowRoot!.querySelector('slot')!;
     const breadcrumb = slot.assignedElements()[2] as UUIBreadcrumbItemElement;
     expect(breadcrumb.lastItem).to.be.true;
+    expect(breadcrumb.ariaCurrent).to.equal('page');
   });
 
-  it('passes the a11y audit', () => {
-    expect(element).shadowDom.to.be.accessible();
+  it('passes the a11y audit', async () => {
+    await expect(element).shadowDom.to.be.accessible();
   });
 });

--- a/packages/uui-table/lib/uui-table-row.element.ts
+++ b/packages/uui-table/lib/uui-table-row.element.ts
@@ -42,7 +42,7 @@ export class UUITableRowElement extends SelectOnlyMixin(
 
   @queryAssignedElements({
     flatten: true,
-    selector: 'uui-table-cell, [role=cell]',
+    selector: 'uui-table-cell, [uui-table-cell], [role=cell]',
   })
   private slotCellNodes?: unknown[];
 

--- a/packages/uui-table/lib/uui-table-row.element.ts
+++ b/packages/uui-table/lib/uui-table-row.element.ts
@@ -4,7 +4,7 @@ import {
 } from '@umbraco-ui/uui-base/lib/mixins';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { css, html, LitElement } from 'lit';
-import { queryAssignedNodes } from 'lit/decorators.js';
+import { queryAssignedElements } from 'lit/decorators.js';
 
 import { UUITableCellElement } from './uui-table-cell.element';
 
@@ -40,8 +40,11 @@ export class UUITableRowElement extends SelectOnlyMixin(
     this.setAttribute('role', 'row');
   }
 
-  @queryAssignedNodes(undefined, true, 'uui-table-cell')
-  private slotCellNodes?: UUITableCellElement[];
+  @queryAssignedElements({
+    flatten: true,
+    selector: 'uui-table-cell, [role=cell]',
+  })
+  private slotCellNodes?: unknown[];
 
   protected updated(changedProperties: Map<string | number | symbol, unknown>) {
     if (changedProperties.has('selectOnly')) this.updateChildSelectOnly();
@@ -50,9 +53,15 @@ export class UUITableRowElement extends SelectOnlyMixin(
   private updateChildSelectOnly() {
     if (this.slotCellNodes) {
       this.slotCellNodes.forEach(el => {
-        el.disableChildInteraction = this.selectOnly;
+        if (this.elementIsTableCell(el)) {
+          el.disableChildInteraction = this.selectOnly;
+        }
       });
     }
+  }
+
+  private elementIsTableCell(element: unknown): element is UUITableCellElement {
+    return element instanceof UUITableCellElement;
   }
 
   render() {

--- a/packages/uui-table/lib/uui-table-row.test.ts
+++ b/packages/uui-table/lib/uui-table-row.test.ts
@@ -1,3 +1,5 @@
+import '.';
+
 import {
   elementUpdated,
   expect,

--- a/packages/uui-table/lib/uui-table-row.test.ts
+++ b/packages/uui-table/lib/uui-table-row.test.ts
@@ -1,13 +1,13 @@
 import {
-  html,
-  fixture,
-  expect,
   elementUpdated,
+  expect,
+  fixture,
+  html,
   oneEvent,
 } from '@open-wc/testing';
+
 import { UUITableRowElement } from './uui-table-row.element';
 import { UUITableElement } from './uui-table.element';
-import './index';
 
 describe('UuiTableRow', () => {
   let element: UUITableRowElement;
@@ -29,6 +29,10 @@ describe('UuiTableRow', () => {
 
   it('passes the a11y audit', done => {
     expect(tableElement).shadowDom.to.be.accessible({ done });
+  });
+
+  it('is defined as its own instance', () => {
+    expect(element).to.be.instanceOf(UUITableRowElement);
   });
 
   describe('properties', () => {

--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -28,7 +28,7 @@ export class UUITabGroupElement extends LitElement {
 
   @queryAssignedElements({
     flatten: true,
-    selector: 'uui-tab, .uui-tab, [role=tab]',
+    selector: 'uui-tab, [uui-tab], [role=tab]',
   })
   private slotNodes?: HTMLElement[];
 

--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -32,49 +32,46 @@ export class UUITabGroupElement extends LitElement {
   })
   private slotNodes?: HTMLElement[];
 
-  private tabElements: UUITabElement[] = [];
+  private tabElements: HTMLElement[] = [];
 
   private setTabArray() {
-    if (this.slotNodes) {
-      this.tabElements = this.slotNodes.filter(this.elementIsTab);
-    } else {
-      this.tabElements = [];
-    }
-  }
-
-  private elementIsTab(el: unknown): el is UUITabElement {
-    return el instanceof UUITabElement;
+    this.tabElements = this.slotNodes ? this.slotNodes : [];
   }
 
   private onSlotChange() {
+    this.tabElements.forEach(el => {
+      el.removeEventListener(
+        'click',
+        this.onTabActive
+      );
+    });
+
     this.setTabArray();
-    if (this.tabElements) {
-      this.tabElements.forEach(el => {
-        el.removeEventListener(
-          'click',
-          // @ts-ignore TODO: fix typescript error
-          this.onTabActive as EventHandlerNonNull
-        );
-      });
-    }
 
     this.tabElements.forEach(el => {
-      // @ts-ignore TODO: fix typescript error
-      el.addEventListener('click', this.onTabActive as EventHandlerNonNull);
+      el.addEventListener('click', this.onTabActive);
     });
   }
 
   private onTabActive = (e: MouseEvent) => {
     //? should this contain stopPropagation?
-    const selectedElement = e.target as UUITabElement;
-    selectedElement.active = true;
+    const selectedElement = e.target as HTMLElement;
+    if (this.elementIsTabLike(selectedElement)) {
+      selectedElement.active = true;
+    }
 
     const filtered = this.tabElements.filter(el => el !== selectedElement);
 
     filtered.forEach(el => {
-      el.active = false;
+      if (this.elementIsTabLike(el)) {
+        el.active = false;
+      }
     });
   };
+
+  private elementIsTabLike(el: any): el is UUITabElement {
+    return el instanceof UUITabElement || 'active' in el;
+  }
 
   connectedCallback() {
     super.connectedCallback();

--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -1,6 +1,6 @@
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { css, html, LitElement } from 'lit';
-import { queryAssignedNodes } from 'lit/decorators.js';
+import { queryAssignedElements } from 'lit/decorators.js';
 
 import { UUITabElement } from './uui-tab.element';
 
@@ -26,13 +26,24 @@ export class UUITabGroupElement extends LitElement {
     `,
   ];
 
-  @queryAssignedNodes(undefined, true, 'uui-tab')
-  private slotNodes?: UUITabElement[];
+  @queryAssignedElements({
+    flatten: true,
+    selector: 'uui-tab, .uui-tab, [role=tab]',
+  })
+  private slotNodes?: HTMLElement[];
 
   private tabElements: UUITabElement[] = [];
 
   private setTabArray() {
-    this.tabElements = this.slotNodes ? this.slotNodes : [];
+    if (this.slotNodes) {
+      this.tabElements = this.slotNodes.filter(this.elementIsTab);
+    } else {
+      this.tabElements = [];
+    }
+  }
+
+  private elementIsTab(el: unknown): el is UUITabElement {
+    return el instanceof UUITabElement;
   }
 
   private onSlotChange() {
@@ -55,7 +66,7 @@ export class UUITabGroupElement extends LitElement {
 
   private onTabActive = (e: MouseEvent) => {
     //? should this contain stopPropagation?
-    const selectedElement: UUITabElement = e.target as UUITabElement;
+    const selectedElement = e.target as UUITabElement;
     selectedElement.active = true;
 
     const filtered = this.tabElements.filter(el => el !== selectedElement);

--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -40,10 +40,7 @@ export class UUITabGroupElement extends LitElement {
 
   private onSlotChange() {
     this.tabElements.forEach(el => {
-      el.removeEventListener(
-        'click',
-        this.onTabActive
-      );
+      el.removeEventListener('click', this.onTabActive);
     });
 
     this.setTabArray();

--- a/packages/uui-tabs/lib/uui-tabs.story.ts
+++ b/packages/uui-tabs/lib/uui-tabs.story.ts
@@ -33,6 +33,7 @@ export default {
 export const AAAOverview: Story = props => html`
   <uui-tab-group
     style="
+    height: 60px;
     --uui-tab-text: ${props['--uui-tab-text']};
     --uui-tab-text-hover: ${props['--uui-tab-text-hover']};
     --uui-tab-text-active: ${props['--uui-tab-text-active']};

--- a/packages/uui-tabs/lib/uui-tabs.test.ts
+++ b/packages/uui-tabs/lib/uui-tabs.test.ts
@@ -1,7 +1,7 @@
-import { html, fixture, expect, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+
 import { UUITabGroupElement } from './uui-tab-group.element';
 import { UUITabElement } from './uui-tab.element';
-import './index';
 
 describe('UuiTab', () => {
   let element: UUITabGroupElement;
@@ -19,6 +19,14 @@ describe('UuiTab', () => {
     );
 
     tabs = Array.from(element.querySelectorAll('uui-tab'));
+  });
+
+  it('is defined as its own instance', () => {
+    expect(element).to.be.instanceOf(UUITabGroupElement);
+  });
+
+  it('tab element defined as its own instance', () => {
+    expect(tabs[0]).to.be.instanceOf(UUITabElement);
   });
 
   it('it selects an item', () => {
@@ -42,5 +50,9 @@ describe('UuiTab', () => {
 
   it('passes the a11y audit', async () => {
     await expect(element).shadowDom.to.be.accessible();
+  });
+
+  it('tab element passes the a11y audit', async () => {
+    await expect(tabs[0]).shadowDom.to.be.accessible();
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe the changes in detail -->

This adds support for having unknown slotted elements in places like uui-breadcrumb and uui-tab-group by checking up on other query selectors such as role=tab or role=listitem and optionally classes that make sense.

This also replaces `@queryAssignedNodes` with `@queryAssignedElements` because the former is marked as deprecated with the options we provided it such as "flatten". QueryAssignedElements works exactly the same, only it takes in an options object (though I believe the new version of queryAssignedNodes does the same) so Lit can add new options in the future without messing with the API. It also has the advantage of returning HTMLElement's instead which are a bit more useful.

Fixes [AB#17169](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/17169)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
