### PR TITLE
fix: uui-toggle change adjacent sibling combinator to general sibling

### DIFF
--- a/packages/uui-toggle/lib/uui-toggle.element.ts
+++ b/packages/uui-toggle/lib/uui-toggle.element.ts
@@ -60,7 +60,7 @@ export class UUIToggleElement extends UUIBooleanInputElement {
           var(--uui-toggle-border-color, var(--uui-interface-border));
         font-size: calc(var(--uui-toggle-size) * 0.6);
       }
-      label:hover input:not([disabled]) + #slider {
+      label:hover input:not([disabled]) ~ #slider {
         border-color: var(
           --uui-toggle-border-color-hover,
           var(--uui-interface-border-hover)
@@ -80,13 +80,13 @@ export class UUIToggleElement extends UUIBooleanInputElement {
           var(--uui-interface-surface-alt-focus)
         );
       }
-      input:checked + #slider {
+      input:checked ~ #slider {
         background-color: var(--uui-interface-select);
       }
-      label:hover input:checked:not([disabled]) + #slider {
+      label:hover input:checked:not([disabled]) ~ #slider {
         background-color: var(--uui-interface-select-hover);
       }
-      label:focus input:checked + #slider {
+      label:focus input:checked ~ #slider {
         background-color: var(--uui-interface-select-focus);
       }
 
@@ -111,7 +111,7 @@ export class UUIToggleElement extends UUIBooleanInputElement {
         right: calc(var(--uui-toggle-size) * 0.5);
         fill: var(--uui-interface-contrast);
       }
-      input:checked + #slider #icon-check {
+      input:checked ~ #slider #icon-check {
         fill: var(--uui-interface-select-contrast);
       }
 
@@ -128,12 +128,12 @@ export class UUIToggleElement extends UUIBooleanInputElement {
           background-color 120ms;
       }
 
-      input:checked + #slider::after {
+      input:checked ~ #slider::after {
         left: calc(100% - 2px);
         transform: translateX(-100%);
       }
 
-      input:focus + #slider {
+      input:focus ~ #slider {
         outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
           var(--uui-interface-outline);
       }
@@ -146,7 +146,7 @@ export class UUIToggleElement extends UUIBooleanInputElement {
       :host([disabled]) #slider {
         background-color: var(--uui-interface-surface-alt-disabled);
       }
-      :host([disabled]) input:checked + #slider {
+      :host([disabled]) input:checked ~ #slider {
         background-color: var(--uui-interface-select-disabled);
       }
       :host([disabled]) #slider::after {
@@ -158,7 +158,7 @@ export class UUIToggleElement extends UUIBooleanInputElement {
       :host([disabled]) label:active #slider {
         animation: ${UUIHorizontalShakeAnimationValue};
       }
-      :host([disabled]) input:checked + #slider #icon-check {
+      :host([disabled]) input:checked #slider #icon-check {
         fill: var(--uui-interface-select-contrast-disabled);
       }
 


### PR DESCRIPTION
UUI-Toggle: change adjacent sibling combinator to general sibling

## Description

This PR changes the way of styling the toggle `#slider` element when it is determined by the state of `input` element. 

## Types of changes

The adjacent sibling CSS combinator (+) is changed to (~) in every selector.  closes #152

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

This allows a more flexible extending the `UUIToggleElement` class. It allows adding additional elements to the markup without breaking the slider's style. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
