### PR TITLE
Feature/storybook slots documentation

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -52,10 +52,18 @@ setCustomElements(customElements);
 
 function WebComponentFormatter(customElements) {
   for (let tag of customElements.tags || []) {
+    // Find all names of properties
+    const propertyNames = (tag.properties || []).map(p => p.name);
+
     for (let slot of tag.slots || []) {
       // Replace the name of the default slot so Storybook will show it
       if (typeof slot.name === 'string' && slot.name.length === 0) {
         slot.name = 'slot';
+      }
+
+      // If the slot has the same name as a property, then add the word 'slot' to the name
+      if (propertyNames.includes(slot.name)) {
+        slot.name = `${slot.name} slot`;
       }
 
       // Set type of slots

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,9 @@
-import { setCustomElements } from '@storybook/web-components';
-import customElements from '../custom-elements.json';
 import '../packages/uui-css/lib/uui-css.css';
 import 'element-internals-polyfill';
+
+import { setCustomElements } from '@storybook/web-components';
+
+import customElements from '../custom-elements.json';
 
 const sort = (a, b) => {
   if (a[1].name === 'Overview') {
@@ -44,4 +46,24 @@ export const parameters = {
   },
 };
 
+WebComponentFormatter(customElements);
+
 setCustomElements(customElements);
+
+function WebComponentFormatter(customElements) {
+  for (let tag of customElements.tags || []) {
+    for (let slot of tag.slots || []) {
+      // Replace the name of the default slot so Storybook will show it
+      if (typeof slot.name === 'string' && slot.name.length === 0) {
+        slot.name = 'slot';
+      }
+
+      // Set type of slots
+      if (typeof slot.type === 'undefined' || slot.type.length === 0) {
+        slot.type = 'HTMLElement';
+      }
+    }
+  }
+
+  return customElements;
+}

--- a/packages/uui-avatar-group/lib/uui-avatar-group.element.ts
+++ b/packages/uui-avatar-group/lib/uui-avatar-group.element.ts
@@ -6,7 +6,7 @@ import { property, queryAssignedElements, state } from 'lit/decorators.js';
 /**
  * Group a set of avatars, set a limit to minimize the visual space.
  * @element uui-avatar-group
- * @slot - Insert the uui-avatar elements in the default slot
+ * @slot - Insert the `<uui-avatar>` elements in the default slot
  */
 @defineElement('uui-avatar-group')
 export class UUIAvatarGroupElement extends LitElement {

--- a/packages/uui-avatar-group/lib/uui-avatar-group.element.ts
+++ b/packages/uui-avatar-group/lib/uui-avatar-group.element.ts
@@ -6,7 +6,7 @@ import { property, queryAssignedElements, state } from 'lit/decorators.js';
 /**
  * Group a set of avatars, set a limit to minimize the visual space.
  * @element uui-avatar-group
- * @slot default - Insert the uui-avatar elements in the default slot
+ * @slot - Insert the uui-avatar elements in the default slot
  */
 @defineElement('uui-avatar-group')
 export class UUIAvatarGroupElement extends LitElement {

--- a/packages/uui-avatar-group/lib/uui-avatar-group.element.ts
+++ b/packages/uui-avatar-group/lib/uui-avatar-group.element.ts
@@ -6,7 +6,7 @@ import { property, queryAssignedElements, state } from 'lit/decorators.js';
 /**
  * Group a set of avatars, set a limit to minimize the visual space.
  * @element uui-avatar-group
- * @slot for uui-avatar elements
+ * @slot default - Insert the uui-avatar elements in the default slot
  */
 @defineElement('uui-avatar-group')
 export class UUIAvatarGroupElement extends LitElement {

--- a/packages/uui-avatar/lib/uui-avatar.element.ts
+++ b/packages/uui-avatar/lib/uui-avatar.element.ts
@@ -1,11 +1,11 @@
-import { property, state } from 'lit/decorators.js';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
-import { LitElement, html, css } from 'lit';
+import { css, html, LitElement } from 'lit';
+import { property, state } from 'lit/decorators.js';
 
 /**
  *  Avatar for displaying users
  *  @element uui-avatar
- *  @slot For anything other than initials (no more than 2-3 characters)
+ *  @slot default - For anything other than initials (no more than 2-3 characters)
  */
 @defineElement('uui-avatar')
 export class UUIAvatarElement extends LitElement {

--- a/packages/uui-avatar/lib/uui-avatar.element.ts
+++ b/packages/uui-avatar/lib/uui-avatar.element.ts
@@ -5,7 +5,7 @@ import { property, state } from 'lit/decorators.js';
 /**
  *  Avatar for displaying users
  *  @element uui-avatar
- *  @slot default - For anything other than initials (no more than 2-3 characters)
+ *  @slot - For anything other than initials (no more than 2-3 characters)
  */
 @defineElement('uui-avatar')
 export class UUIAvatarElement extends LitElement {

--- a/packages/uui-avatar/lib/uui-avatar.story.ts
+++ b/packages/uui-avatar/lib/uui-avatar.story.ts
@@ -1,4 +1,4 @@
-import '@umbraco-ui/uui-avatar/lib';
+import '.';
 
 import { Story } from '@storybook/web-components';
 import { html } from 'lit-html';
@@ -34,7 +34,7 @@ const Template: Story = (props: any) => html`<uui-avatar
   .imgSrcset=${props.imgSrcset}
   .name=${props.name}
   style="font-size: ${props.fontSize}px; background-color: ${props.backgroundColor}; color: ${props.color}"
-  >${props.slot}</uui-avatar
+  >${props.default}</uui-avatar
 >`;
 
 export const AAAOverview = Template.bind({});
@@ -98,7 +98,7 @@ SlottedContent.argTypes = {
   slot: { table: { category: 'slots' }, control: { type: 'text' } },
 };
 SlottedContent.parameters = {
-  controls: { include: ['slot', 'overflow'] },
+  controls: { include: ['overflow'] },
   docs: {
     source: {
       code: `<uui-avatar overflow name="overflow name">overflow content</uui-avatar>`,
@@ -112,7 +112,7 @@ export const InlineWithText = (props: any) => html`
     <uui-avatar
       name="Hello world"
       style="background-color: ${props.backgroundColor}; color: ${props.color}"
-      >${props.slot}</uui-avatar
+      >${props.default}</uui-avatar
     >
     around
   </div>
@@ -126,12 +126,9 @@ InlineWithText.parameters = {
 };
 
 export const WithBadge = Template.bind({});
-WithBadge.args = { slot: html`<uui-badge>!</uui-badge>`, overflow: true };
-WithBadge.argTypes = {
-  slot: { table: { category: 'slots' }, control: { type: 'text' } },
-};
+WithBadge.args = { default: html`<uui-badge>!</uui-badge>`, overflow: true };
 WithBadge.parameters = {
-  controls: { include: ['slot', 'overflow', 'name'] },
+  controls: { include: ['overflow', 'name'] },
   docs: {
     source: {
       code: `<uui-avatar name="Umbraco HQ"><uui-badge>!</uui-badge></uui-avatar>`,

--- a/packages/uui-avatar/lib/uui-avatar.story.ts
+++ b/packages/uui-avatar/lib/uui-avatar.story.ts
@@ -11,6 +11,9 @@ export default {
     name: 'Umbraco HQ',
     fontSize: 12,
   },
+  argTypes: {
+    slot: { control: { type: 'text' } },
+  },
   // argTypes: {
   //   'img-src': { table: { disable: true } },
   //   'img-srcset': { table: { disable: true } },
@@ -34,7 +37,7 @@ const Template: Story = (props: any) => html`<uui-avatar
   .imgSrcset=${props.imgSrcset}
   .name=${props.name}
   style="font-size: ${props.fontSize}px; background-color: ${props.backgroundColor}; color: ${props.color}"
-  >${props.default}</uui-avatar
+  >${props.slot}</uui-avatar
 >`;
 
 export const AAAOverview = Template.bind({});
@@ -93,12 +96,9 @@ Colors.parameters = {
 };
 
 export const SlottedContent = Template.bind({});
-SlottedContent.args = { default: 'overflow', name: '' };
-SlottedContent.argTypes = {
-  default: { table: { category: 'slots' }, control: { type: 'text' } },
-};
+SlottedContent.args = { slot: 'overflow', name: '' };
 SlottedContent.parameters = {
-  controls: { include: ['overflow'] },
+  controls: { include: ['overflow', 'slot'] },
   docs: {
     source: {
       code: `<uui-avatar overflow name="overflow name">overflow content</uui-avatar>`,
@@ -112,7 +112,7 @@ export const InlineWithText = (props: any) => html`
     <uui-avatar
       name="Hello world"
       style="background-color: ${props.backgroundColor}; color: ${props.color}"
-      >${props.default}</uui-avatar
+      >${props.slot}</uui-avatar
     >
     around
   </div>
@@ -126,7 +126,7 @@ InlineWithText.parameters = {
 };
 
 export const WithBadge = Template.bind({});
-WithBadge.args = { default: html`<uui-badge>!</uui-badge>`, overflow: true };
+WithBadge.args = { slot: html`<uui-badge>!</uui-badge>`, overflow: true };
 WithBadge.parameters = {
   controls: { include: ['overflow', 'name'] },
   docs: {

--- a/packages/uui-avatar/lib/uui-avatar.story.ts
+++ b/packages/uui-avatar/lib/uui-avatar.story.ts
@@ -93,9 +93,9 @@ Colors.parameters = {
 };
 
 export const SlottedContent = Template.bind({});
-SlottedContent.args = { slot: 'overflow', name: '' };
+SlottedContent.args = { default: 'overflow', name: '' };
 SlottedContent.argTypes = {
-  slot: { table: { category: 'slots' }, control: { type: 'text' } },
+  default: { table: { category: 'slots' }, control: { type: 'text' } },
 };
 SlottedContent.parameters = {
   controls: { include: ['overflow'] },

--- a/packages/uui-badge/lib/uui-badge.element.ts
+++ b/packages/uui-badge/lib/uui-badge.element.ts
@@ -6,7 +6,7 @@ import { property } from 'lit/decorators.js';
 /**
  *  A badge to notify that there is something that requires attention of the user. The badge is positioned with `position: absolute`. It will determine its position against the first ancestor with `position: relative`.
  *  @element uui-badge
- *  @slot default - The slot for badge contents
+ *  @slot - The slot for badge contents
  */
 @defineElement('uui-badge')
 export class UUIBadgeElement extends LitElement {

--- a/packages/uui-badge/lib/uui-badge.element.ts
+++ b/packages/uui-badge/lib/uui-badge.element.ts
@@ -1,13 +1,12 @@
-import { LitElement, html, css } from 'lit';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
-import { property } from 'lit/decorators.js';
-
 import { InterfaceLookType } from '@umbraco-ui/uui-base/lib/types';
+import { css, html, LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
 
 /**
  *  A badge to notify that there is something that requires attention of the user. The badge is positioned with `position: absolute`. It will determine its position against the first ancestor with `position: relative`.
  *  @element uui-badge
- *  @slot - for badge contents
+ *  @slot default - The slot for badge contents
  */
 @defineElement('uui-badge')
 export class UUIBadgeElement extends LitElement {

--- a/packages/uui-badge/lib/uui-badge.story.ts
+++ b/packages/uui-badge/lib/uui-badge.story.ts
@@ -13,7 +13,7 @@ export default {
   id: 'uui-badge',
   args: {
     look: 'primary',
-    slot: '1',
+    default: '1',
     attention: false,
   },
   argTypes: {
@@ -36,7 +36,7 @@ const Template: Story = props => html` <uui-icon-registry-essential>
   <div
     style="position:relative; width:80px; height:80px; border: 2px dashed black;">
     <uui-badge .look=${props.look} ?attention=${props.attention}
-      >${props.slot}</uui-badge
+      >${props.default}</uui-badge
     >
   </div>
 </uui-icon-registry-essential>`;
@@ -44,7 +44,7 @@ const Template: Story = props => html` <uui-icon-registry-essential>
 export const AAAOverview = Template.bind({});
 AAAOverview.args = {
   look: 'primary',
-  slot: '1',
+  default: '1',
   attention: false,
 };
 AAAOverview.storyName = 'Overview';
@@ -63,7 +63,7 @@ AAAOverview.parameters = {
 export const WithAttention = Template.bind({});
 WithAttention.args = {
   look: 'danger',
-  slot: '!',
+  default: '!',
   attention: true,
 };
 WithAttention.parameters = {
@@ -81,7 +81,7 @@ WithAttention.parameters = {
 export const WithText = Template.bind({});
 WithText.args = {
   look: 'positive',
-  slot: 'Published',
+  default: 'Published',
 };
 WithText.parameters = {
   docs: {
@@ -98,7 +98,7 @@ WithText.parameters = {
 export const WithIcon = Template.bind({});
 WithIcon.args = {
   look: 'positive',
-  slot: html`<uui-icon name="favorite"></uui-icon>`,
+  default: html`<uui-icon name="favorite"></uui-icon>`,
 };
 WithIcon.parameters = {
   docs: {
@@ -118,11 +118,11 @@ WithIcon.parameters = {
 
 export const OnButton: Story = props => html` <uui-button look="outline">
   Button label
-  <uui-badge .look=${props.look}>${props.slot}</uui-badge>
+  <uui-badge .look=${props.look}>${props.default}</uui-badge>
 </uui-button>`;
 OnButton.args = {
   look: 'danger',
-  slot: '!',
+  default: '!',
 };
 OnButton.parameters = {
   docs: {
@@ -143,14 +143,14 @@ export const Looks: Story = props => html`
       html`<div
         style="position:relative; display:inline-block; width:10px; height:10px; margin-right: 16px;">
         <uui-badge .look=${lookName} ?attention=${props.attention}
-          >${props.slot}</uui-badge
+          >${props.default}</uui-badge
         >
       </div>`
   )}
 `;
 Looks.args = {
   look: 'primary',
-  slot: '!',
+  default: '!',
 };
 
 let lookNamesDocsCode = '';

--- a/packages/uui-badge/lib/uui-badge.story.ts
+++ b/packages/uui-badge/lib/uui-badge.story.ts
@@ -13,7 +13,7 @@ export default {
   id: 'uui-badge',
   args: {
     look: 'primary',
-    default: '1',
+    slot: '1',
     attention: false,
   },
   argTypes: {
@@ -29,6 +29,9 @@ export default {
       ],
       control: { type: 'select' },
     },
+    slot: {
+      control: { type: 'text' },
+    },
   },
 };
 
@@ -36,7 +39,7 @@ const Template: Story = props => html` <uui-icon-registry-essential>
   <div
     style="position:relative; width:80px; height:80px; border: 2px dashed black;">
     <uui-badge .look=${props.look} ?attention=${props.attention}
-      >${props.default}</uui-badge
+      >${props.slot}</uui-badge
     >
   </div>
 </uui-icon-registry-essential>`;
@@ -44,7 +47,7 @@ const Template: Story = props => html` <uui-icon-registry-essential>
 export const AAAOverview = Template.bind({});
 AAAOverview.args = {
   look: 'primary',
-  default: '1',
+  slot: '1',
   attention: false,
 };
 AAAOverview.storyName = 'Overview';
@@ -63,7 +66,7 @@ AAAOverview.parameters = {
 export const WithAttention = Template.bind({});
 WithAttention.args = {
   look: 'danger',
-  default: '!',
+  slot: '!',
   attention: true,
 };
 WithAttention.parameters = {
@@ -81,7 +84,7 @@ WithAttention.parameters = {
 export const WithText = Template.bind({});
 WithText.args = {
   look: 'positive',
-  default: 'Published',
+  slot: 'Published',
 };
 WithText.parameters = {
   docs: {
@@ -98,9 +101,12 @@ WithText.parameters = {
 export const WithIcon = Template.bind({});
 WithIcon.args = {
   look: 'positive',
-  default: html`<uui-icon name="favorite"></uui-icon>`,
+  slot: html`<uui-icon name="favorite"></uui-icon>`,
 };
 WithIcon.parameters = {
+  controls: {
+    exclude: ['slot'],
+  },
   docs: {
     source: {
       code: `
@@ -118,11 +124,11 @@ WithIcon.parameters = {
 
 export const OnButton: Story = props => html` <uui-button look="outline">
   Button label
-  <uui-badge .look=${props.look}>${props.default}</uui-badge>
+  <uui-badge .look=${props.look}>${props.slot}</uui-badge>
 </uui-button>`;
 OnButton.args = {
   look: 'danger',
-  default: '!',
+  slot: '!',
 };
 OnButton.parameters = {
   docs: {
@@ -143,14 +149,14 @@ export const Looks: Story = props => html`
       html`<div
         style="position:relative; display:inline-block; width:10px; height:10px; margin-right: 16px;">
         <uui-badge .look=${lookName} ?attention=${props.attention}
-          >${props.default}</uui-badge
+          >${props.slot}</uui-badge
         >
       </div>`
   )}
 `;
 Looks.args = {
   look: 'primary',
-  default: '!',
+  slot: '!',
 };
 
 let lookNamesDocsCode = '';

--- a/packages/uui-base/lib/mixins/FormControlMixin.ts
+++ b/packages/uui-base/lib/mixins/FormControlMixin.ts
@@ -1,5 +1,6 @@
 import { LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
+
 import { UUIFormControlEvent } from '../events';
 
 type Constructor<T = {}> = new (...args: any[]) => T;
@@ -115,7 +116,6 @@ export const FormControlMixin = <T extends Constructor<LitElement>>(
 
     /**
      * Apply validation rule for requiring a value of this form control.
-     * @type {boolean}
      * @attr
      * @default false
      */
@@ -124,27 +124,21 @@ export const FormControlMixin = <T extends Constructor<LitElement>>(
 
     /**
      * Required validation message.
-     * @type {boolean}
      * @attr
-     * @default
      */
     @property({ type: String, attribute: 'required-message' })
     requiredMessage = 'This field is required';
 
     /**
      * Apply custom error on this input.
-     * @type {boolean}
      * @attr
-     * @default false
      */
     @property({ type: Boolean, reflect: true })
     error = false;
 
     /**
      * Custom error message.
-     * @type {boolean}
      * @attr
-     * @default
      */
     @property({ type: String, attribute: 'error-message' })
     errorMessage = 'This field is invalid';

--- a/packages/uui-base/lib/mixins/LabelMixin.ts
+++ b/packages/uui-base/lib/mixins/LabelMixin.ts
@@ -22,7 +22,7 @@ export const LabelMixin = <T extends Constructor<LitElement>>(
   /**
    * Label mixin class containing the label functionality.
    *
-   * @slot default - Override the default label
+   * @slot - Override the default label
    */
   class LabelMixinClass extends superClass {
     /**

--- a/packages/uui-base/lib/mixins/LabelMixin.ts
+++ b/packages/uui-base/lib/mixins/LabelMixin.ts
@@ -22,7 +22,7 @@ export const LabelMixin = <T extends Constructor<LitElement>>(
   /**
    * Label mixin class containing the label functionality.
    *
-   * @slot default - area to place the label
+   * @slot default - Override the default label
    */
   class LabelMixinClass extends superClass {
     /**

--- a/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
+++ b/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
@@ -80,7 +80,6 @@ export abstract class UUIBooleanInputElement extends FormControlMixin(
 
   /**
    * Specifies the label position of the checkbox or the toggle
-   * @type {'left' | 'right' | 'top' | 'bottom'}
    * @attr label-position
    * @default right
    */

--- a/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
+++ b/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
@@ -80,6 +80,7 @@ export abstract class UUIBooleanInputElement extends FormControlMixin(
 
   /**
    * Specifies the label position of the checkbox or the toggle
+   * @type {'left' | 'right' | 'top' | 'bottom'}
    * @attr label-position
    * @default right
    */

--- a/packages/uui-box/lib/uui-box.element.ts
+++ b/packages/uui-box/lib/uui-box.element.ts
@@ -1,12 +1,12 @@
-import { LitElement, html, css } from 'lit';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { css, html, LitElement } from 'lit';
 
 /**
  *  A box for grouping elements
  *  @element uui-box
  *  @slot header - header area for title
  *  @slot main - main content area
- *  @slot area with no padding
+ *  @slot default - area with no padding
  *
  */
 @defineElement('uui-box')

--- a/packages/uui-box/lib/uui-box.element.ts
+++ b/packages/uui-box/lib/uui-box.element.ts
@@ -6,7 +6,7 @@ import { css, html, LitElement } from 'lit';
  *  @element uui-box
  *  @slot header - header area for title
  *  @slot main - main content area
- *  @slot default - area with no padding
+ *  @slot - area with no padding
  *
  */
 @defineElement('uui-box')

--- a/packages/uui-box/lib/uui-box.story.ts
+++ b/packages/uui-box/lib/uui-box.story.ts
@@ -1,6 +1,4 @@
 import '.';
-import '@umbraco-ui/uui-button/lib';
-import '@umbraco-ui/uui-input/lib';
 
 import { Story } from '@storybook/web-components';
 import { html } from 'lit-html';

--- a/packages/uui-breadcrumbs/lib/uui-breadcrumb-item.element.ts
+++ b/packages/uui-breadcrumbs/lib/uui-breadcrumb-item.element.ts
@@ -5,7 +5,7 @@ import { property } from 'lit/decorators.js';
 /**
  * A breadcrumb-item to be used with the breadcrumbs component.
  *  @element uui-breadcrumb-item
- *  @slot - to show display an element inside the breadcrumb
+ *  @slot default - This slot displays elements inside the breadcrumb
  *  @csspart separator - change the content of the after element of this part to change the separator
  */
 @defineElement('uui-breadcrumb-item')

--- a/packages/uui-breadcrumbs/lib/uui-breadcrumb-item.element.ts
+++ b/packages/uui-breadcrumbs/lib/uui-breadcrumb-item.element.ts
@@ -5,7 +5,7 @@ import { property } from 'lit/decorators.js';
 /**
  * A breadcrumb-item to be used with the breadcrumbs component.
  *  @element uui-breadcrumb-item
- *  @slot default - This slot displays elements inside the breadcrumb
+ *  @slot - This slot displays elements inside the breadcrumb
  *  @csspart separator - change the content of the after element of this part to change the separator
  */
 @defineElement('uui-breadcrumb-item')

--- a/packages/uui-breadcrumbs/lib/uui-breadcrumbs.element.ts
+++ b/packages/uui-breadcrumbs/lib/uui-breadcrumbs.element.ts
@@ -7,7 +7,7 @@ import { UUIBreadcrumbItemElement } from './uui-breadcrumb-item.element';
 /**
  * A breadcrumbs component to be used in combination with the uui-breadcrumb-item.
  *  @element uui-breadcrumbs
- *  @slot to display nested breadcrumb items
+ *  @slot default - Slot to display nested breadcrumb items. It supports `<uui-breadcrumb-item>` elements or elements containing the `role="listitem"` attribute
  */
 @defineElement('uui-breadcrumbs')
 export class UUIBreadcrumbsElement extends LitElement {

--- a/packages/uui-breadcrumbs/lib/uui-breadcrumbs.element.ts
+++ b/packages/uui-breadcrumbs/lib/uui-breadcrumbs.element.ts
@@ -7,7 +7,7 @@ import { UUIBreadcrumbItemElement } from './uui-breadcrumb-item.element';
 /**
  * A breadcrumbs component to be used in combination with the uui-breadcrumb-item.
  *  @element uui-breadcrumbs
- *  @slot default - Slot to display nested breadcrumb items. It supports `<uui-breadcrumb-item>` elements or elements containing the `role="listitem"` attribute
+ *  @slot - Slot to display nested breadcrumb items. It supports `<uui-breadcrumb-item>` elements or elements containing the `role="listitem"` attribute
  */
 @defineElement('uui-breadcrumbs')
 export class UUIBreadcrumbsElement extends LitElement {

--- a/packages/uui-button-group/lib/uui-button-group.element.ts
+++ b/packages/uui-button-group/lib/uui-button-group.element.ts
@@ -4,7 +4,7 @@ import { css, html, LitElement } from 'lit';
 /**
  *  Place <uui-button> elements in the slot. They will be nicely displayed.
  *  @element uui-button-group
- *  @slot default - The slot for buttons. It supports `<uui-button>` elements out of the box.
+ *  @slot - The slot for buttons. It supports `<uui-button>` elements out of the box.
  */
 @defineElement('uui-button-group')
 export class UUIButtonGroupElement extends LitElement {

--- a/packages/uui-button-group/lib/uui-button-group.element.ts
+++ b/packages/uui-button-group/lib/uui-button-group.element.ts
@@ -4,7 +4,7 @@ import { css, html, LitElement } from 'lit';
 /**
  *  Place <uui-button> elements in the slot. They will be nicely displayed.
  *  @element uui-button-group
- *  @slot - for buttons
+ *  @slot default - The slot for buttons. It supports `<uui-button>` elements out of the box.
  */
 @defineElement('uui-button-group')
 export class UUIButtonGroupElement extends LitElement {

--- a/packages/uui-card-content-node/lib/uui-card-content-node.element.ts
+++ b/packages/uui-card-content-node/lib/uui-card-content-node.element.ts
@@ -1,5 +1,5 @@
-import { UUICardElement } from '@umbraco-ui/uui-card/lib';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { UUICardElement } from '@umbraco-ui/uui-card/lib';
 import { css, html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
 
@@ -8,6 +8,7 @@ import { property, state } from 'lit/decorators.js';
  *  @fires {UUICardEvent} open - fires when the card title is clicked
  *  @fires {UUICardEvent} selected - fires when the card is selected
  *  @description - Card component for displaying a content-node.
+ *  @slot icon - slot for the icon with support for `<uui-icon>` elements
  */
 
 @defineElement('uui-card-content-node')

--- a/packages/uui-card-content-node/lib/uui-card-content-node.element.ts
+++ b/packages/uui-card-content-node/lib/uui-card-content-node.element.ts
@@ -8,9 +8,11 @@ import { property, state } from 'lit/decorators.js';
  *  @fires {UUICardEvent} open - fires when the card title is clicked
  *  @fires {UUICardEvent} selected - fires when the card is selected
  *  @description - Card component for displaying a content-node.
+ *  @slot - slot for the default content area
  *  @slot icon - slot for the icon with support for `<uui-icon>` elements
+ *  @slot tag - slot for the tag with support for `<uui-tag>` elements
+ *  @slot actions - slot for the actions with support for the `<uui-action-bar>` element
  */
-
 @defineElement('uui-card-content-node')
 export class UUICardContentNodeElement extends UUICardElement {
   static styles = [

--- a/packages/uui-card-content-node/lib/uui-card-content-node.story.ts
+++ b/packages/uui-card-content-node/lib/uui-card-content-node.story.ts
@@ -15,9 +15,6 @@ export default {
     error: false,
     disabled: false,
   },
-  parameters: {
-    controls: { include: ['name', 'selected', 'disabled'] },
-  },
   decorators: [
     (Story: any) => html`<div style="width: 300px;">${Story()}</div>`,
   ],
@@ -152,6 +149,7 @@ Disabled.args = {
   disabled: true,
 };
 Disabled.parameters = {
+  controls: { include: ['disabled'] },
   docs: {
     source: {
       code: `

--- a/packages/uui-card-content-node/lib/uui-card-content-node.story.ts
+++ b/packages/uui-card-content-node/lib/uui-card-content-node.story.ts
@@ -15,73 +15,84 @@ export default {
     error: false,
     disabled: false,
   },
+  parameters: {
+    controls: { include: ['name', 'selected', 'disabled'] },
+  },
+  decorators: [
+    (Story: any) => html`<div style="width: 300px;">${Story()}</div>`,
+  ],
 };
 
 export const AAAOverview: Story = props =>
   html`
-    <div style="width: 300px">
-      <uui-card-content-node
-        name=${props.name}
-        ?selectable=${props.selectable}
-        ?selected=${props.selected}
-        ?error=${props.error}
-        ?disabled=${props.disabled}>
-        <uui-tag size="s" slot="tag" look="positive">Published</uui-tag>
-        <!-- TODO: we should make some kind of component for this data layout: -->
-        <ul style="list-style: none; padding-inline-start: 0px; margin: 0;">
-          <li><span style="font-weight: 700">Created:</span> Yesterday</li>
-          <li>
-            <span style="font-weight: 700">Last Edited: </span> 2021-03-15 09:29
-          </li>
-          <li>
-            <span style="font-weight: 700">Some property:</span> Some value
-          </li>
-          <li>
-            <span style="font-weight: 700">Another property:</span> Another
-            value
-          </li>
-        </ul>
-      </uui-card-content-node>
-    </div>
+    <uui-card-content-node
+      name=${props.name}
+      ?selectable=${props.selectable}
+      ?selected=${props.selected}
+      ?error=${props.error}
+      ?disabled=${props.disabled}>
+      <uui-tag size="s" slot="tag" look="positive">Published</uui-tag>
+      <!-- TODO: we should make some kind of component for this data layout: -->
+      <ul style="list-style: none; padding-inline-start: 0px; margin: 0;">
+        <li><span style="font-weight: 700">Created:</span> Yesterday</li>
+        <li>
+          <span style="font-weight: 700">Last Edited: </span> 2021-03-15 09:29
+        </li>
+        <li><span style="font-weight: 700">Some property:</span> Some value</li>
+        <li>
+          <span style="font-weight: 700">Another property:</span> Another value
+        </li>
+      </ul>
+    </uui-card-content-node>
   `;
 AAAOverview.storyName = 'Overview';
 AAAOverview.parameters = {
   docs: {
     source: {
-      code: `<uui-card-content-node name="The card">
-      <!-- Missing proper layout component for the details -->
-    </uui-card-content-node>`,
+      code: `
+<uui-card-content-node name="The card">
+  <uui-tag size="s" slot="tag" look="positive">Published</uui-tag>
+  <ul style="list-style: none; padding-inline-start: 0px; margin: 0;">
+    <li><span style="font-weight: 700">Created:</span> Yesterday</li>
+    <li>
+      <span style="font-weight: 700">Last Edited: </span> 2021-03-15 09:29
+    </li>
+    <li>
+      <span style="font-weight: 700">Some property:</span> Some value
+    </li>
+    <li>
+      <span style="font-weight: 700">Another property:</span> Another
+      value
+    </li>
+  </ul>
+</uui-card-content-node>
+    `,
     },
   },
 };
 
 export const CustomIcon: Story = props => html`
   <uui-icon-registry-essential>
-    <div style="width: 300px">
-      <uui-card-content-node
-        name=${props.name}
-        ?selectable=${props.selectable}
-        ?selected=${props.selected}
-        ?error=${props.error}
-        ?disabled=${props.disabled}>
-        <uui-icon slot="icon" name="picture"></uui-icon>
-        <uui-tag size="s" slot="tag" look="positive">Published</uui-tag>
-        <!-- TODO: we should make some kind of component for this data layout: -->
-        <ul style="list-style: none; padding-inline-start: 0px; margin: 0;">
-          <li><span style="font-weight: 700">Created:</span> Yesterday</li>
-          <li>
-            <span style="font-weight: 700">Last Edited: </span> 2021-03-15 09:29
-          </li>
-          <li>
-            <span style="font-weight: 700">Some property:</span> Some value
-          </li>
-          <li>
-            <span style="font-weight: 700">Another property:</span> Another
-            value
-          </li>
-        </ul>
-      </uui-card-content-node>
-    </div>
+    <uui-card-content-node
+      name=${props.name}
+      ?selectable=${props.selectable}
+      ?selected=${props.selected}
+      ?error=${props.error}
+      ?disabled=${props.disabled}>
+      <uui-icon slot="icon" name="picture"></uui-icon>
+      <uui-tag size="s" slot="tag" look="positive">Published</uui-tag>
+      <!-- TODO: we should make some kind of component for this data layout: -->
+      <ul style="list-style: none; padding-inline-start: 0px; margin: 0;">
+        <li><span style="font-weight: 700">Created:</span> Yesterday</li>
+        <li>
+          <span style="font-weight: 700">Last Edited: </span> 2021-03-15 09:29
+        </li>
+        <li><span style="font-weight: 700">Some property:</span> Some value</li>
+        <li>
+          <span style="font-weight: 700">Another property:</span> Another value
+        </li>
+      </ul>
+    </uui-card-content-node>
   </uui-icon-registry-essential>
 `;
 
@@ -98,29 +109,27 @@ CustomIcon.parameters = {
 };
 
 export const Actions: Story = props => html`
-  <div style="width: 300px">
-    <uui-card-content-node
-      name=${props.name}
-      ?selectable=${props.selectable}
-      ?selected=${props.selected}
-      ?error=${props.error}
-      ?disabled=${props.disabled}>
-      <uui-action-bar slot="actions">
-        <uui-button label="Remove">Remove</uui-button>
-      </uui-action-bar>
-      <!-- TODO: we should make some kind of component for this data layout: -->
-      <ul style="list-style: none; padding-inline-start: 0px; margin: 0;">
-        <li><span style="font-weight: 700">Created:</span> Yesterday</li>
-        <li>
-          <span style="font-weight: 700">Last Edited: </span> 2021-03-15 09:29
-        </li>
-        <li><span style="font-weight: 700">Some property:</span> Some value</li>
-        <li>
-          <span style="font-weight: 700">Another property:</span> Another value
-        </li>
-      </ul>
-    </uui-card-content-node>
-  </div>
+  <uui-card-content-node
+    name=${props.name}
+    ?selectable=${props.selectable}
+    ?selected=${props.selected}
+    ?error=${props.error}
+    ?disabled=${props.disabled}>
+    <uui-action-bar slot="actions">
+      <uui-button label="Remove">Remove</uui-button>
+    </uui-action-bar>
+    <!-- TODO: we should make some kind of component for this data layout: -->
+    <ul style="list-style: none; padding-inline-start: 0px; margin: 0;">
+      <li><span style="font-weight: 700">Created:</span> Yesterday</li>
+      <li>
+        <span style="font-weight: 700">Last Edited: </span> 2021-03-15 09:29
+      </li>
+      <li><span style="font-weight: 700">Some property:</span> Some value</li>
+      <li>
+        <span style="font-weight: 700">Another property:</span> Another value
+      </li>
+    </ul>
+  </uui-card-content-node>
 `;
 
 Actions.parameters = {
@@ -137,33 +146,7 @@ Actions.parameters = {
   },
 };
 
-export const Disabled: Story = props => html`
-  <div style="width: 300px">
-    <uui-card-content-node
-      name=${props.name}
-      ?selectable=${props.selectable}
-      ?selected=${props.selected}
-      ?error=${props.error}
-      ?disabled=${props.disabled}>
-      <uui-action-bar slot="actions">
-        <uui-button label="Remove" ?disabled=${props.disabled}>
-          Remove
-        </uui-button>
-      </uui-action-bar>
-      <!-- TODO: we should make some kind of component for this data layout: -->
-      <ul style="list-style: none; padding-inline-start: 0px; margin: 0;">
-        <li><span style="font-weight: 700">Created:</span> Yesterday</li>
-        <li>
-          <span style="font-weight: 700">Last Edited: </span> 2021-03-15 09:29
-        </li>
-        <li><span style="font-weight: 700">Some property:</span> Some value</li>
-        <li>
-          <span style="font-weight: 700">Another property:</span> Another value
-        </li>
-      </ul>
-    </uui-card-content-node>
-  </div>
-`;
+export const Disabled = AAAOverview.bind({});
 
 Disabled.args = {
   disabled: true,
@@ -172,8 +155,7 @@ Disabled.parameters = {
   docs: {
     source: {
       code: `
-      <uui-card-content-node disabled name="The card">
-      </uui-card-content-node>
+      <uui-card-content-node disabled name="The card"></uui-card-content-node>
     `,
     },
   },

--- a/packages/uui-card-media/lib/uui-card-media.element.ts
+++ b/packages/uui-card-media/lib/uui-card-media.element.ts
@@ -10,7 +10,7 @@ import { property, state } from 'lit/decorators.js';
  *  @description - Card component for displaying a media item.
  *  @slot tag - slot for the tag with support for `<uui-tag>` elements
  *  @slot actions - slot for the actions with support for the `<uui-action-bar>` element
- *  @slot default - slot for the default content area
+ *  @slot - slot for the default content area
  */
 
 @defineElement('uui-card-media')

--- a/packages/uui-card-media/lib/uui-card-media.element.ts
+++ b/packages/uui-card-media/lib/uui-card-media.element.ts
@@ -1,5 +1,5 @@
-import { UUICardElement } from '@umbraco-ui/uui-card/lib';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { UUICardElement } from '@umbraco-ui/uui-card/lib';
 import { css, html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
 
@@ -8,6 +8,9 @@ import { property, state } from 'lit/decorators.js';
  *  @fires {UUICardEvent} open - fires when the media card title is clicked
  *  @fires {UUICardEvent} selected - fires when the card is selected
  *  @description - Card component for displaying a media item.
+ *  @slot tag - slot for the tag with support for `<uui-tag>` elements
+ *  @slot actions - slot for the actions with support for the `<uui-action-bar>` element
+ *  @slot default - slot for the default content area
  */
 
 @defineElement('uui-card-media')

--- a/packages/uui-card-user/lib/uui-card-user.element.ts
+++ b/packages/uui-card-user/lib/uui-card-user.element.ts
@@ -8,6 +8,9 @@ import { property } from 'lit/decorators.js';
  *  @fires {UUICardEvent} open - fires when the user card title is clicked
  *  @fires {UUICardEvent} selected - fires when the card is selected
  *  @description - Card component for displaying a user node.
+ *  @slot - slot for the default content area
+ *  @slot tag - slot for the tag with support for `<uui-tag>` elements
+ *  @slot actions - slot for the actions with support for the `<uui-action-bar>` element
  */
 
 @defineElement('uui-card-user')

--- a/packages/uui-checkbox/lib/uui-checkbox.element.ts
+++ b/packages/uui-checkbox/lib/uui-checkbox.element.ts
@@ -11,7 +11,6 @@ import { css, html } from 'lit';
  *  Umbraco checkbox, toggles between checked and uncheck
  *  @element uui-checkbox
  *  @fires UUIBooleanInputEvent#change - fires when the element is begin checked by a user action
- *  @slot to overwrite displayed label content
  *  @cssprop --uui-checkbox-size - To set the size of the checkbox.
  *  @extends UUIBooleanInputElement
  */

--- a/packages/uui-checkbox/lib/uui-checkbox.story.ts
+++ b/packages/uui-checkbox/lib/uui-checkbox.story.ts
@@ -40,7 +40,7 @@ export const AAAOverview: Story = props =>
       .labelPosition=${props.labelPosition}
       ?disabled=${props.disabled}
       ?checked=${props.checked}
-      >${props.default}</uui-checkbox
+      >${props.slot}</uui-checkbox
     >
   `;
 AAAOverview.args = { label: 'label' };
@@ -51,7 +51,7 @@ AAAOverview.argTypes = {
     options: ['left', 'right', 'top', 'bottom'],
     control: 'select',
   },
-  default: { control: { type: 'text' } },
+  slot: { control: { type: 'text' } },
   '--uui-checkbox-size': { control: { type: 'text' } },
 };
 

--- a/packages/uui-checkbox/lib/uui-checkbox.story.ts
+++ b/packages/uui-checkbox/lib/uui-checkbox.story.ts
@@ -40,7 +40,7 @@ export const AAAOverview: Story = props =>
       .labelPosition=${props.labelPosition}
       ?disabled=${props.disabled}
       ?checked=${props.checked}
-      >${props.slot}</uui-checkbox
+      >${props.default}</uui-checkbox
     >
   `;
 AAAOverview.args = { label: 'label' };
@@ -51,7 +51,7 @@ AAAOverview.argTypes = {
     options: ['left', 'right', 'top', 'bottom'],
     control: 'select',
   },
-  slot: { control: { type: 'text' } },
+  default: { control: { type: 'text' } },
   '--uui-checkbox-size': { control: { type: 'text' } },
 };
 

--- a/packages/uui-dialog-layout/lib/uui-dialog-layout.element.ts
+++ b/packages/uui-dialog-layout/lib/uui-dialog-layout.element.ts
@@ -1,10 +1,10 @@
-import { LitElement, html, css } from 'lit';
-import { property, state } from 'lit/decorators.js';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { css, html, LitElement } from 'lit';
+import { property, state } from 'lit/decorators.js';
 
 /**
  * @element uui-dialog-layout
- * @slot default - Use this for the text content
+ * @slot - Use this for the text content
  * @slot headline - Use this for slotted headline
  * @slot actions - Use this for actions
  * @description - Default dialog layout

--- a/packages/uui-dialog/lib/uui-dialog.element.ts
+++ b/packages/uui-dialog/lib/uui-dialog.element.ts
@@ -1,9 +1,9 @@
-import { LitElement, html, css } from 'lit';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { css, html, LitElement } from 'lit';
 
 /**
  *  @element uui-dialog
- *  @slot for dialog content
+ *  @slot default - The slot for dialog content
  *  @description - All-round dialog
  */
 @defineElement('uui-dialog')

--- a/packages/uui-dialog/lib/uui-dialog.element.ts
+++ b/packages/uui-dialog/lib/uui-dialog.element.ts
@@ -3,7 +3,7 @@ import { css, html, LitElement } from 'lit';
 
 /**
  *  @element uui-dialog
- *  @slot default - The slot for dialog content
+ *  @slot - The slot for dialog content
  *  @description - All-round dialog
  */
 @defineElement('uui-dialog')

--- a/packages/uui-form-layout-item/lib/uui-form-layout-item.element.ts
+++ b/packages/uui-form-layout-item/lib/uui-form-layout-item.element.ts
@@ -7,7 +7,7 @@ import { property, state } from 'lit/decorators.js';
 /**
  * @element uui-form-layout-item
  * @description - Form item composes label, input and validation-messages in a proper layout.
- * @slot default - for button contents
+ * @slot - for button contents
  * @slot message - for extras in the messages container
  * @slot description - for extras in the description container
  * @slot label - for label contents

--- a/packages/uui-form-layout-item/lib/uui-form-layout-item.element.ts
+++ b/packages/uui-form-layout-item/lib/uui-form-layout-item.element.ts
@@ -1,14 +1,16 @@
-import { LitElement, html, css } from 'lit';
-import { property, state } from 'lit/decorators.js';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { css, html, LitElement } from 'lit';
+import { property, state } from 'lit/decorators.js';
 
 // TODO: Make sure validation messages can be seen for the whole Form Item. Make them follow the screen if form controls are taller than available screen height.
 
 /**
  * @element uui-form-layout-item
  * @description - Form item composes label, input and validation-messages in a proper layout.
- * @slot - for button contents
+ * @slot default - for button contents
  * @slot message - for extras in the messages container
+ * @slot description - for extras in the description container
+ * @slot label - for label contents
  */
 
 @defineElement('uui-form-layout-item')

--- a/packages/uui-form-validation-message/lib/uui-form-validation-message.element.ts
+++ b/packages/uui-form-validation-message/lib/uui-form-validation-message.element.ts
@@ -1,14 +1,14 @@
-import { LitElement, html, css } from 'lit';
-import { repeat } from 'lit/directives/repeat.js';
-import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
-import { FormControlMixinInterface } from '@umbraco-ui/uui-base/lib/mixins';
 import { UUIFormControlEvent } from '@umbraco-ui/uui-base/lib/events';
+import { FormControlMixinInterface } from '@umbraco-ui/uui-base/lib/mixins';
+import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { css, html, LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
 
 /**
  * @element uui-form-validation-message
  * @description - Component for displaying one or more validation messages from Form Control within the given scope. Notice: Only supports components that build on the FormControlMixing.
- * @slot - for button contents
+ * @slot default - for button contents
  * @slot message - for extras in the messages container
  */
 

--- a/packages/uui-form-validation-message/lib/uui-form-validation-message.element.ts
+++ b/packages/uui-form-validation-message/lib/uui-form-validation-message.element.ts
@@ -8,7 +8,7 @@ import { repeat } from 'lit/directives/repeat.js';
 /**
  * @element uui-form-validation-message
  * @description - Component for displaying one or more validation messages from Form Control within the given scope. Notice: Only supports components that build on the FormControlMixing.
- * @slot default - for button contents
+ * @slot - for button contents
  * @slot message - for extras in the messages container
  */
 

--- a/packages/uui-keyboard-shortcut/lib/uui-key.element.ts
+++ b/packages/uui-keyboard-shortcut/lib/uui-key.element.ts
@@ -4,7 +4,7 @@ import { queryAssignedNodes } from 'lit/decorators.js';
 /**
  *  A visual representation of a key on you keyboard. use inside `<uui-keyboard-shortcut></uui-keyboard-shortcut>`
  *  @element uui-key
- *  @slot default - for the key name. Anything you put in here will be lowercase.
+ *  @slot - for the key name. Anything you put in here will be lowercase.
  */
 export class UUIKeyElement extends LitElement {
   static styles = [

--- a/packages/uui-keyboard-shortcut/lib/uui-key.element.ts
+++ b/packages/uui-keyboard-shortcut/lib/uui-key.element.ts
@@ -4,7 +4,7 @@ import { queryAssignedNodes } from 'lit/decorators.js';
 /**
  *  A visual representation of a key on you keyboard. use inside `<uui-keyboard-shortcut></uui-keyboard-shortcut>`
  *  @element uui-key
- *  @slot - for the key name. Anything you put in here will be lowercase.
+ *  @slot default - for the key name. Anything you put in here will be lowercase.
  */
 export class UUIKeyElement extends LitElement {
   static styles = [

--- a/packages/uui-keyboard-shortcut/lib/uui-keyboard-shortcut.element.ts
+++ b/packages/uui-keyboard-shortcut/lib/uui-keyboard-shortcut.element.ts
@@ -1,10 +1,10 @@
-import { css, html, LitElement } from 'lit';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { css, html, LitElement } from 'lit';
 
 /**
  *  A visual representation of a keyboard shortcut.
  *  @element uui-keyboard-shortcut
- *  @slot - for `<uui-key></uui-key>` elements
+ *  @slot default - for `<uui-key></uui-key>` elements
  */
 @defineElement('uui-keyboard-shortcut')
 export class UUIKeyboardShortcutElement extends LitElement {

--- a/packages/uui-keyboard-shortcut/lib/uui-keyboard-shortcut.element.ts
+++ b/packages/uui-keyboard-shortcut/lib/uui-keyboard-shortcut.element.ts
@@ -4,7 +4,7 @@ import { css, html, LitElement } from 'lit';
 /**
  *  A visual representation of a keyboard shortcut.
  *  @element uui-keyboard-shortcut
- *  @slot default - for `<uui-key></uui-key>` elements
+ *  @slot - for `<uui-key></uui-key>` elements
  */
 @defineElement('uui-keyboard-shortcut')
 export class UUIKeyboardShortcutElement extends LitElement {

--- a/packages/uui-label/lib/uui-label.element.ts
+++ b/packages/uui-label/lib/uui-label.element.ts
@@ -5,7 +5,7 @@ import { property } from 'lit/decorators.js';
 /**
  * Label element for Custom Element
  * @element uui-label
- * @slot default - for the label text.
+ * @slot - for the label text.
  */
 @defineElement('uui-label')
 export class UUILabelElement extends LitElement {

--- a/packages/uui-label/lib/uui-label.element.ts
+++ b/packages/uui-label/lib/uui-label.element.ts
@@ -1,11 +1,11 @@
-import { LitElement, html, css } from 'lit';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { css, html, LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
 
 /**
  * Label element for Custom Element
  * @element uui-label
- * @slot - for the label text.
+ * @slot default - for the label text.
  */
 @defineElement('uui-label')
 export class UUILabelElement extends LitElement {

--- a/packages/uui-label/lib/uui-label.story.ts
+++ b/packages/uui-label/lib/uui-label.story.ts
@@ -9,11 +9,19 @@ export default {
   id: 'uui-label',
   title: 'Inputs/Label',
   component: 'uui-label',
+  args: {
+    slot: 'Label',
+  },
+  argTypes: {
+    slot: {
+      control: { type: 'text' },
+    },
+  },
 };
 
 const Template: Story = props => html`
   <uui-label ?disabled=${props.disabled} ?required=${props.required}
-    >Label</uui-label
+    >${props.slot}</uui-label
   >
 `;
 

--- a/packages/uui-label/lib/uui-label.story.ts
+++ b/packages/uui-label/lib/uui-label.story.ts
@@ -9,6 +9,11 @@ export default {
   id: 'uui-label',
   title: 'Inputs/Label',
   component: 'uui-label',
+  parameters: {
+    controls: {
+      include: ['disabled', 'required'],
+    },
+  },
 };
 
 const Template: Story = props => html`

--- a/packages/uui-label/lib/uui-label.story.ts
+++ b/packages/uui-label/lib/uui-label.story.ts
@@ -9,11 +9,6 @@ export default {
   id: 'uui-label',
   title: 'Inputs/Label',
   component: 'uui-label',
-  parameters: {
-    controls: {
-      include: ['disabled', 'required'],
-    },
-  },
 };
 
 const Template: Story = props => html`

--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -17,7 +17,7 @@ import { UUIMenuItemEvent } from './UUIMenuItemEvent';
  *  @fires {UUIMenuItemEvent} show-children - fires when the expand icon is clicked to show nested menu items
  *  @fires {UUIMenuItemEvent} hide-children - fires when the expend icon is clicked to hide nested menu items
  *  @fires {UUIMenuItemEvent} click-label - fires when the label is clicked
- *  @slot default - nested menu items go here
+ *  @slot - nested menu items go here
  *  @slot icon - icon area
  *  @slot actions - actions area
  *  @slot label-slot - area to place the label (name: label)

--- a/packages/uui-popover/lib/uui-popover.element.ts
+++ b/packages/uui-popover/lib/uui-popover.element.ts
@@ -1,6 +1,7 @@
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { css, html, LitElement } from 'lit';
 import { property, query } from 'lit/decorators.js';
+
 import { UUIPopoverEvent } from './UUIPopoverEvent';
 
 export type PopoverPlacement =
@@ -32,6 +33,7 @@ function mathClamp(value: number, min: number, max: number) {
  * @element uui-popover
  * @description Open a modal aligned with the opening element. This does not jet work within two layers of scroll containers.
  * @fires close - When popover is closed by user interaction.
+ * @slot trigger - The element that triggers the popover.
  */
 @defineElement('uui-popover')
 export class UUIPopoverElement extends LitElement {
@@ -76,11 +78,10 @@ export class UUIPopoverElement extends LitElement {
 
   /**
    * Define the placement of the popover-modal.
-   * @type {string}
    * @attr placement
    * @default 'bottom-start'
    */
-  @property({ type: String })
+  @property({ type: String, reflect: true })
   get placement(): PopoverPlacement {
     return this._placement;
   }

--- a/packages/uui-popover/lib/uui-popover.story.ts
+++ b/packages/uui-popover/lib/uui-popover.story.ts
@@ -226,7 +226,13 @@ export const Nested: Story = props => {
   `;
 };
 
-export const Tooltip: Story = () => {
+Nested.parameters = {
+  controls: {
+    include: ['placement', 'margin'],
+  },
+};
+
+export const Tooltip: Story = props => {
   const mouseover = (id: string) => {
     const popover = document.querySelector(id) as UUIPopoverElement;
     popover.open = true;
@@ -248,7 +254,7 @@ export const Tooltip: Story = () => {
             <uui-popover
               style="margin: auto"
               id="tooltip"
-              placement="auto"
+              placement="${props.placement}"
               margin="8">
               <b
                 slot="trigger"
@@ -270,7 +276,7 @@ export const Tooltip: Story = () => {
             <uui-popover
               style="margin: auto"
               id="tooltip-2"
-              placement="auto"
+              placement="${props.placement}"
               margin="8">
               <b
                 slot="trigger"
@@ -298,6 +304,16 @@ export const Tooltip: Story = () => {
       </div>
     </div>
   `;
+};
+
+Tooltip.args = {
+  placement: 'auto',
+};
+
+Tooltip.parameters = {
+  controls: {
+    include: ['placement', 'margin'],
+  },
 };
 
 Tooltip.play = () => {

--- a/packages/uui-radio/lib/uui-radio-group.element.ts
+++ b/packages/uui-radio/lib/uui-radio-group.element.ts
@@ -15,7 +15,7 @@ const SPACE = ' ';
 
 /**
  *  @element uui-radio-group
- *  @slot for uui-radio elements
+ *  @slot default - slot for `<uui-radio>` elements or custom elements that extend from `UUIRadioElement`
  */
 @defineElement('uui-radio-group')
 export class UUIRadioGroupElement extends FormControlMixin(LitElement) {

--- a/packages/uui-radio/lib/uui-radio-group.element.ts
+++ b/packages/uui-radio/lib/uui-radio-group.element.ts
@@ -15,7 +15,7 @@ const SPACE = ' ';
 
 /**
  *  @element uui-radio-group
- *  @slot default - slot for `<uui-radio>` elements or custom elements that extend from `UUIRadioElement`
+ *  @slot - slot for `<uui-radio>` elements or custom elements that extend from `UUIRadioElement`
  */
 @defineElement('uui-radio-group')
 export class UUIRadioGroupElement extends FormControlMixin(LitElement) {

--- a/packages/uui-radio/lib/uui-radio.element.ts
+++ b/packages/uui-radio/lib/uui-radio.element.ts
@@ -1,19 +1,19 @@
-import { html, css, LitElement } from 'lit';
-import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
-import { query, property } from 'lit/decorators.js';
 import {
-  UUIHorizontalShakeKeyframes,
   UUIHorizontalShakeAnimationValue,
+  UUIHorizontalShakeKeyframes,
 } from '@umbraco-ui/uui-base/lib/animations';
+import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { css, html, LitElement } from 'lit';
+import { property, query } from 'lit/decorators.js';
+
 import { UUIRadioEvent } from './UUIRadioEvent';
 
 /**
  *  @element uui-radio
  *  @description - a single radio, should never be use as a stand-alone. Must be wrapped in `<uui-radio-group></uui-radio-group>` element.
- *  @slot - for label
- * @cssprop --uui-radio-button-size - Sets the size of the radio button.
- * @fires change - on input change
- *
+ *  @slot default - slot to set the label if no `label` attribute is set.
+ *  @cssprop --uui-radio-button-size - Sets the size of the radio button.
+ *  @fires change - on input change
  */
 @defineElement('uui-radio')
 export class UUIRadioElement extends LitElement {

--- a/packages/uui-radio/lib/uui-radio.element.ts
+++ b/packages/uui-radio/lib/uui-radio.element.ts
@@ -11,7 +11,7 @@ import { UUIRadioEvent } from './UUIRadioEvent';
 /**
  *  @element uui-radio
  *  @description - a single radio, should never be use as a stand-alone. Must be wrapped in `<uui-radio-group></uui-radio-group>` element.
- *  @slot default - slot to set the label if no `label` attribute is set.
+ *  @slot - slot to set the label if no `label` attribute is set.
  *  @cssprop --uui-radio-button-size - Sets the size of the radio button.
  *  @fires change - on input change
  */

--- a/packages/uui-radio/lib/uui-radio.story.ts
+++ b/packages/uui-radio/lib/uui-radio.story.ts
@@ -13,7 +13,7 @@ export default {
     disabled: false,
   },
   argTypes: {
-    default: { control: { type: 'text' } },
+    slot: { control: { type: 'text' } },
   },
 };
 
@@ -24,7 +24,7 @@ export const AAAOverview: Story = props =>
     .name=${props.name}
     ?disabled=${props.disabled}
     ?checked=${props.checked}
-    >${props.default}</uui-radio
+    >${props.slot}</uui-radio
   >`;
 AAAOverview.storyName = 'Overview';
 AAAOverview.parameters = {

--- a/packages/uui-radio/lib/uui-radio.story.ts
+++ b/packages/uui-radio/lib/uui-radio.story.ts
@@ -12,6 +12,9 @@ export default {
     checked: false,
     disabled: false,
   },
+  argTypes: {
+    default: { control: { type: 'text' } },
+  },
 };
 
 export const AAAOverview: Story = props =>
@@ -21,13 +24,21 @@ export const AAAOverview: Story = props =>
     .name=${props.name}
     ?disabled=${props.disabled}
     ?checked=${props.checked}
-    >Label</uui-radio
+    >${props.default}</uui-radio
   >`;
 AAAOverview.storyName = 'Overview';
 AAAOverview.parameters = {
   docs: {
     source: {
-      code: `Copy from GroupedOverview story`,
+      code: `<uui-radio-group name="Test">
+      <uui-radio value="Value 1" disabled>Option 1</uui-radio>
+      <uui-radio value="Value 2" label="Option 2"></uui-radio>
+      <uui-radio value="Value 3">Option 3</uui-radio>
+      <uui-radio value="Value 4" disabled>Option 4</uui-radio>
+      <uui-radio value="Value 5" checked>Option 5</uui-radio>
+      <uui-radio value="Value 6">Option 6</uui-radio>
+      <uui-radio value="Value 7" disabled>Option 7</uui-radio>
+    </uui-radio-group>`,
     },
   },
 };

--- a/packages/uui-ref-node/lib/uui-ref-node.element.ts
+++ b/packages/uui-ref-node/lib/uui-ref-node.element.ts
@@ -9,7 +9,7 @@ import { property, state } from 'lit/decorators.js';
  *  @fires {UUIRefEvent} selected - fires when the ref is selected
  *  @fires {UUIRefEvent} unselected - fires when the ref is unselected
  *  @description - Component for displaying a reference to a generic node.
- *  @slot default - for content
+ *  @slot - for content
  *  @slot icon - for an icon
  *  @slot tag - for a tag
  *  @slot actions - for actions

--- a/packages/uui-ref-node/lib/uui-ref-node.element.ts
+++ b/packages/uui-ref-node/lib/uui-ref-node.element.ts
@@ -1,5 +1,5 @@
-import { UUIRefElement } from '@umbraco-ui/uui-ref/lib';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { UUIRefElement } from '@umbraco-ui/uui-ref/lib';
 import { css, html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 
@@ -9,7 +9,7 @@ import { property, state } from 'lit/decorators.js';
  *  @fires {UUIRefEvent} selected - fires when the ref is selected
  *  @fires {UUIRefEvent} unselected - fires when the ref is unselected
  *  @description - Component for displaying a reference to a generic node.
- *  @slot - for content
+ *  @slot default - for content
  *  @slot icon - for an icon
  *  @slot tag - for a tag
  *  @slot actions - for actions

--- a/packages/uui-ref-node/lib/uui-ref-node.story.ts
+++ b/packages/uui-ref-node/lib/uui-ref-node.story.ts
@@ -1,7 +1,9 @@
+import '.';
+
 import { Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+
 import { ArrayOfUmbracoWords } from '../../../storyhelpers/UmbracoWordGenerator';
-import './index';
 
 export default {
   id: 'uui-ref-node',

--- a/packages/uui-ref-node/lib/uui-ref-node.story.ts
+++ b/packages/uui-ref-node/lib/uui-ref-node.story.ts
@@ -9,23 +9,24 @@ export default {
   id: 'uui-ref-node',
   title: 'Displays/References/Node',
   component: 'uui-ref-node',
+  decorators: [
+    (Story: any) => html`<div style="max-width: 420px;">${Story()}</div>`,
+  ],
 };
 
 const Template: Story = props => html`
-  <div style="max-width: 420px;">
-    <uui-ref-node
-      name="${props.name}"
-      detail="${props.detail}"
-      ?selectable=${props.selectable}
-      ?selectOnly=${props.selectOnly}
-      ?error=${props.error}
-      ?disabled=${props.disabled}>
-      <uui-tag size="s" slot="tag" look="positive">Published</uui-tag>
-      <uui-action-bar slot="actions"
-        ><uui-button><uui-icon name="delete"></uui-icon></uui-button
-      ></uui-action-bar>
-    </uui-ref-node>
-  </div>
+  <uui-ref-node
+    name="${props.name}"
+    detail="${props.detail}"
+    ?selectable=${props.selectable}
+    ?selectOnly=${props.selectOnly}
+    ?error=${props.error}
+    ?disabled=${props.disabled}>
+    <uui-tag size="s" slot="tag" look="positive">Published</uui-tag>
+    <uui-action-bar slot="actions"
+      ><uui-button><uui-icon name="delete"></uui-icon></uui-button
+    ></uui-action-bar>
+  </uui-ref-node>
 `;
 
 export const AAAOverview = Template.bind({});
@@ -52,16 +53,14 @@ AAAOverview.parameters = {
 };
 
 export const CustomIcon: Story = () => html`
-  <div style="max-width: 420px;">
-    <uui-ref-node-data-type
-      name="Rabbit Suit Product Page"
-      detail="path/to/nowhere">
-      <uui-icon slot="icon" name="shopping-basket-alt"></uui-icon>
-      <uui-action-bar slot="actions">
-        <uui-button label="Remove">Remove</uui-button>
-      </uui-action-bar>
-    </uui-ref-node-data-type>
-  </div>
+  <uui-ref-node-data-type
+    name="Rabbit Suit Product Page"
+    detail="path/to/nowhere">
+    <uui-icon slot="icon" name="shopping-basket-alt"></uui-icon>
+    <uui-action-bar slot="actions">
+      <uui-button label="Remove">Remove</uui-button>
+    </uui-action-bar>
+  </uui-ref-node-data-type>
 `;
 
 CustomIcon.parameters = {
@@ -82,19 +81,14 @@ CustomIcon.parameters = {
 };
 
 export const Border: Story = () => html`
-  <div style="max-width: 420px;">
-    <uui-ref-node
-      border
-      name="Rabbit Suit Product Page"
-      detail="path/to/nowhere">
-      <uui-tag size="s" slot="tag" look="positive">Published</uui-tag>
-      <uui-action-bar slot="actions">
-        <uui-button type="button" label="Delete"
-          ><uui-icon name="delete"></uui-icon
-        ></uui-button>
-      </uui-action-bar>
-    </uui-ref-node>
-  </div>
+  <uui-ref-node border name="Rabbit Suit Product Page" detail="path/to/nowhere">
+    <uui-tag size="s" slot="tag" look="positive">Published</uui-tag>
+    <uui-action-bar slot="actions">
+      <uui-button type="button" label="Delete"
+        ><uui-icon name="delete"></uui-icon
+      ></uui-button>
+    </uui-action-bar>
+  </uui-ref-node>
 `;
 
 Border.parameters = {
@@ -116,19 +110,17 @@ Border.parameters = {
 };
 
 export const Selectable: Story = props => html`
-  <div style="max-width: 420px;">
-    <uui-ref-node
-      ?selectable="${props.selectable}"
-      name="Rabbit Suit Product Page"
-      detail="path/to/nowhere">
-      <uui-tag size="s" slot="tag" look="positive">Published</uui-tag>
-      <uui-action-bar slot="actions">
-        <uui-button type="button" label="Delete"
-          ><uui-icon name="delete"></uui-icon
-        ></uui-button>
-      </uui-action-bar>
-    </uui-ref-node>
-  </div>
+  <uui-ref-node
+    ?selectable="${props.selectable}"
+    name="Rabbit Suit Product Page"
+    detail="path/to/nowhere">
+    <uui-tag size="s" slot="tag" look="positive">Published</uui-tag>
+    <uui-action-bar slot="actions">
+      <uui-button type="button" label="Delete"
+        ><uui-icon name="delete"></uui-icon
+      ></uui-button>
+    </uui-action-bar>
+  </uui-ref-node>
 `;
 
 Selectable.args = {
@@ -154,19 +146,17 @@ Selectable.parameters = {
 };
 
 export const Disabled: Story = props => html`
-  <div style="max-width: 420px;">
-    <uui-ref-node
-      ?disabled="${props.disabled}"
-      name="Rabbit Suit Product Page"
-      detail="path/to/nowhere">
-      <uui-tag size="s" slot="tag" look="positive">Published</uui-tag>
-      <uui-action-bar slot="actions">
-        <uui-button type="button" label="Delete"
-          ><uui-icon name="delete"></uui-icon
-        ></uui-button>
-      </uui-action-bar>
-    </uui-ref-node>
-  </div>
+  <uui-ref-node
+    ?disabled="${props.disabled}"
+    name="Rabbit Suit Product Page"
+    detail="path/to/nowhere">
+    <uui-tag size="s" slot="tag" look="positive">Published</uui-tag>
+    <uui-action-bar slot="actions">
+      <uui-button type="button" label="Delete"
+        ><uui-icon name="delete"></uui-icon
+      ></uui-button>
+    </uui-action-bar>
+  </uui-ref-node>
 `;
 
 Disabled.args = {
@@ -193,7 +183,7 @@ Disabled.parameters = {
 
 const listOfNodeNames: string[] = ArrayOfUmbracoWords(10);
 export const Listed: Story = () => html`
-  <uui-ref-list style="max-width: 420px;">
+  <uui-ref-list>
     ${listOfNodeNames.map(
       name => html`<uui-ref-node name=${name} detail="path/to/nowhere">
         <uui-tag size="s" slot="tag" look="positive">Published</uui-tag>

--- a/packages/uui-scroll-container/lib/uui-scroll-container.element.ts
+++ b/packages/uui-scroll-container/lib/uui-scroll-container.element.ts
@@ -3,7 +3,7 @@ import { css, html, LitElement } from 'lit';
 
 /**
  *  @element uui-scroll-container
- *  @slot default - for content
+ *  @slot - for content
  *  @description - Component for displaying a larger amount of .
  */
 @defineElement('uui-scroll-container')

--- a/packages/uui-scroll-container/lib/uui-scroll-container.element.ts
+++ b/packages/uui-scroll-container/lib/uui-scroll-container.element.ts
@@ -1,9 +1,9 @@
-import { LitElement, html, css } from 'lit';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { css, html, LitElement } from 'lit';
 
 /**
  *  @element uui-scroll-container
- *  @slot - for content
+ *  @slot default - for content
  *  @description - Component for displaying a larger amount of .
  */
 @defineElement('uui-scroll-container')

--- a/packages/uui-scroll-container/lib/uui-scroll-container.story.ts
+++ b/packages/uui-scroll-container/lib/uui-scroll-container.story.ts
@@ -7,131 +7,156 @@ export default {
   id: 'uui-scroll-container',
   title: 'Displays/Scroll Container',
   component: 'uui-scroll-container',
+  argTypes: {
+    slot: {
+      control: { type: 'text' },
+    },
+  },
+  parameters: {
+    controls: {
+      exclude: ['styles'],
+    },
+  },
 };
 
-export const Overview: Story = () =>
+export const Overview: Story = props =>
   html`
     <uui-scroll-container style="width:400px; height:400px;">
-      <h3>You should try to be up here</h3>
-      <p>
-        clumsy, ok thank you for waiting<br />
-        Let's see if we can get this up and running<br />
-        umm we gotta a lot to cover over the next one and a half hour<br />
-        so errr, Say cheese, ahh awesome, what a wonderful day
-      </p>
-      <p>
-        Thank you very much for coming errr <br />
-        welcome to the biggest Codegarden ever<br />
-        without a doubt our biggest ever<br />
-        the biggest err ever Codegarden<br />
-        we are more than 380 people err today, <br />which is err about a little
-        more than twenty times the people at the first Codegarden<br />
-        err this year there is more than 700 people, <br />which makes it more
-        than 30 times bigger than the very first one<br />
-        err so awesome to be back at the err the err Umbraco festival
-      </p>
-      <p>
-        Hey, before we start I just want to be the first one to use the 'hi-five
-        I suck' tag<br />
-        the only thing that makes this very different from my normal Christmas
-        Eve<br />
-        is that I don't get sweaters like these from my inlaws which makes it
-        even better...<br />
-        so the book will be a little delayed, and that's my fault
-      </p>
-      <p>
-        ahhh it's amazing to be back <br />
-        umm I've really been looking forward to this<br />
-        I love Codegarden is because we're all together<br />
-        all the people you talk to on the forums, maillist people suddenly you
-        see them in real life<br />
-        this is fantastic<br />
-        but we just have so much to share
-      </p>
-      <p>
-        You should try to be up here<br />
-        it's scary and awesome at the same time
-      </p>
-      <p>
-        so let's err let's start<br />
-        perhaps always people say<br />
-        Doug has this weird thing on my machine, I can't see anything<br />
-        aha he has notes, he's been preparing<br />
-        which I have of course...
-      </p>
-      <p>
-        You should try to be up here<br />
-        I was here I think as the slide says quite a number of years ago<br />
-        We have slides and we have demos and there is so much that can go
-        wrong<br />
-        err which is awesome
-      </p>
-      <p>
-        So back in the day Per and I did demos and they failed<br />
-        and then we were told you can't fail in a keynote<br />
-        so then we made boring slideshow demos<br />
-        and pre-recorded videos<br />
-        and almost no dangerous demos <br />
-        and we are so bored<br />
-        we need stress<br />
-        we need panic<br />
-        we need to smell bad afterwards<br />
-        and then Pete Duncanson isn't here<br />
-        so we are going to have a buffet of Yellow Screens of Death
-      </p>
-      <p>You should try to be up here</p>
-      <p>
-        umm<br />
-        those hats are still in use, err at the HQ you have to wear the hat
-        <br />
-        if you forgot to log out of the computer <br />
-        and someone gets to post in Slack that you are giving out free beer,
-        <br />
-        you have to wear the hat.
-      </p>
-      <p>
-        I am really excited that so many people have come here<br />
-        it's pretty wild to just stand up here<br />
-        one of the reasons I love Codegarden is because we're all together<br />
-        all the people you talk to on the forums, maillist people<br />
-        suddenly you see them in real life and for me, that's kinda like
-        Christmas Eve
-      </p>
-      <p>
-        just think about it for a second <br />
-        people gathered here<br />
-        all passionate about Umbraco<br />
-        travelled across the world to share our ideas, our thoughts and maybe
-        even umm... some code<br />
-        I really think it's crazy
-      </p>
-      <p>
-        you should try to be up here <br />
-        it's the most awesome sight ever
-      </p>
-      <p>Are you ready?</p>
-      <p>I don't know if you can see the slides now?</p>
-      <p>
-        Community and Infinity<br />
-        Are you ready?<br />
-        don't worry it's not as abstract as it sounds
-      </p>
-      <p>there is a long break after this one so err</p>
-      <p>and now I have transitions</p>
+      ${props.slot
+        ? props.slot
+        : html` <h3>You should try to be up here</h3>
+            <p>
+              clumsy, ok thank you for waiting<br />
+              Let's see if we can get this up and running<br />
+              umm we gotta a lot to cover over the next one and a half hour<br />
+              so errr, Say cheese, ahh awesome, what a wonderful day
+            </p>
+            <p>
+              Thank you very much for coming errr <br />
+              welcome to the biggest Codegarden ever<br />
+              without a doubt our biggest ever<br />
+              the biggest err ever Codegarden<br />
+              we are more than 380 people err today, <br />which is err about a
+              little more than twenty times the people at the first
+              Codegarden<br />
+              err this year there is more than 700 people, <br />which makes it
+              more than 30 times bigger than the very first one<br />
+              err so awesome to be back at the err the err Umbraco festival
+            </p>
+            <p>
+              Hey, before we start I just want to be the first one to use the
+              'hi-five I suck' tag<br />
+              the only thing that makes this very different from my normal
+              Christmas Eve<br />
+              is that I don't get sweaters like these from my inlaws which makes
+              it even better...<br />
+              so the book will be a little delayed, and that's my fault
+            </p>
+            <p>
+              ahhh it's amazing to be back <br />
+              umm I've really been looking forward to this<br />
+              I love Codegarden is because we're all together<br />
+              all the people you talk to on the forums, maillist people suddenly
+              you see them in real life<br />
+              this is fantastic<br />
+              but we just have so much to share
+            </p>
+            <p>
+              You should try to be up here<br />
+              it's scary and awesome at the same time
+            </p>
+            <p>
+              so let's err let's start<br />
+              perhaps always people say<br />
+              Doug has this weird thing on my machine, I can't see anything<br />
+              aha he has notes, he's been preparing<br />
+              which I have of course...
+            </p>
+            <p>
+              You should try to be up here<br />
+              I was here I think as the slide says quite a number of years
+              ago<br />
+              We have slides and we have demos and there is so much that can go
+              wrong<br />
+              err which is awesome
+            </p>
+            <p>
+              So back in the day Per and I did demos and they failed<br />
+              and then we were told you can't fail in a keynote<br />
+              so then we made boring slideshow demos<br />
+              and pre-recorded videos<br />
+              and almost no dangerous demos <br />
+              and we are so bored<br />
+              we need stress<br />
+              we need panic<br />
+              we need to smell bad afterwards<br />
+              and then Pete Duncanson isn't here<br />
+              so we are going to have a buffet of Yellow Screens of Death
+            </p>
+            <p>You should try to be up here</p>
+            <p>
+              umm<br />
+              those hats are still in use, err at the HQ you have to wear the
+              hat
+              <br />
+              if you forgot to log out of the computer <br />
+              and someone gets to post in Slack that you are giving out free
+              beer,
+              <br />
+              you have to wear the hat.
+            </p>
+            <p>
+              I am really excited that so many people have come here<br />
+              it's pretty wild to just stand up here<br />
+              one of the reasons I love Codegarden is because we're all
+              together<br />
+              all the people you talk to on the forums, maillist people<br />
+              suddenly you see them in real life and for me, that's kinda like
+              Christmas Eve
+            </p>
+            <p>
+              just think about it for a second <br />
+              people gathered here<br />
+              all passionate about Umbraco<br />
+              travelled across the world to share our ideas, our thoughts and
+              maybe even umm... some code<br />
+              I really think it's crazy
+            </p>
+            <p>
+              you should try to be up here <br />
+              it's the most awesome sight ever
+            </p>
+            <p>Are you ready?</p>
+            <p>I don't know if you can see the slides now?</p>
+            <p>
+              Community and Infinity<br />
+              Are you ready?<br />
+              don't worry it's not as abstract as it sounds
+            </p>
+            <p>there is a long break after this one so err</p>
+            <p>and now I have transitions</p>`}
     </uui-scroll-container>
   `;
 
-export const NotEnoughContent: Story = () =>
+export const NotEnoughContent: Story = props =>
   html`
     <uui-scroll-container style="width:400px; height:400px;">
-      Very little text, no Scrollbar appearing
+      ${props.slot}
     </uui-scroll-container>
   `;
 
-export const VeryWideContent: Story = () =>
+NotEnoughContent.args = {
+  slot: 'Very little text, no Scrollbar appearing',
+};
+
+export const VeryWideContent: Story = props =>
   html`
     <uui-scroll-container style="width:400px; height:400px;">
-      line is way toooo long
-      WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY<br />
+      ${props.slot}
     </uui-scroll-container>
   `;
+
+VeryWideContent.args = {
+  slot: html` line is way toooo long
+    WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY<br />`,
+};

--- a/packages/uui-table/lib/uui-table-cell.element.ts
+++ b/packages/uui-table/lib/uui-table-cell.element.ts
@@ -5,7 +5,7 @@ import { property } from 'lit/decorators.js';
 /**
  *  Table cell that detects if it has overflow and if so it'll add a title attribute to itself to display full text. Must be a child of uui-table-row
  *  @element uui-table-cell
- *  @slot default - slot for table cell content
+ *  @slot - slot for table cell content
  */
 @defineElement('uui-table-cell')
 export class UUITableCellElement extends LitElement {

--- a/packages/uui-table/lib/uui-table-cell.element.ts
+++ b/packages/uui-table/lib/uui-table-cell.element.ts
@@ -5,7 +5,7 @@ import { property } from 'lit/decorators.js';
 /**
  *  Table cell that detects if it has overflow and if so it'll add a title attribute to itself to display full text. Must be a child of uui-table-row
  *  @element uui-table-cell
- *  @slot for table cell content
+ *  @slot default - slot for table cell content
  */
 @defineElement('uui-table-cell')
 export class UUITableCellElement extends LitElement {

--- a/packages/uui-table/lib/uui-table-head.element.ts
+++ b/packages/uui-table/lib/uui-table-head.element.ts
@@ -4,7 +4,7 @@ import { css, html, LitElement } from 'lit';
 /**
  *  Table head element. Holds the styles for table head. Parent to uui-table-head-cell.
  *  @element uui-table-head
- *  @slot default - slot for uui-table-head-cell elements.
+ *  @slot - slot for uui-table-head-cell elements.
  */
 @defineElement('uui-table-head')
 export class UUITableHeadElement extends LitElement {

--- a/packages/uui-table/lib/uui-table-head.element.ts
+++ b/packages/uui-table/lib/uui-table-head.element.ts
@@ -4,7 +4,7 @@ import { css, html, LitElement } from 'lit';
 /**
  *  Table head element. Holds the styles for table head. Parent to uui-table-head-cell.
  *  @element uui-table-head
- *  @slot for uui-table-head-cell elements.
+ *  @slot default - slot for uui-table-head-cell elements.
  */
 @defineElement('uui-table-head')
 export class UUITableHeadElement extends LitElement {

--- a/packages/uui-table/lib/uui-table.element.ts
+++ b/packages/uui-table/lib/uui-table.element.ts
@@ -4,7 +4,7 @@ import { css, html, LitElement } from 'lit';
 /**
  *  Recreation of native table and it's child elements. `<uui-table>` is a parent element to `<uui-table-head>` `<and uui-table-row>`. To make it fully accessible remember to add aria-label and aria-describedby.
  *  @element uui-table
- *  @slot default - slot for `<uui-table-head>` and `<uui-table-row>` elements. Make a table out of them.
+ *  @slot - slot for `<uui-table-head>` and `<uui-table-row>` elements. Make a table out of them.
  */
 @defineElement('uui-table')
 export class UUITableElement extends LitElement {

--- a/packages/uui-table/lib/uui-table.element.ts
+++ b/packages/uui-table/lib/uui-table.element.ts
@@ -4,7 +4,7 @@ import { css, html, LitElement } from 'lit';
 /**
  *  Recreation of native table and it's child elements. `<uui-table>` is a parent element to `<uui-table-head>` `<and uui-table-row>`. To make it fully accessible remember to add aria-label and aria-describedby.
  *  @element uui-table
- *  @slot for uui-table-head and uui-table-row elements. Make a table out of them.
+ *  @slot default - slot for `<uui-table-head>` and `<uui-table-row>` elements. Make a table out of them.
  */
 @defineElement('uui-table')
 export class UUITableElement extends LitElement {

--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -6,7 +6,7 @@ import { UUITabElement } from './uui-tab.element';
 
 /**
  *  @element uui-tab-group
- *  @slot default - Default slot for the tab group
+ *  @slot - Default slot for the tab group
  */
 @defineElement('uui-tab-group')
 export class UUITabGroupElement extends LitElement {

--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -6,6 +6,7 @@ import { UUITabElement } from './uui-tab.element';
 
 /**
  *  @element uui-tab-group
+ *  @slot default - Default slot for the tab group
  */
 @defineElement('uui-tab-group')
 export class UUITabGroupElement extends LitElement {

--- a/packages/uui-tag/lib/uui-tag.element.ts
+++ b/packages/uui-tag/lib/uui-tag.element.ts
@@ -1,16 +1,16 @@
-import { LitElement, html, css } from 'lit';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
-import { property } from 'lit/decorators.js';
 import {
-  InterfaceLookType,
   InterfaceLookDefaultValue,
+  InterfaceLookType,
 } from '@umbraco-ui/uui-base/lib/types';
+import { css, html, LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
 
 /**
  *
  *  @element uui-tag
  *  @description Tag component from Umbraco UI components library. Comes in one shape, but different looks and sizes
- *  @slot - for tag contents
+ *  @slot default - slot for tag contents
  *  @cssprop --uui-tag-font-size - overwrite the default font-size for the tag.
  */
 @defineElement('uui-tag')
@@ -78,9 +78,7 @@ export class UUITagElement extends LitElement {
 
   /**
    * Defines the look of the tag.
-   * @type {''|'primary'|'secondary'|'outline'|'placeholder'|'positive'|'warning'|'danger'}
    * @attr
-   * @default ''
    */
   @property({ reflect: true })
   public look: InterfaceLookType = InterfaceLookDefaultValue;

--- a/packages/uui-tag/lib/uui-tag.element.ts
+++ b/packages/uui-tag/lib/uui-tag.element.ts
@@ -10,7 +10,7 @@ import { property } from 'lit/decorators.js';
  *
  *  @element uui-tag
  *  @description Tag component from Umbraco UI components library. Comes in one shape, but different looks and sizes
- *  @slot default - slot for tag contents
+ *  @slot - slot for tag contents
  *  @cssprop --uui-tag-font-size - overwrite the default font-size for the tag.
  */
 @defineElement('uui-tag')

--- a/packages/uui-tag/lib/uui-tag.story.ts
+++ b/packages/uui-tag/lib/uui-tag.story.ts
@@ -10,10 +10,10 @@ export default {
   id: 'uui-tag',
   args: {
     look: '',
-    default: 'Hello',
+    slot: 'Hello',
   },
   argTypes: {
-    default: { table: { category: 'slots' }, control: { type: 'text' } },
+    slot: { control: { type: 'text' } },
     look: {
       options: [
         'primary',
@@ -30,7 +30,7 @@ export default {
 };
 
 const Template: Story = props => html`
-  <uui-tag .look=${props.look}>${props.default}</uui-tag>
+  <uui-tag .look=${props.look}>${props.slot}</uui-tag>
 `;
 
 export const AAAOverview = Template.bind({});

--- a/packages/uui-tag/lib/uui-tag.story.ts
+++ b/packages/uui-tag/lib/uui-tag.story.ts
@@ -10,10 +10,10 @@ export default {
   id: 'uui-tag',
   args: {
     look: '',
-    slot: 'Hello',
+    default: 'Hello',
   },
   argTypes: {
-    slot: { table: { category: 'slots' }, control: { type: 'text' } },
+    default: { table: { category: 'slots' }, control: { type: 'text' } },
     look: {
       options: [
         'primary',
@@ -25,11 +25,12 @@ export default {
         'danger',
       ],
     },
+    '--uui-tag-font-size': { control: { type: 'text' } },
   },
 };
 
 const Template: Story = props => html`
-  <uui-tag .look=${props.look}>${props.slot}</uui-tag>
+  <uui-tag .look=${props.look}>${props.default}</uui-tag>
 `;
 
 export const AAAOverview = Template.bind({});
@@ -75,6 +76,9 @@ export const Sizing: Story = props =>
   `;
 
 Sizing.parameters = {
+  controls: {
+    include: ['look'],
+  },
   docs: {
     source: {
       code: `

--- a/packages/uui-toast-notification-container/lib/uui-toast-notification-container.element.ts
+++ b/packages/uui-toast-notification-container/lib/uui-toast-notification-container.element.ts
@@ -8,6 +8,7 @@ import { property } from 'lit/decorators.js';
 
 /**
  * @element uui-toast-notification-container
+ * @slot default - slot for toast layout/content
  */
 @defineElement('uui-toast-notification-container')
 export class UUIToastNotificationContainerElement extends LitElement {

--- a/packages/uui-toast-notification-container/lib/uui-toast-notification-container.element.ts
+++ b/packages/uui-toast-notification-container/lib/uui-toast-notification-container.element.ts
@@ -8,7 +8,7 @@ import { property } from 'lit/decorators.js';
 
 /**
  * @element uui-toast-notification-container
- * @slot default - slot for toast layout/content
+ * @slot - slot for toast layout/content
  */
 @defineElement('uui-toast-notification-container')
 export class UUIToastNotificationContainerElement extends LitElement {

--- a/packages/uui-toast-notification-layout/lib/uui-toast-notification-layout.element.ts
+++ b/packages/uui-toast-notification-layout/lib/uui-toast-notification-layout.element.ts
@@ -6,7 +6,7 @@ import { property, state } from 'lit/decorators.js';
 /**
  *  @element uui-toast-notification-layout
  *  @description - Component for setting the layout for a toast notification, to be used within toast-notification.
- *  @slot default - for content
+ *  @slot - for content
  *  @slot headline - for headline
  *  @slot actions - for actions
  */

--- a/packages/uui-toast-notification-layout/lib/uui-toast-notification-layout.element.ts
+++ b/packages/uui-toast-notification-layout/lib/uui-toast-notification-layout.element.ts
@@ -40,12 +40,11 @@ export class UUIToastNotificationLayoutElement extends LitElement {
 
   /**
    * Headline for this notification, can also be set via the 'headline' slot.
-   * @type string
    * @attr
-   * @default null
+   * @default
    */
   @property({ type: String })
-  headline: string | null = null;
+  headline: string = '';
 
   @state()
   private _headlineSlotHasContent = false;

--- a/packages/uui-toast-notification-layout/lib/uui-toast-notification-layout.element.ts
+++ b/packages/uui-toast-notification-layout/lib/uui-toast-notification-layout.element.ts
@@ -1,12 +1,12 @@
-import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
 import { css, html, LitElement } from 'lit';
 import { property, state } from 'lit/decorators.js';
 
 /**
  *  @element uui-toast-notification-layout
  *  @description - Component for setting the layout for a toast notification, to be used within toast-notification.
- *  @slot - for content
+ *  @slot default - for content
  *  @slot headline - for headline
  *  @slot actions - for actions
  */

--- a/packages/uui-toast-notification-layout/lib/uui-toast-notification-layout.story.ts
+++ b/packages/uui-toast-notification-layout/lib/uui-toast-notification-layout.story.ts
@@ -7,15 +7,14 @@ export default {
   id: 'uui-toast-notification-layout',
   title: 'Displays/Toast Notification/Toast Notification Layout',
   component: 'uui-toast-notification-layout',
-  args: {
-    headline: 'Headline',
-  },
   argTypes: {
-    headline: {
-      control: { type: 'text' },
-    },
     slot: {
       control: { type: 'text' },
+    },
+  },
+  parameters: {
+    controls: {
+      exclude: ['styles'],
     },
   },
   decorators: [
@@ -29,9 +28,13 @@ export const Overview: Story = props =>
     <uui-button slot="actions" look="primary" label="button"></uui-button>
   </uui-toast-notification-layout>`;
 
+Overview.args = {
+  headline: 'Headline',
+};
+
 export const SlottedContent: Story = props =>
   html`<uui-toast-notification-layout>
-    <h3 slot="headline">${props.headline}</h3>
+    <h3 slot="headline">${props['headline slot']}</h3>
     ${props.slot}
     <div slot="actions">
       <uui-icon-registry-essential>
@@ -48,11 +51,16 @@ export const SlottedContent: Story = props =>
   </uui-toast-notification-layout>`;
 
 SlottedContent.args = {
+  'headline slot': 'Headline',
   slot: 'This is the default slot',
+};
+
+SlottedContent.argTypes = {
+  'headline slot': { control: { type: 'text' } },
 };
 
 SlottedContent.parameters = {
   controls: {
-    include: ['headline', 'slot'],
+    include: ['headline slot', 'slot'],
   },
 };

--- a/packages/uui-toast-notification-layout/lib/uui-toast-notification-layout.story.ts
+++ b/packages/uui-toast-notification-layout/lib/uui-toast-notification-layout.story.ts
@@ -7,10 +7,52 @@ export default {
   id: 'uui-toast-notification-layout',
   title: 'Displays/Toast Notification/Toast Notification Layout',
   component: 'uui-toast-notification-layout',
+  args: {
+    headline: 'Headline',
+  },
+  argTypes: {
+    headline: {
+      control: { type: 'text' },
+    },
+    slot: {
+      control: { type: 'text' },
+    },
+  },
+  decorators: [
+    (Story: any) => html`<div style="max-width:200px;">${Story()}</div>`,
+  ],
 };
 
-export const Overview: Story = () =>
-  html`<uui-toast-notification-layout headline="Headline">
+export const Overview: Story = props =>
+  html`<uui-toast-notification-layout .headline=${props.headline}>
     Use this component within your dialog-element.
     <uui-button slot="actions" look="primary" label="button"></uui-button>
   </uui-toast-notification-layout>`;
+
+export const SlottedContent: Story = props =>
+  html`<uui-toast-notification-layout>
+    <h3 slot="headline">${props.headline}</h3>
+    ${props.slot}
+    <div slot="actions">
+      <uui-icon-registry-essential>
+        <uui-action-bar>
+          <uui-button look="primary"
+            ><uui-icon name="add"></uui-icon
+          ></uui-button>
+          <uui-button look="outline"
+            ><uui-icon name="delete"></uui-icon
+          ></uui-button>
+        </uui-action-bar>
+      </uui-icon-registry-essential>
+    </div>
+  </uui-toast-notification-layout>`;
+
+SlottedContent.args = {
+  slot: 'This is the default slot',
+};
+
+SlottedContent.parameters = {
+  controls: {
+    include: ['headline', 'slot'],
+  },
+};

--- a/packages/uui-toast-notification/lib/uui-toast-notification.element.ts
+++ b/packages/uui-toast-notification/lib/uui-toast-notification.element.ts
@@ -18,7 +18,7 @@ import { UUIToastNotificationEvent } from './UUIToastNotificationEvent';
  *  @fires {UUIToastNotificationEvent} closing - fires when the toast is starting to close
  *  @fires {UUIToastNotificationEvent} closed - fires when the toast is closed
  *  @description - Component for displaying a toast notification, preferably used in toast-notification-container.
- *  @slot - for dialog layout/content
+ *  @slot default - slot for dialog layout/content
  */
 @defineElement('uui-toast-notification')
 export class UUIToastNotificationElement extends LitElement {

--- a/packages/uui-toast-notification/lib/uui-toast-notification.element.ts
+++ b/packages/uui-toast-notification/lib/uui-toast-notification.element.ts
@@ -18,7 +18,7 @@ import { UUIToastNotificationEvent } from './UUIToastNotificationEvent';
  *  @fires {UUIToastNotificationEvent} closing - fires when the toast is starting to close
  *  @fires {UUIToastNotificationEvent} closed - fires when the toast is closed
  *  @description - Component for displaying a toast notification, preferably used in toast-notification-container.
- *  @slot default - slot for dialog layout/content
+ *  @slot - slot for dialog layout/content
  */
 @defineElement('uui-toast-notification')
 export class UUIToastNotificationElement extends LitElement {

--- a/packages/uui-toast-notification/lib/uui-toast-notification.story.ts
+++ b/packages/uui-toast-notification/lib/uui-toast-notification.story.ts
@@ -11,12 +11,15 @@ export default {
     open: true,
     look: '',
     headline: 'Toast notification layout headline',
-    message: 'Message to be displayed, shown by toast notification layout.',
+    slot: 'Message to be displayed, shown by toast notification layout.',
   },
   argTypes: {
     look: {
       options: ['', 'primary', 'positive', 'warning', 'danger'],
       control: { type: 'select' },
+    },
+    slot: {
+      control: { type: 'text' },
     },
   },
 };
@@ -25,7 +28,7 @@ const Template: Story = props => html`<uui-toast-notification
   .open=${props.open}
   .look=${props.look}>
   <uui-toast-notification-layout .headline=${props.headline}>
-    ${props.message}
+    ${props.slot}
   </uui-toast-notification-layout>
 </uui-toast-notification>`;
 
@@ -43,14 +46,13 @@ export const ErrorStyle: Story = props => html`<uui-toast-notification
   .open=${props.open}
   .look=${props.look}>
   <uui-toast-notification-layout .headline=${props.headline}>
-    ${props.message}
+    ${props.slot}
     <uui-button slot="actions" look="danger">Retry</uui-button>
   </uui-toast-notification-layout>
 </uui-toast-notification>`;
 ErrorStyle.args = {
   headline: 'Document could not be published!',
-  message:
-    'An error occurred while attempting to contact the server. Please check your internet connection.',
+  slot: 'An error occurred while attempting to contact the server. Please check your internet connection.',
   look: 'danger',
 };
 ErrorStyle.parameters = {
@@ -71,13 +73,13 @@ export const PositiveStyle: Story = props => html`<uui-toast-notification
   .open=${props.open}
   .look=${props.look}>
   <uui-toast-notification-layout .headline=${props.headline}>
-    ${props.message}
+    ${props.slot}
     <uui-button slot="actions" .look=${props.look}>View in browser</uui-button>
   </uui-toast-notification-layout>
 </uui-toast-notification>`;
 PositiveStyle.args = {
   headline: 'Document was published',
-  message: 'This document is now saved and published.',
+  slot: 'This document is now saved and published.',
   look: 'positive',
 };
 PositiveStyle.parameters = {
@@ -96,16 +98,19 @@ PositiveStyle.parameters = {
 export const CustomLayout: Story = props => html`<uui-toast-notification
   .open=${props.open}
   look="danger">
-  Its recommended to use the 'uui-toast-notification-layout' component as the
-  layout for your toasts. This will ensure consistency in toast appearances,
-  help achieving the best user experience. If 'uui-toast-notification-layout'
-  does not provide the options to solve your needs, it is possible append
-  anything within the toast-notification component. But please consider this
-  very carefully.
+  ${props.slot
+    ? props.slot
+    : html` Its recommended to use the 'uui-toast-notification-layout' component
+      as the layout for your toasts. This will ensure consistency in toast
+      appearances, help achieving the best user experience. If
+      'uui-toast-notification-layout' does not provide the options to solve your
+      needs, it is possible append anything within the toast-notification
+      component. But please consider this very carefully.`}
 </uui-toast-notification>`;
 CustomLayout.args = {
   headline: '',
   look: 'danger',
+  slot: undefined,
 };
 CustomLayout.parameters = {
   docs: {

--- a/packages/uui-toggle/lib/uui-toggle.element.ts
+++ b/packages/uui-toggle/lib/uui-toggle.element.ts
@@ -14,7 +14,6 @@ import { css, html } from 'lit';
  *  Umbraco Toggle-switch, toggles between off/on. Technically a checkbox.
  *  @element uui-toggle
  *  @fires UUIBooleanInputEvent#change- fires when the element is begin checked by a user action
- *  @slot to overwrite displayed label content
  *  @cssprop --uui-toggle-size - Define the toggle size.
  *  @cssprop --uui-toggle-switch-width - Define the slider width.
  *  @cssprop --uui-toggle-background-color - Set the toggle background color


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This ensures that all default slots does not have a name, and that they are still shown in Storybook.

This also adds missing stories for slots and enables dynamic slot experimentation in a few different stories.

Note that we are hacking this preview of Storybook a bit in terms of formatting custom elements. I have created an issue on [their tracker to highlight this](https://github.com/storybookjs/storybook/issues/17733).

Fixes [AB#17745](https://dev.azure.com/umbraco/243e7927-03b2-44e2-908f-d4ac7ea5daaa/_workitems/edit/17745)

<!--- Describe the changes in detail -->

## Screenshots

The toast notification element has both a property and a slot named `headline`, which is now shown like this.
![image](https://user-images.githubusercontent.com/752371/158594042-ae181f65-6446-4507-bef3-ac8c20678ed4.png)


The same element now has a story to demonstrate all slots.
![image](https://user-images.githubusercontent.com/752371/158594131-3a0ef139-9efd-48a2-bb3d-e119cd094a8f.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
