### PR TITLE
Hide native input in Safari.

### DIFF
--- a/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
+++ b/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
@@ -36,6 +36,7 @@ export abstract class UUIBooleanInputElement extends FormControlMixin(
         position: absolute;
         height: 0px;
         width: 0px;
+        margin-top: -4px;
       }
 
       :host([label-position='left']) label {


### PR DESCRIPTION
Hidden native input behind custom UI, just moved up a little, as it was peaking out on Safari.