### PR TITLE
Implement demandCustomElement for all packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35351,6 +35351,7 @@
       "version": "0.0.19",
       "license": "MIT",
       "dependencies": {
+        "@umbraco-ui/uui-avatar": "0.0.19",
         "@umbraco-ui/uui-base": "0.0.17"
       }
     },
@@ -35400,7 +35401,8 @@
       "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "0.0.17"
+        "@umbraco-ui/uui-base": "0.0.17",
+        "@umbraco-ui/uui-icon-registry-essential": "0.0.3"
       }
     },
     "packages/uui-button-group": {
@@ -35408,8 +35410,7 @@
       "version": "0.0.12",
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "0.0.17",
-        "@umbraco-ui/uui-icon-registry-essential": "0.0.3"
+        "@umbraco-ui/uui-base": "0.0.17"
       }
     },
     "packages/uui-button-inline-create": {
@@ -35473,7 +35474,8 @@
       "license": "MIT",
       "dependencies": {
         "@umbraco-ui/uui-base": "0.0.17",
-        "@umbraco-ui/uui-boolean-input": "0.0.3"
+        "@umbraco-ui/uui-boolean-input": "0.0.3",
+        "@umbraco-ui/uui-icon-registry-essential": "0.0.3"
       }
     },
     "packages/uui-css": {
@@ -35514,7 +35516,8 @@
       "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "0.0.17"
+        "@umbraco-ui/uui-base": "0.0.17",
+        "@umbraco-ui/uui-form-validation-message": "0.0.2"
       }
     },
     "packages/uui-form-validation-message": {
@@ -35564,7 +35567,10 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "0.0.17"
+        "@umbraco-ui/uui-base": "0.0.17",
+        "@umbraco-ui/uui-button": "0.1.10",
+        "@umbraco-ui/uui-icon": "0.0.5",
+        "@umbraco-ui/uui-input": "0.0.19"
       }
     },
     "packages/uui-input-password": {
@@ -35622,7 +35628,9 @@
       "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "0.0.17"
+        "@umbraco-ui/uui-base": "0.0.17",
+        "@umbraco-ui/uui-loader-bar": "0.0.20",
+        "@umbraco-ui/uui-symbol-expand": "0.0.5"
       }
     },
     "packages/uui-pagination": {
@@ -35849,7 +35857,10 @@
       "license": "MIT",
       "dependencies": {
         "@umbraco-ui/uui-base": "0.0.17",
-        "@umbraco-ui/uui-css": "0.0.4"
+        "@umbraco-ui/uui-button": "0.1.10",
+        "@umbraco-ui/uui-css": "0.0.4",
+        "@umbraco-ui/uui-icon": "0.0.5",
+        "@umbraco-ui/uui-icon-registry-essential": "0.0.3"
       }
     },
     "packages/uui-toast-notification-container": {
@@ -35867,10 +35878,7 @@
       "license": "MIT",
       "dependencies": {
         "@umbraco-ui/uui-base": "0.0.17",
-        "@umbraco-ui/uui-button": "0.1.10",
-        "@umbraco-ui/uui-css": "0.0.4",
-        "@umbraco-ui/uui-icon": "0.0.5",
-        "@umbraco-ui/uui-icon-registry-essential": "0.0.3"
+        "@umbraco-ui/uui-css": "0.0.4"
       }
     },
     "packages/uui-toggle": {
@@ -43640,6 +43648,7 @@
     "@umbraco-ui/uui-avatar-group": {
       "version": "file:packages/uui-avatar-group",
       "requires": {
+        "@umbraco-ui/uui-avatar": "0.0.19",
         "@umbraco-ui/uui-base": "0.0.17"
       }
     },
@@ -43677,14 +43686,14 @@
     "@umbraco-ui/uui-button": {
       "version": "file:packages/uui-button",
       "requires": {
-        "@umbraco-ui/uui-base": "0.0.17"
+        "@umbraco-ui/uui-base": "0.0.17",
+        "@umbraco-ui/uui-icon-registry-essential": "0.0.3"
       }
     },
     "@umbraco-ui/uui-button-group": {
       "version": "file:packages/uui-button-group",
       "requires": {
-        "@umbraco-ui/uui-base": "0.0.17",
-        "@umbraco-ui/uui-icon-registry-essential": "0.0.3"
+        "@umbraco-ui/uui-base": "0.0.17"
       }
     },
     "@umbraco-ui/uui-button-inline-create": {
@@ -43734,7 +43743,8 @@
       "version": "file:packages/uui-checkbox",
       "requires": {
         "@umbraco-ui/uui-base": "0.0.17",
-        "@umbraco-ui/uui-boolean-input": "0.0.3"
+        "@umbraco-ui/uui-boolean-input": "0.0.3",
+        "@umbraco-ui/uui-icon-registry-essential": "0.0.3"
       }
     },
     "@umbraco-ui/uui-css": {
@@ -43765,7 +43775,8 @@
     "@umbraco-ui/uui-form-layout-item": {
       "version": "file:packages/uui-form-layout-item",
       "requires": {
-        "@umbraco-ui/uui-base": "0.0.17"
+        "@umbraco-ui/uui-base": "0.0.17",
+        "@umbraco-ui/uui-form-validation-message": "0.0.2"
       }
     },
     "@umbraco-ui/uui-form-validation-message": {
@@ -43803,7 +43814,10 @@
     "@umbraco-ui/uui-input-lock": {
       "version": "file:packages/uui-input-lock",
       "requires": {
-        "@umbraco-ui/uui-base": "0.0.17"
+        "@umbraco-ui/uui-base": "0.0.17",
+        "@umbraco-ui/uui-button": "0.1.10",
+        "@umbraco-ui/uui-icon": "0.0.5",
+        "@umbraco-ui/uui-input": "0.0.19"
       }
     },
     "@umbraco-ui/uui-input-password": {
@@ -43847,7 +43861,9 @@
     "@umbraco-ui/uui-menu-item": {
       "version": "file:packages/uui-menu-item",
       "requires": {
-        "@umbraco-ui/uui-base": "0.0.17"
+        "@umbraco-ui/uui-base": "0.0.17",
+        "@umbraco-ui/uui-loader-bar": "0.0.20",
+        "@umbraco-ui/uui-symbol-expand": "0.0.5"
       }
     },
     "@umbraco-ui/uui-pagination": {
@@ -44020,7 +44036,10 @@
       "version": "file:packages/uui-toast-notification",
       "requires": {
         "@umbraco-ui/uui-base": "0.0.17",
-        "@umbraco-ui/uui-css": "0.0.4"
+        "@umbraco-ui/uui-button": "0.1.10",
+        "@umbraco-ui/uui-css": "0.0.4",
+        "@umbraco-ui/uui-icon": "0.0.5",
+        "@umbraco-ui/uui-icon-registry-essential": "0.0.3"
       }
     },
     "@umbraco-ui/uui-toast-notification-container": {
@@ -44034,10 +44053,7 @@
       "version": "file:packages/uui-toast-notification-layout",
       "requires": {
         "@umbraco-ui/uui-base": "0.0.17",
-        "@umbraco-ui/uui-button": "0.1.10",
-        "@umbraco-ui/uui-css": "0.0.4",
-        "@umbraco-ui/uui-icon": "0.0.5",
-        "@umbraco-ui/uui-icon-registry-essential": "0.0.3"
+        "@umbraco-ui/uui-css": "0.0.4"
       }
     },
     "@umbraco-ui/uui-toggle": {

--- a/packages/uui-avatar-group/package.json
+++ b/packages/uui-avatar-group/package.json
@@ -30,7 +30,8 @@
     "custom-elements.json"
   ],
   "dependencies": {
-    "@umbraco-ui/uui-base": "0.0.17"
+    "@umbraco-ui/uui-base": "0.0.17",
+    "@umbraco-ui/uui-avatar": "0.0.19"
   },
   "scripts": {
     "build": "npm run analyze && tsc --build --force && rollup -c rollup.config.js",

--- a/packages/uui-avatar-group/tsconfig.json
+++ b/packages/uui-avatar-group/tsconfig.json
@@ -12,6 +12,9 @@
   "references": [
     {
       "path": "../uui-base"
+    },
+    {
+      "path": "../uui-avatar"
     }
   ]
 }

--- a/packages/uui-button-group/package.json
+++ b/packages/uui-button-group/package.json
@@ -31,8 +31,7 @@
     "custom-elements.json"
   ],
   "dependencies": {
-    "@umbraco-ui/uui-base": "0.0.17",
-    "@umbraco-ui/uui-icon-registry-essential": "0.0.3"
+    "@umbraco-ui/uui-base": "0.0.17"
   },
   "scripts": {
     "build": "npm run analyze && tsc --build --force && rollup -c rollup.config.js",

--- a/packages/uui-button-group/tsconfig.json
+++ b/packages/uui-button-group/tsconfig.json
@@ -12,9 +12,6 @@
   "references": [
     {
       "path": "../uui-base"
-    },
-    {
-      "path": "../uui-icon-registry-essential"
     }
   ]
 }

--- a/packages/uui-button/lib/uui-button.element.ts
+++ b/packages/uui-button/lib/uui-button.element.ts
@@ -1,9 +1,8 @@
-import '@umbraco-ui/uui-icon/lib';
-
 import {
   UUIHorizontalShakeAnimationValue,
   UUIHorizontalShakeKeyframes,
 } from '@umbraco-ui/uui-base/lib/animations';
+import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
 import { LabelMixin } from '@umbraco-ui/uui-base/lib/mixins';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import {
@@ -609,19 +608,17 @@ export class UUIButtonElement extends LabelMixin('', LitElement) {
     let element = html``;
     switch (this.state) {
       case 'waiting':
-        if (!customElements.get('uui-loader-circle')) {
-          console.warn(
-            'To properly render the waiting state, the uui-loader-circle element has to be registered'
-          );
-        }
+        demandCustomElement(this, 'uui-loader-circle');
         element = html`<uui-loader-circle id="loader"></uui-loader-circle>`;
         break;
       case 'success':
+        demandCustomElement(this, 'uui-icon');
         element = html`<uui-icon
           name="check"
           .fallback=${iconCheck.strings[0]}></uui-icon>`;
         break;
       case 'failed':
+        demandCustomElement(this, 'uui-icon');
         element = html`<uui-icon
           name="wrong"
           .fallback=${iconWrong.strings[0]}></uui-icon>`;

--- a/packages/uui-button/package.json
+++ b/packages/uui-button/package.json
@@ -30,7 +30,8 @@
     "custom-elements.json"
   ],
   "dependencies": {
-    "@umbraco-ui/uui-base": "0.0.17"
+    "@umbraco-ui/uui-base": "0.0.17",
+    "@umbraco-ui/uui-icon-registry-essential": "0.0.3"
   },
   "scripts": {
     "build": "npm run analyze && tsc --build --force && rollup -c rollup.config.js",

--- a/packages/uui-button/tsconfig.json
+++ b/packages/uui-button/tsconfig.json
@@ -12,6 +12,9 @@
   "references": [
     {
       "path": "../uui-base"
+    },
+    {
+      "path": "../uui-icon-registry-essential"
     }
   ]
 }

--- a/packages/uui-card-content-node/lib/uui-card-content-node.element.ts
+++ b/packages/uui-card-content-node/lib/uui-card-content-node.element.ts
@@ -1,4 +1,5 @@
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
 import { UUICardElement } from '@umbraco-ui/uui-card/lib';
 import { css, html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
@@ -108,6 +109,7 @@ export class UUICardContentNodeElement extends UUICardElement {
   }
 
   private _renderFallbackIcon() {
+    demandCustomElement(this, 'uui-icon');
     return html`<uui-icon .svg="${this.fallbackIcon}"></uui-icon>`;
   }
 

--- a/packages/uui-card-media/lib/uui-card-media.element.ts
+++ b/packages/uui-card-media/lib/uui-card-media.element.ts
@@ -1,4 +1,5 @@
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
 import { UUICardElement } from '@umbraco-ui/uui-card/lib';
 import { css, html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
@@ -124,6 +125,13 @@ export class UUICardMediaElement extends UUICardElement {
 
   @state()
   protected hasPreview = false;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+
+    demandCustomElement(this, 'uui-symbol-folder');
+    demandCustomElement(this, 'uui-symbol-file');
+  }
 
   private queryPreviews(e: any): void {
     this.hasPreview =

--- a/packages/uui-card-user/lib/uui-card-user.element.ts
+++ b/packages/uui-card-user/lib/uui-card-user.element.ts
@@ -1,4 +1,5 @@
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
 import { UUICardElement } from '@umbraco-ui/uui-card/lib';
 import { css, html, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
@@ -97,6 +98,12 @@ export class UUICardUserElement extends UUICardElement {
    */
   @property({ type: String })
   name = '';
+
+  connectedCallback(): void {
+    super.connectedCallback();
+
+    demandCustomElement(this, 'uui-avatar');
+  }
 
   public render() {
     return html`

--- a/packages/uui-checkbox/package.json
+++ b/packages/uui-checkbox/package.json
@@ -34,7 +34,8 @@
   ],
   "dependencies": {
     "@umbraco-ui/uui-base": "0.0.17",
-    "@umbraco-ui/uui-boolean-input": "0.0.3"
+    "@umbraco-ui/uui-boolean-input": "0.0.3",
+    "@umbraco-ui/uui-icon-registry-essential": "0.0.3"
   },
   "scripts": {
     "build": "npm run analyze && tsc --build --force && rollup -c rollup.config.js",

--- a/packages/uui-checkbox/tsconfig.json
+++ b/packages/uui-checkbox/tsconfig.json
@@ -15,6 +15,9 @@
     },
     {
       "path": "../uui-boolean-input"
+    },
+    {
+      "path": "../uui-icon-registry-essential"
     }
   ]
 }

--- a/packages/uui-form-layout-item/lib/uui-form-layout-item.element.ts
+++ b/packages/uui-form-layout-item/lib/uui-form-layout-item.element.ts
@@ -1,4 +1,5 @@
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
 import { css, html, LitElement } from 'lit';
 import { property, state } from 'lit/decorators.js';
 
@@ -44,6 +45,12 @@ export class UUIFormLayoutItemElement extends LitElement {
 
   @property({ type: String })
   description: string | null = null;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+
+    demandCustomElement(this, 'uui-form-validation-message');
+  }
 
   @state()
   private _labelSlotHasContent = false;

--- a/packages/uui-form-layout-item/package.json
+++ b/packages/uui-form-layout-item/package.json
@@ -28,7 +28,8 @@
     "custom-elements.json"
   ],
   "dependencies": {
-    "@umbraco-ui/uui-base": "0.0.17"
+    "@umbraco-ui/uui-base": "0.0.17",
+    "@umbraco-ui/uui-form-validation-message": "0.0.2"
   },
   "scripts": {
     "build": "npm run analyze && tsc --build --force && rollup -c rollup.config.js",

--- a/packages/uui-form-layout-item/tsconfig.json
+++ b/packages/uui-form-layout-item/tsconfig.json
@@ -12,6 +12,9 @@
   "references": [
     {
       "path": "../uui-base"
+    },
+    {
+      "path": "../uui-form-validation-message"
     }
   ]
 }

--- a/packages/uui-input-lock/lib/uui-input-lock.element.ts
+++ b/packages/uui-input-lock/lib/uui-input-lock.element.ts
@@ -1,4 +1,5 @@
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
 import { css, html } from 'lit';
 import { UUIInputElement } from '@umbraco-ui/uui-input/lib';
 import {
@@ -45,6 +46,13 @@ export class UUIInputLockElement extends UUIInputElement {
   constructor() {
     super();
     this.readonly = true;
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+
+    demandCustomElement(this, 'uui-icon');
+    demandCustomElement(this, 'uui-button');
   }
 
   _onLockToggle() {

--- a/packages/uui-input-lock/package.json
+++ b/packages/uui-input-lock/package.json
@@ -30,7 +30,10 @@
     "custom-elements.json"
   ],
   "dependencies": {
-    "@umbraco-ui/uui-base": "0.0.17"
+    "@umbraco-ui/uui-base": "0.0.17",
+    "@umbraco-ui/uui-input": "0.0.19",
+    "@umbraco-ui/uui-icon": "0.0.5",
+    "@umbraco-ui/uui-button": "0.1.10"
   },
   "scripts": {
     "build": "npm run analyze && tsc --build --force && rollup -c rollup.config.js",

--- a/packages/uui-input-lock/tsconfig.json
+++ b/packages/uui-input-lock/tsconfig.json
@@ -12,6 +12,15 @@
   "references": [
     {
       "path": "../uui-base"
+    },
+    {
+      "path": "../uui-input"
+    },
+    {
+      "path": "../uui-icon"
+    },
+    {
+      "path": "../uui-button"
     }
   ]
 }

--- a/packages/uui-input-password/lib/uui-input-password.element.ts
+++ b/packages/uui-input-password/lib/uui-input-password.element.ts
@@ -1,4 +1,5 @@
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
 import {
   iconSee,
   iconUnsee,
@@ -44,6 +45,13 @@ export class UUIInputPasswordElement extends UUIInputElement {
     } else {
       this.passwordType = 'password';
     }
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+
+    demandCustomElement(this, 'uui-icon');
+    demandCustomElement(this, 'uui-button');
   }
 
   renderIcon() {

--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -5,6 +5,7 @@ import {
   SelectOnlyMixin,
 } from '@umbraco-ui/uui-base/lib/mixins';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
 import { css, html, LitElement } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -268,6 +269,9 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
   connectedCallback() {
     super.connectedCallback();
     if (!this.hasAttribute('role')) this.setAttribute('role', 'menu');
+
+    demandCustomElement(this, 'uui-symbol-expand');
+    demandCustomElement(this, 'uui-loader-bar');
   }
 
   private iconSlotChanged(e: any): void {

--- a/packages/uui-menu-item/package.json
+++ b/packages/uui-menu-item/package.json
@@ -30,7 +30,9 @@
     "custom-elements.json"
   ],
   "dependencies": {
-    "@umbraco-ui/uui-base": "0.0.17"
+    "@umbraco-ui/uui-base": "0.0.17",
+    "@umbraco-ui/uui-symbol-expand": "0.0.5",
+    "@umbraco-ui/uui-loader-bar": "0.0.20"
   },
   "scripts": {
     "build": "npm run analyze && tsc --build --force && rollup -c rollup.config.js",

--- a/packages/uui-menu-item/tsconfig.json
+++ b/packages/uui-menu-item/tsconfig.json
@@ -12,6 +12,12 @@
   "references": [
     {
       "path": "../uui-base"
+    },
+    {
+      "path": "../uui-symbol-expand"
+    },
+    {
+      "path": "../uui-loader-bar"
     }
   ]
 }

--- a/packages/uui-pagination/lib/uui-pagination.element.ts
+++ b/packages/uui-pagination/lib/uui-pagination.element.ts
@@ -1,5 +1,6 @@
 import { UUIButtonElement } from '@umbraco-ui/uui-button/lib';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
 import { css, html, LitElement } from 'lit';
 import { property, query, queryAll, state } from 'lit/decorators.js';
 
@@ -62,6 +63,9 @@ export class UUIPaginationElement extends LitElement {
     super.connectedCallback();
     if (!this.hasAttribute('role')) this.setAttribute('role', 'navigation');
     this._visiblePages = this._generateVisiblePages(this.current);
+
+    demandCustomElement(this, 'uui-button');
+    demandCustomElement(this, 'uui-button-group');
   }
 
   disconnectedCallback() {

--- a/packages/uui-ref-node/lib/uui-ref-node.element.ts
+++ b/packages/uui-ref-node/lib/uui-ref-node.element.ts
@@ -1,4 +1,5 @@
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
 import { UUIRefElement } from '@umbraco-ui/uui-ref/lib';
 import { css, html } from 'lit';
 import { property, state } from 'lit/decorators.js';
@@ -104,6 +105,12 @@ export class UUIRefNodeElement extends UUIRefElement {
 
   protected fallbackIcon =
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M396.441 138.878l-83.997-83.993-7.331-7.333H105.702v416.701h298.071V146.214l-7.332-7.336zM130.74 439.217V72.591h141.613c37.201 0 19.274 88.18 19.274 88.18s86-20.901 87.104 18.534v259.912H130.74z"></path></svg>';
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    demandCustomElement(this, 'uui-icon');
+  }
 
   private _onSlotIconChange(event: Event) {
     this._iconSlotHasContent =

--- a/packages/uui-toast-notification-layout/package.json
+++ b/packages/uui-toast-notification-layout/package.json
@@ -31,10 +31,7 @@
   ],
   "dependencies": {
     "@umbraco-ui/uui-base": "0.0.17",
-    "@umbraco-ui/uui-button": "0.1.10",
-    "@umbraco-ui/uui-css": "0.0.4",
-    "@umbraco-ui/uui-icon": "0.0.5",
-    "@umbraco-ui/uui-icon-registry-essential": "0.0.3"
+    "@umbraco-ui/uui-css": "0.0.4"
   },
   "scripts": {
     "build": "npm run analyze && tsc --build --force && rollup -c rollup.config.js",

--- a/packages/uui-toast-notification-layout/tsconfig.json
+++ b/packages/uui-toast-notification-layout/tsconfig.json
@@ -14,16 +14,7 @@
       "path": "../uui-base"
     },
     {
-      "path": "../uui-button"
-    },
-    {
       "path": "../uui-css"
-    },
-    {
-      "path": "../uui-icon"
-    },
-    {
-      "path": "../uui-icon-registry-essential"
     }
   ]
 }

--- a/packages/uui-toast-notification/lib/uui-toast-notification.element.ts
+++ b/packages/uui-toast-notification/lib/uui-toast-notification.element.ts
@@ -226,6 +226,10 @@ export class UUIToastNotificationElement extends LitElement {
         this.open = false;
       }
     });
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
 
     demandCustomElement(this, 'uui-button');
     demandCustomElement(this, 'uui-icon');

--- a/packages/uui-toast-notification/package.json
+++ b/packages/uui-toast-notification/package.json
@@ -31,7 +31,10 @@
   ],
   "dependencies": {
     "@umbraco-ui/uui-base": "0.0.17",
-    "@umbraco-ui/uui-css": "0.0.4"
+    "@umbraco-ui/uui-css": "0.0.4",
+    "@umbraco-ui/uui-icon-registry-essential": "0.0.3",
+    "@umbraco-ui/uui-button": "0.1.10",
+    "@umbraco-ui/uui-icon": "0.0.5"
   },
   "scripts": {
     "build": "npm run analyze && tsc --build --force && rollup -c rollup.config.js",

--- a/packages/uui-toast-notification/tsconfig.json
+++ b/packages/uui-toast-notification/tsconfig.json
@@ -15,6 +15,15 @@
     },
     {
       "path": "../uui-css"
+    },
+    {
+      "path": "../uui-icon-registry-essential"
+    },
+    {
+      "path": "../uui-button"
+    },
+    {
+      "path": "../uui-icon"
     }
   ]
 }


### PR DESCRIPTION
## Description

This PR implements `demandCustomElement` for all elements that require other uui-elements. We want to make sure a uui component renders correctly in even given state. demandCustomElement adds a console warn if a required uui-element is not registered in the browser.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
