### PR TITLE
Remove define element warning

### DIFF
--- a/packages/uui-base/lib/registration/index.ts
+++ b/packages/uui-base/lib/registration/index.ts
@@ -21,9 +21,7 @@ export function defineElement(
 
     const existingElement = window.customElements.get(name);
 
-    if (existingElement) {
-      console.warn(`${name} is already defined`, existingElement); // TODO: Remove this in production
-    } else {
+    if (!existingElement) {
       window.customElements.define(name, constructor, options);
     }
   };


### PR DESCRIPTION
This PR removes the warning if a custom element is registered under the same name as an already registered custom element.