### PR TITLE
Add --only-changed to Chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -49,3 +49,6 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           buildScriptName: 'storybook:build'
           exitOnceUploaded: true
+          onlyChanged: '!(dev)'
+          externals: 'packages/uui-css/lib/**/*.css'
+          untraced: '.storybook/images'

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,6 +11,7 @@ on:
       - 'package-lock.json'
       - '.github/workflows/chromatic.yml'
       - '.storybook/**'
+      - '!packages/uui/**'
       - 'packages/*/package.json'
       - 'packages/*/lib/**'
       - 'packages/*/assets/**'


### PR DESCRIPTION
This greatly reduces the amount of snapshots used. We have already exhausted our 5000 snaps for this month after only 4 days.