### PR TITLE
Bugfix: Add missing uui-key element definition

### DIFF
--- a/packages/uui-keyboard-shortcut/lib/uui-key.element.ts
+++ b/packages/uui-keyboard-shortcut/lib/uui-key.element.ts
@@ -1,3 +1,4 @@
+import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { css, html, LitElement } from 'lit';
 import { queryAssignedNodes } from 'lit/decorators.js';
 
@@ -6,6 +7,7 @@ import { queryAssignedNodes } from 'lit/decorators.js';
  *  @element uui-key
  *  @slot - for the key name. Anything you put in here will be lowercase.
  */
+@defineElement('uui-key')
 export class UUIKeyElement extends LitElement {
   static styles = [
     css`

--- a/packages/uui-keyboard-shortcut/lib/uui-key.element.ts
+++ b/packages/uui-keyboard-shortcut/lib/uui-key.element.ts
@@ -1,6 +1,5 @@
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { css, html, LitElement } from 'lit';
-import { queryAssignedNodes } from 'lit/decorators.js';
 
 /**
  *  A visual representation of a key on you keyboard. use inside `<uui-keyboard-shortcut></uui-keyboard-shortcut>`
@@ -21,24 +20,13 @@ export class UUIKeyElement extends LitElement {
         padding: 5px 7px;
         box-sizing: border-box;
         user-select: none;
+        text-transform: lowercase;
       }
     `,
   ];
 
-  @queryAssignedNodes()
-  private slotNodes!: NodeList;
-
-  private _changeCase() {
-    if (this.slotNodes !== null) {
-      this.slotNodes.forEach(node => {
-        if (node.nodeName === '#text' && node.nodeValue)
-          node.nodeValue = node.nodeValue?.toLowerCase();
-      });
-    }
-  }
-
   render() {
-    return html`<slot @slotchange=${this._changeCase}></slot>`;
+    return html`<slot></slot>`;
   }
 }
 

--- a/packages/uui-keyboard-shortcut/lib/uui-key.element.ts
+++ b/packages/uui-keyboard-shortcut/lib/uui-key.element.ts
@@ -41,3 +41,9 @@ export class UUIKeyElement extends LitElement {
     return html`<slot @slotchange=${this._changeCase}></slot>`;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'uui-key': UUIKeyElement;
+  }
+}

--- a/packages/uui-keyboard-shortcut/lib/uui-keyboard-shortcut.test.ts
+++ b/packages/uui-keyboard-shortcut/lib/uui-keyboard-shortcut.test.ts
@@ -6,7 +6,7 @@ import '.';
 describe('UUIKey', () => {
   let element: UUIKeyElement;
   beforeEach(async () => {
-    element = await fixture(html`<uui-key>z</uui-key> `);
+    element = await fixture(html`<uui-key>ESC</uui-key> `);
   });
 
   it('is defined', () => {
@@ -15,6 +15,10 @@ describe('UUIKey', () => {
 
   it('passes the a11y audit', async () => {
     await expect(element).shadowDom.to.be.accessible();
+  });
+
+  it('lowercase text content of element', async () => {
+    expect(element.innerText).to.equal('esc');
   });
 });
 

--- a/packages/uui-keyboard-shortcut/lib/uui-keyboard-shortcut.test.ts
+++ b/packages/uui-keyboard-shortcut/lib/uui-keyboard-shortcut.test.ts
@@ -1,11 +1,16 @@
 import { html, fixture, expect } from '@open-wc/testing';
 import { UUIKeyboardShortcutElement } from './uui-keyboard-shortcut.element';
+import { UUIKeyElement } from './uui-key.element';
 import '.';
 
 describe('UUIKey', () => {
-  let element: UUIKeyboardShortcutElement;
+  let element: UUIKeyElement;
   beforeEach(async () => {
     element = await fixture(html`<uui-key>z</uui-key> `);
+  });
+
+  it('is defined', () => {
+    expect(element).to.be.instanceOf(UUIKeyElement);
   });
 
   it('passes the a11y audit', async () => {
@@ -27,6 +32,10 @@ describe('UUIKeyboardShortcut', () => {
         <uui-key>z</uui-key></uui-keyboard-shortcut
       >
     `);
+  });
+
+  it('is defined', () => {
+    expect(element).to.be.instanceOf(UUIKeyboardShortcutElement);
   });
 
   it('passes the a11y audit', async () => {


### PR DESCRIPTION
This PR adds the missing defineElement decorator to uui-key. When the element got correctly defined the test broke in safari because of the `&#8593;` in the test. 

I have changed the lowercase logic to be based on css instead of the custom changeCase method. I can't figure out if there is a scenario we need to cover that can't be handled with css?

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I confirm that to my knowledge the contribution looks original and that the [contributor is presumably allowed to share it](https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md#ownership-and-copyright).
- [x] I have added tests to cover my changes.
