### PR TITLE
fix: add missing reference to uui-input-lock for uui

### DIFF
--- a/packages/uui/package.json
+++ b/packages/uui/package.json
@@ -62,6 +62,7 @@
     "@umbraco-ui/uui-icon-registry": "0.1.0",
     "@umbraco-ui/uui-icon-registry-essential": "0.1.0",
     "@umbraco-ui/uui-input": "0.1.0",
+    "@umbraco-ui/uui-input-lock": "0.1.0",
     "@umbraco-ui/uui-input-password": "0.1.0",
     "@umbraco-ui/uui-keyboard-shortcut": "0.1.0",
     "@umbraco-ui/uui-label": "0.1.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe the changes in detail -->

Looks like the uui package is missing a single reference to another package making it not work when imported as es module.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
