### PR TITLE
UUI-Box: Removing local definition of --uui-box-default-padding

### DIFF
--- a/packages/uui-box/lib/uui-box.element.ts
+++ b/packages/uui-box/lib/uui-box.element.ts
@@ -6,8 +6,8 @@ import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
 /**
  *  A box for grouping elements
  *  @element uui-box
- *  @slot headline - headline area
- *  @slot header - headline area
+ *  @slot headline - headline area, this area is placed within the headline tag which is located inside the header. Use this to ensure the right headline styling.
+ *  @slot header - header area, use this for things that is not the headline but located in the header.
  *  @slot default - area for the content of the box
  *  @cssprop --uui-box-default-padding - overwrite the box padding
  *

--- a/packages/uui-box/lib/uui-box.element.ts
+++ b/packages/uui-box/lib/uui-box.element.ts
@@ -22,7 +22,6 @@ export class UUIBoxElement extends LitElement {
         box-shadow: var(--uui-shadow-depth-1);
         border-radius: var(--uui-border-radius);
         background-color: var(--uui-interface-surface);
-        --uui-box-default-padding: var(--uui-size-space-5);
       }
 
       #header {

--- a/packages/uui-box/lib/uui-box.test.ts
+++ b/packages/uui-box/lib/uui-box.test.ts
@@ -24,6 +24,24 @@ describe('UUIBox', () => {
     });
   });
 
+  describe('css custom properties', () => {
+    let wrapper: HTMLDivElement;
+    let element: UUIBoxElement;
+    beforeEach(async () => {
+      wrapper = (await fixture(html`<div
+        style="--uui-box-default-padding:1337px;">
+        <uui-box headline="headline"> Main </uui-box>
+      </div>`)) as HTMLDivElement;
+      element = wrapper.querySelector('uui-box')!;
+    });
+    it('allows for --uui-box-default-padding to be defined outside the scope.', () => {
+      const elementStyles = window.getComputedStyle(element);
+      expect(
+        elementStyles.getPropertyValue('--uui-box-default-padding').trim()
+      ).to.equal('1337px');
+    });
+  });
+
   describe('template', () => {
     it('renders a default slot', () => {
       const slot = element.shadowRoot!.querySelector('slot')!;


### PR DESCRIPTION
Do not set the CSS custom property --uui-box-default-padding locally, as that prevents it begin set on a global level.
I as well added tests to prove that it is inherited from a parent.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I confirm that to my knowledge the contribution looks original and that the [contributor is presumably allowed to share it](https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md#ownership-and-copyright).
- [x] I have added tests to cover my changes.
