### PR TITLE
change _onInput method from private to protected

### DIFF
--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -264,10 +264,11 @@ export class UUIInputElement extends FormControlMixin(LitElement) {
     return this._input;
   }
 
-  private _onInput(e: Event) {
+  protected _onInput(e: Event) {
     this.value = (e.target as HTMLInputElement).value;
 
     // TODO: Do we miss an input event?
+    // No, this event is already composed and bubbles, so th enative one just goes out and works. Change is not though. (see more https://html.spec.whatwg.org/multipage/input.html#common-input-element-events)
   }
 
   private _onChange() {


### PR DESCRIPTION
This PR changes the modifier on `_onIput` method from `private` to `protected`. This allows overriding this method by a class that extends `UUIInputElement` and implementing some extra logic happening when the user inputs a value. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)


- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I confirm that to my knowledge the contribution looks original and that the [contributor is presumably allowed to share it](https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md#ownership-and-copyright).
- [x] I have added tests to cover my changes.
