### PR TITLE
UUI-Select: set the element value to the value of selected option

### DIFF
--- a/packages/uui-select/lib/uui-select.element.ts
+++ b/packages/uui-select/lib/uui-select.element.ts
@@ -158,6 +158,8 @@ export class UUISelectElement extends FormControlMixin(LitElement) {
   @state()
   private _disabledGroups: string[] = [];
 
+  private _values: string[] = [];
+
   @query('#native')
   protected _input!: HTMLSelectElement;
 
@@ -212,8 +214,15 @@ export class UUISelectElement extends FormControlMixin(LitElement) {
   willUpdate(changedProperties: Map<string | number | symbol, unknown>) {
     if (changedProperties.has('options')) {
       this._extractGroups();
+      this._values = this.options.map(option => option.value);
       const selected = this.options.find(option => option.selected);
       this.value = selected ? selected.value : '';
+    }
+
+    if (changedProperties.has('value')) {
+      this.value = this._values.includes(this.value as string)
+        ? this.value
+        : '';
     }
     if (changedProperties.has('disabledGroups')) this._createDisabledGroups();
   }

--- a/packages/uui-select/lib/uui-select.element.ts
+++ b/packages/uui-select/lib/uui-select.element.ts
@@ -210,7 +210,11 @@ export class UUISelectElement extends FormControlMixin(LitElement) {
   }
 
   willUpdate(changedProperties: Map<string | number | symbol, unknown>) {
-    if (changedProperties.has('options')) this._extractGroups();
+    if (changedProperties.has('options')) {
+      this._extractGroups();
+      const selected = this.options.find(option => option.selected);
+      this.value = selected ? selected.value : '';
+    }
     if (changedProperties.has('disabledGroups')) this._createDisabledGroups();
   }
 
@@ -274,7 +278,8 @@ export class UUISelectElement extends FormControlMixin(LitElement) {
       aria-label=${this.label}
       @change=${this.setValue}
       ?disabled=${this.disabled}
-      .name=${this.name}>
+      .name=${this.name}
+      .value=${this.value as string}>
       <option disabled selected value="" hidden>${this.placeholder}</option>
       ${this._renderGrouped()}
       ${this.options

--- a/packages/uui-select/lib/uui-select.test.ts
+++ b/packages/uui-select/lib/uui-select.test.ts
@@ -3,7 +3,7 @@ import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { UUISelectElement } from './uui-select.element';
 
 const options: Array<Option> = [
-  { name: 'Carrot', value: 'orange' },
+  { name: 'Carrot', value: 'orange', selected: true },
   { name: 'Cucumber', value: 'green' },
   { name: 'Aubergine', value: 'purple' },
   { name: 'Blueberry', value: 'Blue' },
@@ -64,11 +64,7 @@ describe('UUISelect in Form', () => {
   beforeEach(async () => {
     formElement = await fixture(
       html` <form>
-        <uui-select
-          label="foo"
-          name="bar"
-          .options=${options}
-          value=${options[0].value}></uui-select>
+        <uui-select label="foo" name="bar" .options=${options}></uui-select>
       </form>`
     );
     element = formElement.querySelector('uui-select') as any;
@@ -117,7 +113,9 @@ describe('UUISelect in Form', () => {
         await elementUpdated(element);
       });
 
-      it('sets element to invalid when value is empty', () => {
+      it('sets element to invalid when value is empty', async () => {
+        element.value = '';
+        await elementUpdated(element);
         expect(element.checkValidity()).to.be.false;
       });
 

--- a/packages/uui-select/lib/uui-select.test.ts
+++ b/packages/uui-select/lib/uui-select.test.ts
@@ -75,6 +75,14 @@ describe('UUISelect in Form', () => {
     expect(element.value).to.be.equal('orange');
   });
 
+  it('if value is set to a string that is not in the options array the value is empty string', async () => {
+    element.value = 'something silly';
+    await elementUpdated(element);
+    const formData = new FormData(formElement);
+    expect(element.value).to.be.equal('');
+    expect(formData.get('bar')).to.be.equal('');
+  });
+
   it('form output', () => {
     const formData = new FormData(formElement);
     expect(formData.get('bar')).to.be.equal('orange');


### PR DESCRIPTION
This PR fixes bug in UUISelect caused the element to have an empty value despite of an option being set to selected. 

## Description

In the `willUpdate` if property `options` is changed the value of uui-slect element will be set to the value of the selected option if it is present. On top of that the value of native select in the shadow dom is now bind to the `value` property of the `UUISelect` and it is not possible to set the value to something different then values of the options. This behavior fully reflects the native select. 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

When the elememnt has preselected option the value should reflect the value of the option. It should not be possible to set the value to something different then values of the options. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
