### PR TITLE
fix the color of the toast notification close button

### DIFF
--- a/packages/uui-toast-notification/lib/uui-toast-notification.element.ts
+++ b/packages/uui-toast-notification/lib/uui-toast-notification.element.ts
@@ -189,20 +189,17 @@ export class UUIToastNotificationElement extends LitElement {
     }
   };
 
+  @query('#toast')
+  private _toastEl!: HTMLElement;
   private _timer: Timer | null = null;
   private _pauseTimer: boolean = false;
 
-  @query('#toast')
-  private _toastEl!: HTMLElement;
-
-  private _animationTimeout?: number;
-
   protected isOpen = false;
+  private _open = false;
 
   @state()
   private _animate = false;
-
-  private _open = false;
+  private _animationTimeout?: number;
 
   /**
    * define if this toast should open or close.

--- a/packages/uui-toast-notification/lib/uui-toast-notification.element.ts
+++ b/packages/uui-toast-notification/lib/uui-toast-notification.element.ts
@@ -121,12 +121,12 @@ export class UUIToastNotificationElement extends LitElement {
 
   /**
    * Changes the look of the notification to one of the predefined, symbolic looks. Example set this to danger for errors.
-   * @type {""|"primary"|"positive"|"warning"|"danger"}
+   * @type {""|"default"|"primary"|"positive"|"warning"|"danger"}
    * @attr
    * @default ""
    */
   @property({ reflect: true })
-  color = '';
+  color: '' | 'default' | 'positive' | 'warning' | 'danger' = '';
 
   private _autoClose: number | null = null;
   /**
@@ -343,7 +343,7 @@ export class UUIToastNotificationElement extends LitElement {
           <div id="close">
             <uui-button
               .label=${'close'}
-              ?color=${this.color}
+              .color=${this.color}
               .look=${this.color ? 'primary' : 'default'}
               @click=${() => (this.open = false)}>
               <uui-icon


### PR DESCRIPTION
uui-toast-notification did not parse the color prop correctly, so it did still have the primary look with default color.

example of error:

<img width="434" alt="image" src="https://user-images.githubusercontent.com/6791648/171717849-f87366c0-3808-4037-995d-74fa88ae9867.png">

this fix changes it to:

<img width="421" alt="image" src="https://user-images.githubusercontent.com/6791648/171719737-a182c20c-f321-4ff5-a47d-473f6c62dcd3.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
