### PR TITLE
Fix expand SVGs in safari

### DIFF
--- a/packages/uui-symbol-expand/lib/uui-symbol-expand.element.ts
+++ b/packages/uui-symbol-expand/lib/uui-symbol-expand.element.ts
@@ -38,7 +38,7 @@ export class UUISymbolExpandElement extends LitElement {
   public open = false;
 
   render() {
-    return html`<svg viewBox="0 0 512 512">
+    return html`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
       <path d="M 255.125 400.35 L 88.193 188.765 H 422.055 Z"></path>
     </svg>`;
   }

--- a/packages/uui-symbol-expand/lib/uui-symbol-expand.element.ts
+++ b/packages/uui-symbol-expand/lib/uui-symbol-expand.element.ts
@@ -21,6 +21,8 @@ export class UUISymbolExpandElement extends LitElement {
         transform: rotate(-90deg);
         transform-origin: 50% 50%;
         transition: transform 120ms ease-in-out;
+        width: 100%;
+        height: 100%;
       }
 
       :host([open]) svg {

--- a/packages/uui-symbol-sort/lib/uui-symbol-sort.element.ts
+++ b/packages/uui-symbol-sort/lib/uui-symbol-sort.element.ts
@@ -80,10 +80,13 @@ export class UUISymbolSortElement extends ActiveMixin(LitElement) {
   public descending = false;
 
   render() {
-    return html`<svg id="up" viewBox="0 0 512 512">
+    return html`<svg
+        id="up"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 512 512">
         <path d="M 255.125 400.35 L 88.193 188.765 H 422.055 Z"></path>
       </svg>
-      <svg id="down" viewBox="0 0 512 512">
+      <svg id="down" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path d="M 255.125 400.35 L 88.193 188.765 H 422.055 Z"></path>
       </svg>`;
   }


### PR DESCRIPTION
Adding CSS height and width to expand the symbol.
Adding xmlns to SVGs

fixes https://github.com/umbraco/Umbraco.UI/issues/225

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
