### PR TITLE
fix: disable-child-interaction going over edges + other details

### DIFF
--- a/packages/uui-css/lib/uui-text.css
+++ b/packages/uui-css/lib/uui-text.css
@@ -104,10 +104,10 @@
 
 .uui-text a:link,
 .uui-text a:active {
-  color: var(--uui-color-space-cadet);
+  color: var(--uui-color-interactive);
 }
 .uui-text a:hover {
-  color: var(--uui-color-violet-blue);
+  color: var(--uui-color-interactive-emphasis);
 }
 
 .uui-text small {

--- a/packages/uui-table/lib/uui-table-cell.element.ts
+++ b/packages/uui-table/lib/uui-table-cell.element.ts
@@ -14,6 +14,7 @@ export class UUITableCellElement extends LitElement {
   static styles = [
     css`
       :host {
+        position: relative;
         display: table-cell;
         height: var(--uui-table-cell-height, var(--uui-size-12));
         padding: var(

--- a/packages/uui-table/lib/uui-table-row.element.ts
+++ b/packages/uui-table/lib/uui-table-row.element.ts
@@ -23,23 +23,46 @@ export class UUITableRowElement extends SelectOnlyMixin(
       :host {
         display: table-row;
         position: relative;
+        outline-offset: -3px;
       }
 
       :host([selectable]) {
         cursor: pointer;
       }
 
+      :host(:focus) {
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+          var(--uui-color-focus);
+      }
       :host([selected]) {
         outline: 2px solid
           var(--uui-table-row-color-selected, var(--uui-color-selected));
-        outline-offset: -3px;
       }
-
-      :host(:focus) {
+      :host([selected]:focus) {
         outline-color: var(--uui-color-focus);
       }
     `,
   ];
+
+  constructor() {
+    super();
+
+    // hide outline if mouse-interaction:
+    let hadMouseDown = false;
+    this.addEventListener('blur', () => {
+      if (hadMouseDown === false) {
+        this.style.setProperty('--uui-show-focus-outline', '1');
+      }
+      hadMouseDown = false;
+    });
+    this.addEventListener('mousedown', () => {
+      this.style.setProperty('--uui-show-focus-outline', '0');
+      hadMouseDown = true;
+    });
+    this.addEventListener('mouseup', () => {
+      hadMouseDown = false;
+    });
+  }
 
   connectedCallback() {
     super.connectedCallback();


### PR DESCRIPTION
Fixing table-cell disable-child-interaction as after element went over the edge of the cell.
also fixing so outlines only show when using keyboard interaction
and correction colors of uui-text as they were forgotten when implementing the new color system.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
