### PR TITLE
fix: vertical align content of UUI-Button anchor tag

### DIFF
--- a/packages/uui-button/lib/uui-button.element.ts
+++ b/packages/uui-button/lib/uui-button.element.ts
@@ -100,12 +100,15 @@ export class UUIButtonElement extends FormControlMixin(
         text-align: inherit;
         border: none;
         cursor: inherit;
-        display: block;
+
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
 
         /* for anchor tag: */
         text-decoration: none;
         color: currentColor;
-        line-height: normal;
+        line-height: inherit;
 
         border-width: var(--uui-button-border-width, 1px);
         border-style: solid;
@@ -119,7 +122,6 @@ export class UUIButtonElement extends FormControlMixin(
           calc(var(--uui-size-2) * var(--uui-button-padding-right-factor)) 0
           calc(var(--uui-size-2) * var(--uui-button-padding-left-factor));
 
-        vertical-align: middle;
         box-shadow: none;
       }
       button[disabled]:active,

--- a/packages/uui-button/lib/uui-button.story.ts
+++ b/packages/uui-button/lib/uui-button.story.ts
@@ -324,12 +324,14 @@ export const AnchorTag = Template.bind({});
 AnchorTag.args = {
   href: 'https://www.umbraco.com',
   target: '_blank',
+  look: 'primary',
 };
 AnchorTag.parameters = {
   docs: {
     source: {
       code: html`
         <uui-button
+          look="primary"
           label="Open umbraco.com"
           href="http://www.umbraco.com"
           target="_blank">


### PR DESCRIPTION
Use flex-box (flex-inline) to vertical align content of UUI-Button anchor tag

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
