### PR TITLE
fix: change notification color primary to default

### DIFF
--- a/packages/uui-toast-notification/lib/uui-toast-notification.element.ts
+++ b/packages/uui-toast-notification/lib/uui-toast-notification.element.ts
@@ -96,7 +96,7 @@ export class UUIToastNotificationElement extends LitElement {
         color: var(--uui-color-text);
         border-color: var(--uui-color-surface);
       }
-      :host([color='primary']) #toast > div {
+      :host([color='default']) #toast > div {
         background-color: var(--uui-color-default);
         color: var(--uui-color-default-contrast);
         border-color: var(--uui-color-default-standalone);


### PR DESCRIPTION
`uui-notification` css does not follow look/color system. This PR fixes that.

## Description

Notification element was acceping primary to the color property.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)



- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
