### PR TITLE
change height to min-height in uui-button

### DIFF
--- a/packages/uui-button/lib/uui-button.element.ts
+++ b/packages/uui-button/lib/uui-button.element.ts
@@ -52,7 +52,7 @@ export class UUIButtonElement extends FormControlMixin(
         --uui-button-padding-left-factor: 3;
         --uui-button-padding-right-factor: 3;
 
-        height: var(--uui-button-height, var(--uui-size-11));
+        min-height: var(--uui-button-height, var(--uui-size-11));
         max-height: 100%;
         cursor: pointer;
 


### PR DESCRIPTION
This PR changes `height` to `min-height` in the uui-button component

## Description
Because the height is fixed on the button, it cannot handle more then 1 line. See picture. 
![image](https://user-images.githubusercontent.com/56249914/181462550-65618dc5-d440-492b-9fd6-27ae6574e973.png).

By changing the `height` to `min-height` the button can stretch nicely.
![image](https://user-images.githubusercontent.com/56249914/181463101-2014b1f9-e70c-47f4-aa86-758abdf31960.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
