### PR TITLE
Fix various issues of combobox and related

### DIFF
--- a/packages/uui-combobox/lib/uui-combobox.element.ts
+++ b/packages/uui-combobox/lib/uui-combobox.element.ts
@@ -83,11 +83,11 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
     return this._value;
   }
   set value(newValue) {
-    super.value = newValue;
-
     if (typeof newValue === 'string') {
       this._updateValue(newValue);
     }
+
+    super.value = newValue;
   }
 
   /**
@@ -185,7 +185,7 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
   private _onBlur = () =>
     requestAnimationFrame(() => {
       if (document.activeElement !== this) {
-        this._close();
+        this._onClose();
       }
     });
 
@@ -201,10 +201,9 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
     e.stopImmediatePropagation();
 
     this.value = this._comboboxList?.value || '';
-    this._displayValue = this._comboboxList?.displayValue || '';
     this.search = this.value ? this.search : '';
 
-    this._close();
+    this._onClose();
 
     this.dispatchEvent(new UUIComboboxEvent(UUIComboboxEvent.CHANGE));
   };
@@ -214,16 +213,14 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
     this.open = true;
   };
 
-  private _close = () => {
+  private _onClose = () => {
     if (!this.open) return;
 
     this.open = false;
-
-    // Reset display and input value:
-    this._displayValue = this._comboboxList?.displayValue || '';
+    this.search = '';
+    // Reset input(search-input) value:
     this._input.value = this._displayValue;
 
-    this.search = '';
     this.dispatchEvent(new UUIComboboxEvent(UUIComboboxEvent.SEARCH));
   };
 
@@ -238,21 +235,22 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
     }
 
     if (e.key === 'Escape' || e.key === 'Enter') {
-      this._close();
+      this._onClose();
     }
   };
 
-  private _clear = (e: any) => {
+  private _onClear = (e: any) => {
     if (e.key && e.key !== 'Enter') return;
 
     e.preventDefault(); // TODO: could we avoid this.
     e.stopImmediatePropagation(); // TODO: could we avoid this.
 
-    this._displayValue = '';
-    this._input.value = this._displayValue;
-    this.search = '';
     this.value = '';
-    this._comboboxList.value = this.value;
+    this.search = '';
+    // Reset input(search-input) value:
+    this._input.value = this._displayValue;
+
+    this.dispatchEvent(new UUIComboboxEvent(UUIComboboxEvent.SEARCH));
     this.dispatchEvent(new UUIComboboxEvent(UUIComboboxEvent.CHANGE));
   };
 
@@ -263,7 +261,6 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
       label="combobox-input"
       type="text"
       .value=${this._displayValue}
-      .placeholder=${this._displayValue}
       autocomplete="off"
       @click=${this._open}
       @input=${this._onInput}
@@ -284,8 +281,8 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
     return html`<uui-button
       id="clear-button"
       class=${this.value || this.search ? '--show' : ''}
-      @click=${this._clear}
-      @keydown=${this._clear}
+      @click=${this._onClear}
+      @keydown=${this._onClear}
       label="clear"
       slot="append"
       compact
@@ -307,7 +304,7 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
       <uui-popover
         .open=${this.open}
         .margin=${-1}
-        @close=${() => this._close()}>
+        @close=${() => this._onClose()}>
         ${this._renderInput()} ${this._renderDropdown()}
       </uui-popover>
     `;

--- a/packages/uui-form-validation-message/lib/uui-form-validation-message.element.ts
+++ b/packages/uui-form-validation-message/lib/uui-form-validation-message.element.ts
@@ -78,7 +78,7 @@ export class UUIFormValidationMessageElement extends LitElement {
   private _messages = new Map<FormControlMixinInterface, string>();
 
   private _onControlInvalid = (e: UUIFormControlEvent) => {
-    const ctrl = e.target;
+    const ctrl = (e as any).path[0];
     if (ctrl.pristine === false) {
       // Currently we only show message from components who does have the pristine property. (we only want to show messages from fields that are NOT pristine aka. that are dirty or in a from that has been submitted)
       this._messages.set(ctrl, ctrl.validationMessage);
@@ -89,7 +89,8 @@ export class UUIFormValidationMessageElement extends LitElement {
   };
 
   private _onControlValid = (e: UUIFormControlEvent) => {
-    this._messages.delete(e.target);
+    const ctrl = (e as any).path[0];
+    this._messages.delete(ctrl);
     this.requestUpdate();
   };
 

--- a/packages/uui-form-validation-message/lib/uui-form-validation-message.element.ts
+++ b/packages/uui-form-validation-message/lib/uui-form-validation-message.element.ts
@@ -78,7 +78,7 @@ export class UUIFormValidationMessageElement extends LitElement {
   private _messages = new Map<FormControlMixinInterface, string>();
 
   private _onControlInvalid = (e: UUIFormControlEvent) => {
-    const ctrl = (e as any).path[0];
+    const ctrl = (e as any).composedPath()[0];
     if (ctrl.pristine === false) {
       // Currently we only show message from components who does have the pristine property. (we only want to show messages from fields that are NOT pristine aka. that are dirty or in a from that has been submitted)
       this._messages.set(ctrl, ctrl.validationMessage);
@@ -89,7 +89,7 @@ export class UUIFormValidationMessageElement extends LitElement {
   };
 
   private _onControlValid = (e: UUIFormControlEvent) => {
-    const ctrl = (e as any).path[0];
+    const ctrl = (e as any).composedPath()[0];
     this._messages.delete(ctrl);
     this.requestUpdate();
   };


### PR DESCRIPTION
fixes https://github.com/umbraco/Umbraco.UI/issues/263

The uui-form-validation-message was using event target to identify the component. It turned out that because we now have bubbling events, the events from the search input also got registered as the combobox and since it's always valid that overwrote the state of the combobox. This is fixed by using `.composedPath()[0]`

We also had some internal state of combobox that wasn't handled right, so cleaned up the values a bit.

Fixes the following cases:

- Clear button doesn't clear search result
- Typing in search field and closing the dropdown hides the value
- Validation message of combobox does not always show up in uui-form-validation-message

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

## How to test?

See issue.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
