### PR TITLE
Bugfix/dispatching of events twice

### DIFF
--- a/packages/uui-base/lib/events/UUIEvent.ts
+++ b/packages/uui-base/lib/events/UUIEvent.ts
@@ -4,6 +4,7 @@
 
 const DefaultInit = {
   composed: true,
+  bubbles: true,
 };
 export class UUIEvent<
   DetailType extends Record<string, any> = Record<string, any>,

--- a/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
+++ b/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
@@ -142,7 +142,6 @@ export abstract class UUIBooleanInputElement extends FormControlMixin(
   }
 
   private _onKeypress(e: KeyboardEvent): void {
-    e.stopPropagation();
     if (e.key == 'Enter') {
       this.submit();
     }

--- a/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
+++ b/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
@@ -142,6 +142,7 @@ export abstract class UUIBooleanInputElement extends FormControlMixin(
   }
 
   private _onKeypress(e: KeyboardEvent): void {
+    e.stopPropagation();
     if (e.key == 'Enter') {
       this.submit();
     }
@@ -190,7 +191,8 @@ export abstract class UUIBooleanInputElement extends FormControlMixin(
     this._input.click();
   }
 
-  private _onInputChange() {
+  private _onInputChange(e: Event) {
+    e.stopPropagation();
     this.pristine = false;
     this.checked = this._input.checked;
     this.dispatchEvent(new UUIBooleanInputEvent(UUIBooleanInputEvent.CHANGE));

--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -264,6 +264,7 @@ export class UUIInputElement extends FormControlMixin(
   }
 
   private _onKeypress(e: KeyboardEvent): void {
+    e.stopPropagation();
     if (this.type !== 'color' && e.key == 'Enter') {
       this.submit();
     }
@@ -281,12 +282,14 @@ export class UUIInputElement extends FormControlMixin(
   }
 
   protected onInput(e: Event) {
+    e.stopPropagation();
     this.value = (e.target as HTMLInputElement).value;
 
     this.dispatchEvent(new UUIInputEvent(UUIInputEvent.INPUT));
   }
 
-  protected onChange() {
+  protected onChange(e: Event) {
+    e.stopPropagation();
     this.pristine = false;
     this.dispatchEvent(new UUIInputEvent(UUIInputEvent.CHANGE));
   }

--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -264,7 +264,6 @@ export class UUIInputElement extends FormControlMixin(
   }
 
   private _onKeypress(e: KeyboardEvent): void {
-    e.stopPropagation();
     if (this.type !== 'color' && e.key == 'Enter') {
       this.submit();
     }

--- a/packages/uui-radio/lib/uui-radio-group.element.ts
+++ b/packages/uui-radio/lib/uui-radio-group.element.ts
@@ -251,7 +251,6 @@ export class UUIRadioGroupElement extends FormControlMixin(LitElement) {
   }
 
   private _onKeypress(e: KeyboardEvent): void {
-    e.stopPropagation();
     if (e.key == 'Enter') {
       this.submit();
     }

--- a/packages/uui-radio/lib/uui-radio-group.element.ts
+++ b/packages/uui-radio/lib/uui-radio-group.element.ts
@@ -117,6 +117,7 @@ export class UUIRadioGroupElement extends FormControlMixin(LitElement) {
   }
 
   private _handleSlotChange(e: Event) {
+    e.stopPropagation();
     // TODO: make sure to diff new and old ones to only add and remove event listeners on relevant elements.
 
     this._radioElements?.forEach(el => {
@@ -225,6 +226,7 @@ export class UUIRadioGroupElement extends FormControlMixin(LitElement) {
   }
 
   private _onKeydown(e: KeyboardEvent) {
+    e.stopPropagation();
     switch (e.key) {
       case ARROW_LEFT:
       case ARROW_UP: {
@@ -249,6 +251,7 @@ export class UUIRadioGroupElement extends FormControlMixin(LitElement) {
   }
 
   private _onKeypress(e: KeyboardEvent): void {
+    e.stopPropagation();
     if (e.key == 'Enter') {
       this.submit();
     }
@@ -264,6 +267,7 @@ export class UUIRadioGroupElement extends FormControlMixin(LitElement) {
   };
 
   private _handleSelectOnClick = (e: UUIRadioEvent) => {
+    e.stopPropagation();
     if (e.target.checked === true) {
       this.value = e.target.value;
       this._fireChangeEvent();

--- a/packages/uui-radio/lib/uui-radio.element.ts
+++ b/packages/uui-radio/lib/uui-radio.element.ts
@@ -220,7 +220,8 @@ export class UUIRadioElement extends LitElement {
     this.inputElement.click();
   }
 
-  private _onChange() {
+  private _onChange(e: Event) {
+    e.stopPropagation();
     const checked = this.inputElement.checked;
     this.checked = checked;
     if (checked) {

--- a/packages/uui-select/lib/uui-select.element.ts
+++ b/packages/uui-select/lib/uui-select.element.ts
@@ -229,6 +229,7 @@ export class UUISelectElement extends FormControlMixin(LitElement) {
   }
 
   protected setValue(e: Event) {
+    e.stopPropagation();
     const target = e.target as HTMLSelectElement;
     if (e.target) this.value = target.value;
     this.dispatchEvent(

--- a/packages/uui-slider/lib/uui-slider.element.ts
+++ b/packages/uui-slider/lib/uui-slider.element.ts
@@ -374,6 +374,7 @@ export class UUISliderElement extends FormControlMixin(LitElement) {
   };
 
   private _onKeypress(e: KeyboardEvent): void {
+    e.stopPropagation();
     if (e.key == 'Enter') {
       this.submit();
     }
@@ -392,12 +393,14 @@ export class UUISliderElement extends FormControlMixin(LitElement) {
     this._sliderPosition = `${Math.floor(ratio * 100000) / 1000}%`;
   }
 
-  private _onInput() {
+  private _onInput(e: Event) {
+    e.stopPropagation();
     this.value = this._input.value;
     this.dispatchEvent(new UUISliderEvent(UUISliderEvent.INPUT));
   }
 
-  private _onChange() {
+  private _onChange(e: Event) {
+    e.stopPropagation();
     this.pristine = false;
     this.dispatchEvent(new UUISliderEvent(UUISliderEvent.CHANGE));
   }

--- a/packages/uui-slider/lib/uui-slider.element.ts
+++ b/packages/uui-slider/lib/uui-slider.element.ts
@@ -374,7 +374,6 @@ export class UUISliderElement extends FormControlMixin(LitElement) {
   };
 
   private _onKeypress(e: KeyboardEvent): void {
-    e.stopPropagation();
     if (e.key == 'Enter') {
       this.submit();
     }

--- a/packages/uui-textarea/lib/uui-textarea.element.ts
+++ b/packages/uui-textarea/lib/uui-textarea.element.ts
@@ -255,7 +255,8 @@ export class UUITextareaElement extends FormControlMixin(LitElement) {
     //this.dispatchEvent(new UUITextareaEvent(UUITextareaEvent.INPUT));
   }
 
-  private onChange() {
+  private onChange(e: Event) {
+    e.stopPropagation();
     this.pristine = false;
     this.dispatchEvent(new UUITextareaEvent(UUITextareaEvent.CHANGE));
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

bubbles set to true on default
and a lot of e.stopPropagation() for where events could maybe clash with native events

Theres some other dispatch of events (forexample in combobox's method `_onclose` has a search event dispatched. Would we need a stopPropagation here as well? I assumed not because I dont think it had anything to do with native events, but please let me know if I'm wrong here.

<!--- Describe the changes in detail -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
