### PR TITLE
FIXES:#297 - Missing custom icon for reference nodes in Storybook

### DIFF
--- a/packages/uui-ref-node-data-type/lib/uui-ref-node-data-type.story.ts
+++ b/packages/uui-ref-node-data-type/lib/uui-ref-node-data-type.story.ts
@@ -48,14 +48,16 @@ AAAOverview.parameters = {
 };
 
 export const CustomIcon: Story = () => html`
-  <div style="max-width: 420px;">
-    <uui-ref-node-data-type name="Color Picker" alias="Umbraco.ColorPicker">
-      <uui-icon slot="icon" name="colorpicker"></uui-icon>
-      <uui-action-bar slot="actions">
-        <uui-button label="Remove">Remove</uui-button>
-      </uui-action-bar>
-    </uui-ref-node-data-type>
-  </div>
+  <uui-icon-registry-essential>
+    <div style="max-width: 420px;">
+      <uui-ref-node-data-type name="Color Picker" alias="Umbraco.ColorPicker">
+        <uui-icon slot="icon" name="colorpicker"></uui-icon>
+        <uui-action-bar slot="actions">
+          <uui-button label="Remove">Remove</uui-button>
+        </uui-action-bar>
+      </uui-ref-node-data-type>
+    </div>
+  </uui-icon-registry-essential>
 `;
 
 CustomIcon.parameters = {

--- a/packages/uui-ref-node-document-type/lib/uui-ref-node-document-type.story.ts
+++ b/packages/uui-ref-node-document-type/lib/uui-ref-node-document-type.story.ts
@@ -48,14 +48,16 @@ AAAOverview.parameters = {
 };
 
 export const CustomIcon: Story = () => html`
-  <div style="max-width: 420px;">
-    <uui-ref-node-data-type name="Product Page" alias="productPage">
-      <uui-icon slot="icon" name="shopping-basket-alt"></uui-icon>
-      <uui-action-bar slot="actions">
-        <uui-button label="Remove">Remove</uui-button>
-      </uui-action-bar>
-    </uui-ref-node-data-type>
-  </div>
+  <uui-icon-registry-essential>
+    <div style="max-width: 420px;">
+      <uui-ref-node-data-type name="Product Page" alias="productPage">
+        <uui-icon slot="icon" name="colorpicker"></uui-icon>
+        <uui-action-bar slot="actions">
+          <uui-button label="Remove">Remove</uui-button>
+        </uui-action-bar>
+      </uui-ref-node-data-type>
+    </div>
+  </uui-icon-registry-essential>
 `;
 
 CustomIcon.parameters = {
@@ -65,7 +67,7 @@ CustomIcon.parameters = {
 <uui-ref-node-data-type
   name="Product Page"
   alias="productPage">
-  <uui-icon slot="icon" name="shopping-basket-alt"></uui-icon>
+  <uui-icon slot="icon" name="colorpicker"></uui-icon>
   <uui-action-bar slot="actions">
     <uui-button label="Remove">Remove</uui-button>
   </uui-action-bar>

--- a/packages/uui-ref-node-form/lib/uui-ref-node-form.story.ts
+++ b/packages/uui-ref-node-form/lib/uui-ref-node-form.story.ts
@@ -47,16 +47,18 @@ AAAOverview.parameters = {
 };
 
 export const CustomIcon: Story = () => html`
-  <div style="max-width: 420px;">
-    <uui-ref-node-data-type
-      name="Newsletter Signup"
-      detail="Signup for newsletter">
-      <uui-icon slot="icon" name="newspaper-alt"></uui-icon>
-      <uui-action-bar slot="actions">
-        <uui-button label="Remove">Remove</uui-button>
-      </uui-action-bar>
-    </uui-ref-node-data-type>
-  </div>
+  <uui-icon-registry-essential>
+    <div style="max-width: 420px;">
+      <uui-ref-node-data-type
+        name="Newsletter Signup"
+        detail="Signup for newsletter">
+        <uui-icon slot="icon" name="colorpicker"></uui-icon>
+        <uui-action-bar slot="actions">
+          <uui-button label="Remove">Remove</uui-button>
+        </uui-action-bar>
+      </uui-ref-node-data-type>
+    </div>
+  </uui-icon-registry-essential>
 `;
 
 CustomIcon.parameters = {
@@ -66,7 +68,7 @@ CustomIcon.parameters = {
 <uui-ref-node-data-type
   name="Newsletter Signup"
   detail="Signup for newsletter">
-  <uui-icon slot="icon" name="newspaper-alt"></uui-icon>
+  <uui-icon slot="icon" name="colorpicker"></uui-icon>
   <uui-action-bar slot="actions">
     <uui-button label="Remove">Remove</uui-button>
   </uui-action-bar>

--- a/packages/uui-ref-node-member/lib/uui-ref-node-member.story.ts
+++ b/packages/uui-ref-node-member/lib/uui-ref-node-member.story.ts
@@ -48,16 +48,18 @@ AAAOverview.parameters = {
 };
 
 export const CustomIcon: Story = () => html`
-  <div style="max-width: 420px;">
-    <uui-ref-node-member
-      name="Arnold Vitz"
-      group-name="Visitor, Registered-Member">
-      <uui-icon slot="icon" name="crown-alt"></uui-icon>
-      <uui-action-bar slot="actions">
-        <uui-button label="Remove">Remove</uui-button>
-      </uui-action-bar>
-    </uui-ref-node-member>
-  </div>
+  <uui-icon-registry-essential>
+    <div style="max-width: 420px;">
+      <uui-ref-node-member
+        name="Arnold Vitz"
+        group-name="Visitor, Registered-Member">
+        <uui-icon slot="icon" name="colorpicker"></uui-icon>
+        <uui-action-bar slot="actions">
+          <uui-button label="Remove">Remove</uui-button>
+        </uui-action-bar>
+      </uui-ref-node-member>
+    </div>
+  </uui-icon-registry-essential>
 `;
 
 CustomIcon.parameters = {
@@ -67,7 +69,7 @@ CustomIcon.parameters = {
 <uui-ref-node-member
   name="Arnold Vitz"
   group-name="Visitor, Registered-Member">
-  <uui-icon slot="icon" name="crown-alt"></uui-icon>
+  <uui-icon slot="icon" name="colorpicker"></uui-icon>
   <uui-action-bar slot="actions">
     <uui-button label="Remove">Remove</uui-button>
   </uui-action-bar>

--- a/packages/uui-ref-node-package/lib/uui-ref-node-package.story.ts
+++ b/packages/uui-ref-node-package/lib/uui-ref-node-package.story.ts
@@ -7,6 +7,11 @@ export default {
   id: 'uui-ref-node-package',
   title: 'Displays/References/Package',
   component: 'uui-ref-node-package',
+  decorators: [
+    (Story: any) => html`
+      <uui-icon-registry-essential>${Story()}</uui-icon-registry-essential>
+    `,
+  ],
 };
 
 const Template: Story = props => html`

--- a/packages/uui-ref-node-user/lib/uui-ref-node-user.story.ts
+++ b/packages/uui-ref-node-user/lib/uui-ref-node-user.story.ts
@@ -48,14 +48,16 @@ AAAOverview.parameters = {
 };
 
 export const CustomIcon: Story = () => html`
-  <div style="max-width: 420px;">
-    <uui-ref-node-member name="Arnold Edits" group-name="Editor, Translator">
-      <uui-icon slot="icon" name="crown-alt"></uui-icon>
-      <uui-action-bar slot="actions">
-        <uui-button label="Remove">Remove</uui-button>
-      </uui-action-bar>
-    </uui-ref-node-member>
-  </div>
+  <uui-icon-registry-essential>
+    <div style="max-width: 420px;">
+      <uui-ref-node-member name="Arnold Edits" group-name="Editor, Translator">
+        <uui-icon slot="icon" name="colorpicker"></uui-icon>
+        <uui-action-bar slot="actions">
+          <uui-button label="Remove">Remove</uui-button>
+        </uui-action-bar>
+      </uui-ref-node-member>
+    </div>
+  </uui-icon-registry-essential>
 `;
 
 CustomIcon.parameters = {
@@ -65,7 +67,7 @@ CustomIcon.parameters = {
 <uui-ref-node-data-type
   name="Arnold Edits"
   group-name="Editor, Translator">
-  <uui-icon slot="icon" name="crown-alt"></uui-icon>
+  <uui-icon slot="icon" name="colorpicker"></uui-icon>
   <uui-action-bar slot="actions">
     <uui-button label="Remove">Remove</uui-button>
   </uui-action-bar>

--- a/packages/uui-ref-node/lib/uui-ref-node.story.ts
+++ b/packages/uui-ref-node/lib/uui-ref-node.story.ts
@@ -58,14 +58,16 @@ AAAOverview.parameters = {
 };
 
 export const CustomIcon: Story = () => html`
-  <uui-ref-node-data-type
-    name="Rabbit Suit Product Page"
-    detail="path/to/nowhere">
-    <uui-icon slot="icon" name="shopping-basket-alt"></uui-icon>
-    <uui-action-bar slot="actions">
-      <uui-button label="Remove">Remove</uui-button>
-    </uui-action-bar>
-  </uui-ref-node-data-type>
+  <essential-icon-registry>
+    <uui-ref-node-data-type
+      name="Rabbit Suit Product Page"
+      detail="path/to/nowhere">
+      <uui-icon slot="icon" name="colorpicker"></uui-icon>
+      <uui-action-bar slot="actions">
+        <uui-button label="Remove">Remove</uui-button>
+      </uui-action-bar>
+    </uui-ref-node-data-type>
+  </essential-icon-registry>
 `;
 
 CustomIcon.parameters = {
@@ -75,7 +77,7 @@ CustomIcon.parameters = {
 <uui-ref-node
   name="Rabbit Suit Product Page"
   detail="path/to/nowhere">
-  <uui-icon slot="icon" name="shopping-basket-alt"></uui-icon>
+  <uui-icon slot="icon" name="colorpicker"></uui-icon>
   <uui-action-bar slot="actions">
     <uui-button label="Remove">Remove</uui-button>
   </uui-action-bar>

--- a/packages/uui-ref-node/lib/uui-ref-node.story.ts
+++ b/packages/uui-ref-node/lib/uui-ref-node.story.ts
@@ -10,7 +10,11 @@ export default {
   title: 'Displays/References/Node',
   component: 'uui-ref-node',
   decorators: [
-    (Story: any) => html`<div style="max-width: 420px;">${Story()}</div>`,
+    (Story: any) => html`
+      <uui-icon-registry-essential>
+        <div style="max-width: 420px;">${Story()}</div>
+      </uui-icon-registry-essential>
+    `,
   ],
 };
 
@@ -24,7 +28,8 @@ const Template: Story = props => html`
     ?disabled=${props.disabled}>
     <uui-tag size="s" slot="tag" color="positive">Published</uui-tag>
     <uui-action-bar slot="actions"
-      ><uui-button><uui-icon name="delete"></uui-icon></uui-button
+      ><uui-button label="delete"
+        ><uui-icon name="delete"></uui-icon></uui-button
     ></uui-action-bar>
   </uui-ref-node>
 `;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes issue: #297
Adds missing `essential-icon-registry` wrapper for ref nodes stories.
Also renames some custom icons

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
