### PR TITLE
fix focus issues on uui-combobox

### DIFF
--- a/packages/uui-combobox/lib/uui-combobox.element.ts
+++ b/packages/uui-combobox/lib/uui-combobox.element.ts
@@ -58,17 +58,6 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
         box-shadow: var(--uui-shadow-depth-3);
       }
 
-      #clear-button {
-        pointer-events: none;
-        opacity: 0;
-        transition: opacity 120ms;
-      }
-
-      #clear-button.--show {
-        pointer-events: auto;
-        opacity: 1;
-      }
-
       #caret {
         margin-right: var(--uui-size-3, 9px);
         display: flex;
@@ -250,6 +239,8 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
     // Reset input(search-input) value:
     this._input.value = this._displayValue;
 
+    this._input.focus();
+
     this.dispatchEvent(new UUIComboboxEvent(UUIComboboxEvent.SEARCH));
     this.dispatchEvent(new UUIComboboxEvent(UUIComboboxEvent.CHANGE));
   };
@@ -278,22 +269,23 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
   };
 
   private _renderClearButton = () => {
-    return html`<uui-button
-      id="clear-button"
-      class=${this.value || this.search ? '--show' : ''}
-      @click=${this._onClear}
-      @keydown=${this._onClear}
-      label="clear"
-      slot="append"
-      compact
-      style="height: 100%;">
-      <uui-icon name="remove" .fallback=${iconRemove.strings[0]}></uui-icon>
-    </uui-button>`;
+    return this.value || this.search
+      ? html`<uui-button
+          id="clear-button"
+          @click=${this._onClear}
+          @keydown=${this._onClear}
+          label="clear"
+          slot="append"
+          compact
+          style="height: 100%;">
+          <uui-icon name="remove" .fallback=${iconRemove.strings[0]}></uui-icon>
+        </uui-button>`
+      : '';
   };
 
   private _renderDropdown = () => {
     return html`<div id="dropdown" slot="popover">
-      <uui-scroll-container id="scroll-container">
+      <uui-scroll-container tabindex="-1" id="scroll-container">
         <slot></slot>
       </uui-scroll-container>
     </div>`;

--- a/packages/uui-combobox/lib/uui-combobox.element.ts
+++ b/packages/uui-combobox/lib/uui-combobox.element.ts
@@ -171,9 +171,10 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
   }
 
   private _onMouseDown = () => requestAnimationFrame(() => this._input.focus());
+
   private _onBlur = () =>
     requestAnimationFrame(() => {
-      if (document.activeElement !== this) {
+      if (!this.shadowRoot?.activeElement) {
         this._onClose();
       }
     });

--- a/packages/uui-scroll-container/lib/uui-scroll-container.element.ts
+++ b/packages/uui-scroll-container/lib/uui-scroll-container.element.ts
@@ -36,7 +36,9 @@ export class UUIScrollContainerElement extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.setAttribute('tabindex', '0');
+    if (!this.hasAttribute('tabindex')) {
+      this.setAttribute('tabindex', '0');
+    }
   }
   render() {
     return html`<slot></slot>`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a bug that would close the combobox when clicking an option but not select it.
Fixes focus issues on the combobox. Now you can only focus the input and the clear button (only when visible).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
