### PR TITLE
docs: uui-button-inline-create was documented twice because of a typo

### DIFF
--- a/packages/uui-button-inline-create/lib/uui-button-inline-create.element.ts
+++ b/packages/uui-button-inline-create/lib/uui-button-inline-create.element.ts
@@ -10,7 +10,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { UUIButtonInlineCreateEvent } from './UUIButtonInlineCreateEvent';
 
 /**
- *  @element uui-inline-create-button
+ *  @element uui-button-inline-create
  *  @description - Special button for creating new elements
  *  @attr {Boolean} vertical - display vertical version of the button
  *  @fires click on user click


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Unfortunately because of this error, the button was created twice in the custom-elements.json file

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

