### PR TITLE
Fix typo in Button Looks and Colors Story

### DIFF
--- a/packages/uui-button/lib/uui-button.story.ts
+++ b/packages/uui-button/lib/uui-button.story.ts
@@ -305,7 +305,7 @@ WithIcon.parameters = {
   docs: {
     source: {
       code: `
-      <uui-button look="primary" label="A11Y proper abel"><uui-icon name="alert"></uui-icon>Button Label</uui-button>`,
+      <uui-button look="primary" label="A11Y proper label"><uui-icon name="alert"></uui-icon>Button Label</uui-button>`,
     },
   },
 };


### PR DESCRIPTION
This is just typo fix in the label on an example in the Button Looks and Colors story.