### PR TITLE
[Input lock] Bump opacity a bit, to pass color contrast accessibility check

### DIFF
--- a/packages/uui-input-lock/lib/uui-input-lock.element.ts
+++ b/packages/uui-input-lock/lib/uui-input-lock.element.ts
@@ -27,7 +27,7 @@ export class UUIInputLockElement extends UUIInputElement {
 
       :host([locked]) #input {
         cursor: not-allowed;
-        opacity: 0.5;
+        opacity: 0.55;
       }
     `,
   ];


### PR DESCRIPTION
I noticed that Input lock violated an accessibility check regarding color contrast. So I bumped the opacity of the input a bit, to make it pass.

```
Element has insufficient color contrast of 3.89 (foreground color: #7a7a7b, background color: #f3f3f5, font size: 11.3pt (15px), font weight: normal). Expected contrast ratio of 4.5:1
```

