### PR TITLE
fix: Add cd to installation instruction before npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ This project uses nodejs, so you should install `nodejs` as the package manager 
 
 ```sh
 git clone https://github.com/umbraco/Umbraco.UI.git
+cd .\Umbraco.UI\
 npm install
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The installation instruction was missing the choose directory command after cloning the git repo.

<!--- Describe the changes in detail -->

I added one line of command code.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
