### PR TITLE
uui-input change aling-items to stretch

### DIFF
--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -44,7 +44,7 @@ export class UUIInputElement extends FormControlMixin(
       :host {
         position: relative;
         display: inline-flex;
-        align-items: center;
+        align-items: stretch;
         height: var(--uui-size-11);
         text-align: left;
         box-sizing: border-box;


### PR DESCRIPTION
This PR changes `uui-input` host element `align-items` css property from `center` to `stretch`.
It fixes the problem of white frame apearing around the autocompleted input. 

You can fix this also by giving the embeded input a `height: 100%` .
To my best knowledge this is not a breakig change but the above approach might be safer. 

Fixes #361 



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)


<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
