### PR TITLE
Case insensitivity when using combobox-avatar

### DIFF
--- a/packages/uui-combobox/lib/uui-combobox.story.ts
+++ b/packages/uui-combobox/lib/uui-combobox.story.ts
@@ -63,7 +63,7 @@ const avatars = [
 ];
 
 const basicFilter = (options: string[], search: string) =>
-  options.filter(option => option.includes(search));
+  options.filter(option => option.toLowerCase().includes(search.toLowerCase()));
 
 const renderAvatar = (option: any) => html` <uui-combobox-list-option
   .displayValue=${option.name}
@@ -218,7 +218,9 @@ Avatars.args = {
   options: avatars,
   renderMod: (avatar: any) => renderAvatar(avatar),
   filter: (options: any[], search: string) =>
-    options.filter(option => option.name.includes(search)),
+    options.filter(option =>
+      option.name.toLowerCase().includes(search.toLowerCase())
+    ),
 };
 
 export const CountrySelect: Story = props => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe the changes in detail -->
When searching in the combo box for both avatar and simple ignore case.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Resolution to [Issue 357](https://github.com/umbraco/Umbraco.UI/issues/357)

## How to test?

Load Storybook, open Combobox Avatar and search for **r2**. You will then see R2-D2 in the results.

## Screenshots (if appropriate)

![combobox search](https://user-images.githubusercontent.com/5808078/199124272-0e400682-ee4e-4079-84e4-b26de1e0190c.gif)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
