### PR TITLE
uui-input-file => Only show add button when multiple or no file selected

### DIFF
--- a/packages/uui-input-file/lib/uui-input-file.element.ts
+++ b/packages/uui-input-file/lib/uui-input-file.element.ts
@@ -1,6 +1,6 @@
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { property, query, state } from 'lit/decorators.js';
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { UUIFileDropzoneElement } from '@umbraco-ui/uui-file-dropzone/lib';
 import { FormControlMixin } from '@umbraco-ui/uui-base/lib/mixins';
 import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
@@ -265,12 +265,13 @@ export class UUIInputFileElement extends FormControlMixin(LitElement) {
         label="Drop files here"></uui-file-dropzone>
       <div id="files">
         ${this._renderFiles()}
-        ${this._files.length === 0 || this.multiple ?
-          html`<uui-button
-            @click=${this._handleClick}
-            id="add-button"
-            look="placeholder"
-            label="Add"></uui-button>` : nothing}
+        ${this._files.length === 0 || this.multiple
+          ? html`<uui-button
+              @click=${this._handleClick}
+              id="add-button"
+              look="placeholder"
+              label="Add"></uui-button>`
+          : nothing}
       </div>
     `;
   }

--- a/packages/uui-input-file/lib/uui-input-file.element.ts
+++ b/packages/uui-input-file/lib/uui-input-file.element.ts
@@ -265,11 +265,12 @@ export class UUIInputFileElement extends FormControlMixin(LitElement) {
         label="Drop files here"></uui-file-dropzone>
       <div id="files">
         ${this._renderFiles()}
-        <uui-button
-          @click=${this._handleClick}
-          id="add-button"
-          look="placeholder"
-          label="Add"></uui-button>
+        ${this._files.length === 0 || this.multiple ?
+          html`<uui-button
+            @click=${this._handleClick}
+            id="add-button"
+            look="placeholder"
+            label="Add"></uui-button>` : nothing}
       </div>
     `;
   }


### PR DESCRIPTION
## Description

Change updates uui-input-file to only show the add button only when multiple is true, or when no files are selected (single-file mode).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

The picker works correctly in it's current shape (ie single mode only allows one file, multiple allows many), I'm just not sure the UI makes sense - continuing to display the Add button after selecting a file in single mode is potentially confusing, even though the button will replace the existing selection. 

Alternatively could consider changing the button text when a file is selected in single-mode (ie `Replace` or `Change selection` or something similar)

I won't lose a minute of sleep if the current implementation is preferred.

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
