### PR TITLE
uui-card-media does not render images correctly

### DIFF
--- a/packages/uui-card-media/lib/uui-card-media.element.ts
+++ b/packages/uui-card-media/lib/uui-card-media.element.ts
@@ -135,23 +135,23 @@ export class UUICardMediaElement extends UUICardElement {
     demandCustomElement(this, 'uui-symbol-file');
   }
 
-  private queryPreviews(e: any): void {
+  private queryPreviews(e: Event): void {
     this.hasPreview =
-      (e.path[0] as HTMLSlotElement).assignedElements({ flatten: true })
-        .length > 0;
+      (e.composedPath()[0] as HTMLSlotElement).assignedElements({
+        flatten: true,
+      }).length > 0;
   }
 
   protected renderMedia() {
-    if (this.hasPreview === false) {
-      if (this.fileExt === '') {
-        return html`<uui-symbol-folder id="folder-symbol"></uui-symbol-folder>`;
-      } else {
-        return html`<uui-symbol-file
-          id="file-symbol"
-          type="${this.fileExt}"></uui-symbol-file>`;
-      }
+    if (this.hasPreview === true) return '';
+
+    if (this.fileExt === '') {
+      return html`<uui-symbol-folder id="folder-symbol"></uui-symbol-folder>`;
     }
-    return '';
+
+    return html`<uui-symbol-file
+      id="file-symbol"
+      type="${this.fileExt}"></uui-symbol-file>`;
   }
 
   public render() {


### PR DESCRIPTION
## Description

Rendering bug caused by invalid property accessor, which was missed due to `any` typing. We were attempting to access `e.path` where `e` was `any` (but was actually a generic `Event`), if we had typed correctly we'd have caught the issue, and not attempted to access `path` and used the correct `compiledPath()`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

Fixes #401 

## How to test?

Build, verify media card renders correctly (and no more console error):

Before:
![image](https://user-images.githubusercontent.com/3248070/213960535-188db169-0c17-443d-9e38-8f05dcaf3ee7.png)
After:
![image](https://user-images.githubusercontent.com/3248070/213960517-0d1541e7-1f12-4233-a5bc-c5bad3f03818.png)

