### PR TITLE
fix: Add whitespace when appending/prepending icon in uui-input

### DIFF
--- a/packages/uui-icon/lib/uui-icon.element.ts
+++ b/packages/uui-icon/lib/uui-icon.element.ts
@@ -26,6 +26,14 @@ export class UUIIconElement extends LitElement {
       ::slotted(svg) {
         fill: var(--uui-icon-color, currentColor);
       }
+
+      :host-context(div[slot='prepend']) {
+        margin-left: var(--uui-size-2, 6px);
+      }
+
+      :host-context(div[slot='append']) {
+        margin-right: var(--uui-size-2, 6px);
+      }
     `,
   ];
 

--- a/packages/uui-input/lib/uui-input.story.ts
+++ b/packages/uui-input/lib/uui-input.story.ts
@@ -167,7 +167,7 @@ export const AppendIcon: Story = props =>
     .value=${props.value}>
     <div
       slot="append"
-      style="background:#f3f3f3; margin-left:var(--uui-size-2, 6px)">
+      style="background:#f3f3f3; padding-left:var(--uui-size-2, 6px)">
       <uui-icon-registry-essential>
         <uui-icon name="delete"></uui-icon>
       </uui-icon-registry-essential>

--- a/packages/uui-input/lib/uui-input.story.ts
+++ b/packages/uui-input/lib/uui-input.story.ts
@@ -138,6 +138,42 @@ export const PrependAndAppend: Story = props =>
     </uui-input>
   `;
 
+export const PrependIcon: Story = props =>
+  html` <uui-input
+    .disabled=${props.disabled}
+    .readonly=${props.readonly}
+    .error=${props.error}
+    .label=${props.label}
+    .type=${props.type}
+    .name=${props.name}
+    .placeholder=${props.placeholder}
+    .value=${props.value}>
+    <div slot="prepend">
+      <uui-icon-registry-essential>
+        <uui-icon name="search"></uui-icon>
+      </uui-icon-registry-essential>
+    </div>
+  </uui-input>`;
+
+export const AppendIcon: Story = props =>
+  html` <uui-input
+    .disabled=${props.disabled}
+    .readonly=${props.readonly}
+    .error=${props.error}
+    .label=${props.label}
+    .type=${props.type}
+    .name=${props.name}
+    .placeholder=${props.placeholder}
+    .value=${props.value}>
+    <div
+      slot="append"
+      style="background:#f3f3f3; margin-left:var(--uui-size-2, 6px)">
+      <uui-icon-registry-essential>
+        <uui-icon name="delete"></uui-icon>
+      </uui-icon-registry-essential>
+    </div>
+  </uui-input>`;
+
 export const MultipleInputs: Story = props =>
   html`
     <uui-input


### PR DESCRIPTION
## Description

When rendering an icon in the prepend or append slot in the uui-input component, the icon was lacking whitespace:
![image](https://user-images.githubusercontent.com/3248070/215386535-47bb7ecc-6895-4940-a2c6-ea23d74517f8.png)

Changes here add whitespace (Append example has inline background color and left-padding):

![image](https://user-images.githubusercontent.com/3248070/215386643-179822be-012b-433b-b199-93fd205e6a6f.png)

![image](https://user-images.githubusercontent.com/3248070/215386667-929ee6bd-759d-49ca-b6b5-3c196ad232ce.png)

For simplicity, the icon has a left-margin when prepended, and a right margin when appended, to move it off the input edge in both cases. Additional styling would need to depend on the context (ie an appended icon with a background color would need additional padding on the left side to separate the input text), which would need to be managed in the specific implementation.

Vertical alignment relies on the icon not being slotted directly, but using an enclosing element (this is the existing behaviour before this change):

```
<div
  slot="append"
  style="background:#f3f3f3; padding-left:var(--uui-size-2, 6px)">
  <uui-icon-registry-essential>
    <uui-icon name="delete"></uui-icon>
  </uui-icon-registry-essential>
</div>
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
