### PR TITLE
bugfix: radio-group initial value not working

### DIFF
--- a/packages/uui-radio/lib/uui-radio-group.element.ts
+++ b/packages/uui-radio/lib/uui-radio-group.element.ts
@@ -59,14 +59,7 @@ export class UUIRadioGroupElement extends FormControlMixin(LitElement) {
     if (newValue === null || newValue === '') {
       this._makeFirstEnabledFocusable();
     }
-    this._radioElements.forEach((el, index) => {
-      if (el.value === newValue) {
-        el.checked = true;
-        this._selected = index;
-      } else {
-        el.checked = false;
-      }
-    });
+    this._updateRadioElementsCheckedState(newValue);
   }
 
   private _selected: number | null = null;
@@ -75,6 +68,11 @@ export class UUIRadioGroupElement extends FormControlMixin(LitElement) {
     super();
     this.addEventListener('keydown', this._onKeydown);
     this.addEventListener('keypress', this._onKeypress);
+
+    // Wait for the radio elements to be added to the dom before updating the checked state.
+    this.updateComplete.then(() => {
+      this._updateRadioElementsCheckedState(this.value);
+    });
   }
 
   connectedCallback() {
@@ -110,6 +108,19 @@ export class UUIRadioGroupElement extends FormControlMixin(LitElement) {
   private _radioElements: UUIRadioElement[] = [];
   private _setNameOnRadios(name: string) {
     this._radioElements?.forEach(el => (el.name = name));
+  }
+
+  private _updateRadioElementsCheckedState(
+    newValue: FormData | FormDataEntryValue
+  ) {
+    this._radioElements.forEach((el, index) => {
+      if (el.value === newValue) {
+        el.checked = true;
+        this._selected = index;
+      } else {
+        el.checked = false;
+      }
+    });
   }
 
   private _setDisableOnRadios(value: boolean) {

--- a/packages/uui-radio/lib/uui-radio-group.test.ts
+++ b/packages/uui-radio/lib/uui-radio-group.test.ts
@@ -252,3 +252,25 @@ describe('UuiRadioGroup when one radio child radio is checked', () => {
     expect(formData.get(`${element.name}`)).to.be.equal('Value 2');
   });
 });
+
+describe('UuiRadioGroup with start value', () => {
+  let radioGroup: UUIRadioGroupElement;
+  let radios: Array<UUIRadioElement>;
+  beforeEach(async () => {
+    radioGroup = await fixture(
+      html` <uui-radio-group value="2">
+        <uui-radio value="1">one</uui-radio>
+        <uui-radio value="2">two</uui-radio>
+        <uui-radio value="3">three</uui-radio>
+        <uui-radio value="4">four</uui-radio>
+      </uui-radio-group>`
+    );
+    radios = Array.from(radioGroup.querySelectorAll('uui-radio'));
+  });
+  it('propagates the start value to the correct child radio', async () => {
+    expect(radios[0]).to.not.have.attribute('checked');
+    expect(radios[1]).to.have.attribute('checked');
+    expect(radios[2]).to.not.have.attribute('checked');
+    expect(radios[3]).to.not.have.attribute('checked');
+  });
+});

--- a/packages/uui-radio/lib/uui-radio.story.ts
+++ b/packages/uui-radio/lib/uui-radio.story.ts
@@ -187,7 +187,7 @@ export const GroupWithStartValue: Story = props => html`
     <uui-radio value="1">one</uui-radio>
     <uui-radio value="2">two</uui-radio>
     <uui-radio value="3">three</uui-radio>
-    <uui-radio value="4">fou2r</uui-radio>
+    <uui-radio value="4">four</uui-radio>
   </uui-radio-group>
 `;
 GroupWithStartValue.args = {

--- a/packages/uui-radio/lib/uui-radio.story.ts
+++ b/packages/uui-radio/lib/uui-radio.story.ts
@@ -181,3 +181,18 @@ export const DisabledGroup: Story = props => html`
 DisabledGroup.args = {
   disabled: true,
 };
+
+export const GroupWithStartValue: Story = props => html`
+  <uui-radio-group value=${props.value}>
+    <uui-radio value="1">one</uui-radio>
+    <uui-radio value="2">two</uui-radio>
+    <uui-radio value="3">three</uui-radio>
+    <uui-radio value="4">fou2r</uui-radio>
+  </uui-radio-group>
+`;
+GroupWithStartValue.args = {
+  value: '3',
+};
+GroupWithStartValue.parameters = {
+  controls: { exclude: ['label', 'checked', 'disabled', 'name'] },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed an issue where having a start/initial value on the radio-group would throw errors and not propagate to it's child radio buttons.
Added test for start value on radio-group

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
