### PR TITLE
add disabled property to uui-combobox

### DIFF
--- a/packages/uui-combobox/lib/uui-combobox.element.ts
+++ b/packages/uui-combobox/lib/uui-combobox.element.ts
@@ -67,6 +67,10 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
         margin-top: -1px;
       }
 
+      :host([disabled]) #caret {
+        fill: var(--uui-color-disabled-contrast);
+      }
+
       #phone-wrapper {
         position: fixed;
         inset: 0;
@@ -141,6 +145,15 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
    */
   @property({ type: String })
   public closeLabel = 'Close';
+
+  /**
+   * Disables the uui-combobox.
+   * @type {boolean}
+   * @attr
+   * @default false
+   */
+  @property({ type: Boolean, reflect: true })
+  disabled = false;
 
   @query('#combobox-input')
   private _input!: HTMLInputElement;
@@ -315,11 +328,12 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
       type="text"
       .value=${this._displayValue}
       autocomplete="off"
+      .disabled=${this.disabled}
       @click=${this._open}
       @input=${this._onInput}
       @keydown=${this._onKeyDown}>
       <slot name="input-prepend" slot="prepend"></slot>
-      ${this._renderClearButton()} ${this._renderCaret()}
+      ${this.disabled ? '' : this._renderClearButton()} ${this._renderCaret()}
       <slot name="input-append" slot="append"></slot>
     </uui-input>`;
   };

--- a/packages/uui-combobox/lib/uui-combobox.story.ts
+++ b/packages/uui-combobox/lib/uui-combobox.story.ts
@@ -14,6 +14,8 @@ export default {
   component: 'uui-combobox',
   args: {
     search: '',
+    disabled: false,
+    readonly: false,
   },
   parameters: {
     docs: {
@@ -99,6 +101,8 @@ const Template: Story = props => {
     displayValueMod,
     valueMod,
     renderMod,
+    disabled,
+    value,
   } = props;
 
   const handleSearch = (e: any) => {
@@ -114,7 +118,9 @@ const Template: Story = props => {
   return html`<uui-combobox
       @change=${handleSelect}
       @search=${handleSearch}
-      style="width: 250px">
+      style="width: 250px"
+      .disabled=${disabled}
+      .value=${value}>
       <uui-combobox-list>
         ${repeat(filter(options, search), (option: any, index: number) =>
           renderMod
@@ -145,6 +151,36 @@ AAAOverview.parameters = {
     source: {
       code: `
 <uui-combobox style="width: 250px">
+  <uui-combobox-list>
+    <uui-combobox-list-option style="padding: 8px">
+      apple
+    </uui-combobox-list-option>
+    <uui-combobox-list-option style="padding: 8px">
+      orange
+    </uui-combobox-list-option>
+    <uui-combobox-list-option style="padding: 8px">
+      lemon
+    </uui-combobox-list-option>
+    ...
+  </uui-combobox-list>
+</uui-combobox>
+  `,
+    },
+  },
+};
+
+export const Disabled: Story = Template.bind({});
+Disabled.args = {
+  options: fruits,
+  filter: basicFilter,
+  disabled: true,
+  value: 'banana',
+};
+Disabled.parameters = {
+  docs: {
+    source: {
+      code: `
+<uui-combobox style="width: 250px" disabled>
   <uui-combobox-list>
     <uui-combobox-list-option style="padding: 8px">
       apple

--- a/packages/uui-combobox/lib/uui-combobox.test.ts
+++ b/packages/uui-combobox/lib/uui-combobox.test.ts
@@ -62,6 +62,9 @@ describe('UUIComboboxElement', () => {
     it('has a value property', () => {
       expect(element).to.have.property('value');
     });
+    it('has a disabled property', () => {
+      expect(element).to.have.property('disabled');
+    });
   });
 
   describe('template', () => {

--- a/packages/uui/tsconfig.json
+++ b/packages/uui/tsconfig.json
@@ -71,10 +71,10 @@
       "path": "../uui-color-slider"
     },
     {
-      "path": "../uui-color-swatches"
+      "path": "../uui-color-swatch"
     },
     {
-      "path": "../uui-color-swatch"
+      "path": "../uui-color-swatches"
     },
     {
       "path": "../uui-combobox"


### PR DESCRIPTION

## Description

This PR adds a `disabled` property to `uui-combobox` element. The value it passed down to the `uui-input` rendered by the component, therefore fixes #412 . 

It does not add readonly property becasue native `select` element does not have one. 

Although PR fixex a big it actually introduces new feature, the ability to disable the element, it it therefore tagged as new feature, not as a bug fix. 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
