### PR TITLE
scroll container is now auto scroll and has an enforce scroll option

### DIFF
--- a/packages/uui-scroll-container/lib/uui-scroll-container.element.ts
+++ b/packages/uui-scroll-container/lib/uui-scroll-container.element.ts
@@ -1,10 +1,13 @@
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { css, html, LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
 
 /**
  *  @element uui-scroll-container
  *  @slot - for content
+ *  @attribute enforce-scroll - forces the scrollbar to appear
  *  @description - Component for displaying a larger amount of .
+ *
  */
 @defineElement('uui-scroll-container')
 export class UUIScrollContainerElement extends LitElement {
@@ -15,6 +18,10 @@ export class UUIScrollContainerElement extends LitElement {
         scrollbar-width: thin;
         scrollbar-color: var(--uui-color-disabled-contrast)
           var(--uui-color-surface);
+        overflow-y: auto;
+      }
+
+      :host([enforce-scroll]) {
         overflow-y: scroll;
       }
 
@@ -33,6 +40,13 @@ export class UUIScrollContainerElement extends LitElement {
       }
     `,
   ];
+
+  /**
+   * @type {boolean}
+   * @attr forces the scrollbar to appear
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'enforce-scroll' })
+  enforceScroll = false;
 
   connectedCallback() {
     super.connectedCallback();

--- a/packages/uui-scroll-container/lib/uui-scroll-container.story.ts
+++ b/packages/uui-scroll-container/lib/uui-scroll-container.story.ts
@@ -146,7 +146,7 @@ export const NotEnoughContent: Story = props =>
   `;
 
 NotEnoughContent.args = {
-  slot: 'Very little text, no Scrollbar appearing',
+  slot: 'Very little text, no scrollbar appearing',
 };
 
 export const VeryWideContent: Story = props =>
@@ -159,4 +159,15 @@ export const VeryWideContent: Story = props =>
 VeryWideContent.args = {
   slot: html` line is way toooo long
     WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY<br />`,
+};
+
+export const EnforceScroll: Story = props =>
+  html`
+    <uui-scroll-container style="width:400px; height:400px;" enforce-scroll>
+      ${props.slot}
+    </uui-scroll-container>
+  `;
+
+EnforceScroll.args = {
+  slot: 'Very little text, but has the enforce-scroll property\n(See with a dark background)',
 };

--- a/packages/uui-scroll-container/lib/uui-scroll-container.test.ts
+++ b/packages/uui-scroll-container/lib/uui-scroll-container.test.ts
@@ -1,4 +1,4 @@
-import { html, fixture, expect } from '@open-wc/testing';
+import { html, fixture, expect, elementUpdated } from '@open-wc/testing';
 import { UUIScrollContainerElement } from './uui-scroll-container.element';
 import '.';
 
@@ -113,5 +113,25 @@ describe('UUIScrollContainerElement with very little content', () => {
   it('cannot scroll sideways', async () => {
     element.scrollLeft = 42;
     await expect(element.scrollLeft).to.be.equal(0);
+  });
+});
+
+describe('properties', () => {
+  let element: UUIScrollContainerElement;
+  beforeEach(async () => {
+    element = await fixture(
+      html`<uui-scroll-container style="width:200px; height:200px;">
+        Hello tests
+      </uui-scroll-container>`
+    );
+  });
+
+  it('has a enforce-scroll property', () => {
+    expect(element).to.have.property('enforceScroll');
+  });
+  it('enforceScroll property set', async () => {
+    element.enforceScroll = true;
+    await elementUpdated(element);
+    expect(element.enforceScroll).to.be.true;
   });
 });


### PR DESCRIPTION
uui-scroll-container is now auto on overflow - the scrollbar will only appear if needed.

- Added option to use enforce-scroll on the element to make the scroll always appear.
- Updated test file
- Added an extra story about enforce scroll.


