### PR TITLE
Fix so uui-ref-list border fits within the given space.

### DIFF
--- a/packages/uui-ref-list/lib/uui-ref-list.element.ts
+++ b/packages/uui-ref-list/lib/uui-ref-list.element.ts
@@ -19,7 +19,8 @@ export class UUIRefListElement extends LitElement {
         content: '';
         position: absolute;
         top: -1px;
-        width: 100%;
+        left: 0;
+        right: 0;
         border-top: 1px solid var(--uui-color-border);
       }
     `,


### PR DESCRIPTION
make the border between items(before element) fit within the width of the list.

![image](https://user-images.githubusercontent.com/6791648/228232306-aea7808e-ee86-42f8-b559-00e2ffb03539.png)
