### PR TITLE
uui-button slot documentation

### DIFF
--- a/packages/uui-base/lib/mixins/LabelMixin.ts
+++ b/packages/uui-base/lib/mixins/LabelMixin.ts
@@ -4,6 +4,12 @@ import { property, state } from 'lit/decorators.js';
 type Constructor<T = {}> = new (...args: any[]) => T;
 
 export declare class LabelMixinInterface {
+  /**
+   * Label to be used for aria-label and potentially as visual label for some components
+   * @type {string}
+   * @prop
+   * @attr
+   */
   label: string;
   protected renderLabel(): TemplateResult;
 }

--- a/packages/uui-base/lib/mixins/LabelMixin.ts
+++ b/packages/uui-base/lib/mixins/LabelMixin.ts
@@ -21,8 +21,6 @@ export const LabelMixin = <T extends Constructor<LitElement>>(
 ) => {
   /**
    * Label mixin class containing the label functionality.
-   *
-   * @slot - Override the default label
    */
   class LabelMixinClass extends superClass {
     /**

--- a/packages/uui-button/lib/uui-button.element.ts
+++ b/packages/uui-button/lib/uui-button.element.ts
@@ -21,6 +21,8 @@ export type UUIButtonType = 'submit' | 'button' | 'reset';
 /**
  *  @element uui-button
  *  @fires {UUIButtonEvent} click - fires when the element is clicked
+ *  @slot - for default content
+ *  @slot label - for label content
  *  @slot extra - for extra
  *  @description - All-round button
  *  @cssprop --uui-button-height - overwrite the button height

--- a/packages/uui-button/lib/uui-button.element.ts
+++ b/packages/uui-button/lib/uui-button.element.ts
@@ -24,7 +24,7 @@ export type UUIButtonType = 'submit' | 'button' | 'reset';
  *  @slot - for default content
  *  @slot label - for label content
  *  @slot extra - for extra
- *  @description - All-round button
+ *  @description - All-around button
  *  @cssprop --uui-button-height - overwrite the button height
  *  @cssprop --uui-button-border-width - overwrite the border width
  *  @cssprop --uui-button-border-radius - overwrite the border radius


### PR DESCRIPTION
### Changes

* Add documentation for the slots of uui-button.
* Remove the inherited 'default' slot documentation from LabelMixin, since each component that uses LabelMixin knows best how to describe what it's doing with label slot, which most of them renames anyway, and some may not even call the `renderLabel` method.