### PR TITLE
fix: uui-file-dropzone does not export its event classes

### DIFF
--- a/packages/uui-file-dropzone/lib/index.ts
+++ b/packages/uui-file-dropzone/lib/index.ts
@@ -1,1 +1,2 @@
 export * from './uui-file-dropzone.element';
+export * from './UUIFileDropzoneEvents';


### PR DESCRIPTION
It is not possible to import the event called `UUIFileDropzoneEvent` from anywhere.