### PR TITLE
fix: uui-file-dropzone does not follow the inferred interface for dropped files

### DIFF
--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
@@ -224,6 +224,7 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
   }
 
   private _onDragEnter(e: DragEvent) {
+    // TODO: make visual indication of wether the file is acceptable or not. If not we need to make a more negative/disabled visual look.
     this._dropzone.classList.add('hover');
     e.preventDefault();
   }

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
@@ -4,7 +4,6 @@ import { query, property } from 'lit/decorators.js';
 import { UUIFileDropzoneEvent } from './UUIFileDropzoneEvents';
 import { LabelMixin } from '@umbraco-ui/uui-base/lib/mixins';
 import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
-import '@umbraco-ui/uui-button/lib/';
 
 /**
  * @element uui-file-dropzone

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
@@ -114,11 +114,11 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
       queue.push(dataTransferItemList[i].webkitGetAsEntry());
     }
 
+    const acceptList: string[] = [];
+    const wildcards: string[] = [];
+
     // if the accept filer is set
     if (this.accept) {
-      const acceptList: string[] = [];
-      const wildcards: string[] = [];
-
       // Create the arrays defined above
       this.accept.split(',').forEach(item => {
         if (item.includes('*')) {
@@ -127,6 +127,7 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
           acceptList.push(item.trim().toLowerCase());
         }
       });
+    }
 
       while (queue.length > 0) {
         const entry: FileSystemFileEntry = queue.shift()!;
@@ -189,27 +190,22 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
     }
   }
 
-  private async _getFile(fileEntry: FileSystemFileEntry): Promise<File> {
-    return await new Promise<File>((resolve, reject) =>
-      fileEntry.file(resolve, reject)
-    );
-  }
+  private _isAccepted(acceptList: string[], wildcards: string[], file: File) {
+    if (acceptList.length === 0 && wildcards.length === 0) {
+      return true;
+    }
 
-  private async _isAccepted(
-    acceptList: string[],
-    wildcards: string[],
-    entry: FileSystemFileEntry
-  ) {
-    const file = await this._getFile(entry);
     const fileType = file.type.toLowerCase();
     const fileExtension = '.' + file.name.split('.')[1].toLowerCase();
 
     if (acceptList.includes(fileExtension)) {
       return true;
     }
+
     if (acceptList.includes(fileType)) {
       return true;
     }
+
     if (wildcards.some(wildcard => fileType.startsWith(wildcard))) {
       return true;
     }

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
@@ -134,7 +134,7 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
       if (entry.kind === 'file') {
         const file = entry.getAsFile();
         if (!file) continue;
-        if (this._isAccepted(acceptList, wildcards, file)) {
+        if (await this._isAccepted(acceptList, wildcards, file)) {
           fileEntries.push(file);
         }
       } else if (entry.kind === 'directory') {

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
@@ -111,10 +111,7 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
   ): Promise<File[]> {
     const fileEntries: File[] = [];
     // Use BFS to traverse entire directory/file structure
-    const queue = [];
-    for (let i = 0; i < dataTransferItemList.length; i++) {
-      queue.push(dataTransferItemList[i].webkitGetAsEntry());
-    }
+    const queue = [...dataTransferItemList];
 
     const acceptList: string[] = [];
     const wildcards: string[] = [];
@@ -141,6 +138,7 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
           fileEntries.push(file);
         }
       } else if (entry.kind === 'directory') {
+        if ('webkitGetAsEntry' in entry === false) continue;
         const directory = entry.webkitGetAsEntry()! as FileSystemDirectoryEntry;
         queue.push(
           ...(await this._readAllDirectoryEntries(directory.createReader()))
@@ -209,7 +207,7 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
     if (items) {
       let result = await this._getAllFileEntries(items);
 
-      if (this.multiple === false && result.length > 0) {
+      if (this.multiple === false && result.length) {
         result = [result[0]];
       }
 

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
@@ -134,7 +134,7 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
       if (entry.kind === 'file') {
         const file = entry.getAsFile();
         if (!file) continue;
-        if (await this._isAccepted(acceptList, wildcards, file)) {
+        if (this._isAccepted(acceptList, wildcards, file)) {
           fileEntries.push(file);
         }
       } else if (entry.kind === 'directory') {

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
@@ -4,6 +4,7 @@ import { query, property } from 'lit/decorators.js';
 import { UUIFileDropzoneEvent } from './UUIFileDropzoneEvents';
 import { LabelMixin } from '@umbraco-ui/uui-base/lib/mixins';
 import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
+import '@umbraco-ui/uui-button/lib/';
 
 /**
  * @element uui-file-dropzone
@@ -257,6 +258,7 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
           ?multiple=${this.multiple}
           @change=${this._onFileInputChange}
           aria-label="${this.label}" />
+        <slot></slot>
       </div>
     `;
   }

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.story.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.story.ts
@@ -1,10 +1,10 @@
-import { StoryFn } from '@storybook/web-components';
+import { Meta, StoryFn } from '@storybook/web-components';
 import { html } from 'lit';
-import { UUIFileDropzoneEvent } from './UUIFileDropzoneEvents';
-import { UUIFileDropzoneElement } from './uui-file-dropzone.element';
+import type { UUIFileDropzoneEvent } from './UUIFileDropzoneEvents';
+import type { UUIFileDropzoneElement } from './uui-file-dropzone.element';
 
 import '@umbraco-ui/uui-symbol-file-dropzone/lib';
-import '.';
+import './uui-file-dropzone.element';
 
 export default {
   id: 'uui-file-dropzone',
@@ -17,7 +17,7 @@ export default {
         </div>
         ${Story()}`,
   ],
-};
+} as Meta<UUIFileDropzoneElement>;
 
 const handleFileChange = (e: UUIFileDropzoneEvent) =>
   console.log('event.detail: ', e.detail);
@@ -33,14 +33,17 @@ export const AAAOverview: StoryFn = props => {
 };
 AAAOverview.storyName = 'Overview';
 
-export const Multiple: StoryFn = () =>
+export const Multiple: StoryFn = props =>
   html`
     <uui-file-dropzone
-      multiple
+      .multiple=${props.multiple}
       @file-change=${handleFileChange}
       label="Drop files here"></uui-file-dropzone>
   `;
 
+Multiple.args = {
+  multiple: true,
+};
 Multiple.parameters = {
   docs: {
     description: {
@@ -50,14 +53,17 @@ Multiple.parameters = {
   },
 };
 
-export const Accept: StoryFn = () =>
+export const Accept: StoryFn = props =>
   html`
     <uui-file-dropzone
-      accept="image/*"
+      .accept=${props.accept}
       @file-change=${handleFileChange}
       label="Drop files here"></uui-file-dropzone>
   `;
 
+Accept.args = {
+  accept: 'image/*',
+};
 Accept.parameters = {
   docs: {
     description: {

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.story.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.story.ts
@@ -5,6 +5,7 @@ import type { UUIFileDropzoneElement } from './uui-file-dropzone.element';
 
 import '@umbraco-ui/uui-symbol-file-dropzone/lib';
 import './uui-file-dropzone.element';
+import '@umbraco-ui/uui-button/lib/';
 
 export default {
   id: 'uui-file-dropzone',


### PR DESCRIPTION
# Description

The event UUIFileDropzoneEvent stipulates that the "detail" object is of type `File[]`. However, when debugging at runtime you could see that the files were of type `FileEntry`, which is an older API. This was due to the fact that the partly supported Webkit method `webkitGetAsEntry()` was being used for dropped files (DataTransferItem's).

The remediation is to use the `getAsFile()` method instead and also to make sure, that `webkitGetAsEntry()` which is still useful for directories is being hidden away behind a guard statement.

In order to actually use the `File` interface instead, we also have to avoid pushing directory entries themselves to the event detail object but instead, only scan them and let their own entries enter the queue to be parsed (if supported in the browser).

Lastly, this PR aims to update the code a bit to avoid repeating the business logic to check for acceptance of files.