### PR TITLE
fix: keydown events are prevented from bubbling in uui-table-cell

### DIFF
--- a/packages/uui-base/lib/mixins/SelectableMixin.ts
+++ b/packages/uui-base/lib/mixins/SelectableMixin.ts
@@ -66,7 +66,6 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
     private handleSelectKeydown(e: KeyboardEvent) {
       if (e.composedPath().indexOf(this.selectableTarget) !== -1) {
         if (e.key !== ' ' && e.key !== 'Enter') return;
-        e.preventDefault();
         this._toggleSelect();
       }
     }

--- a/packages/uui-table/lib/uui-table-cell.story.ts
+++ b/packages/uui-table/lib/uui-table-cell.story.ts
@@ -1,18 +1,21 @@
-import '.';
-
-import { Story } from '@storybook/web-components';
+import type { Meta, StoryFn } from '@storybook/web-components';
 import { html } from 'lit';
 
-import { UUITableCellElement } from './uui-table-cell.element';
+import type { UUITableCellElement } from './uui-table-cell.element';
 
-export default {
+import '@umbraco-ui/uui-input/lib';
+import './uui-table-cell.element';
+
+const meta: Meta<typeof UUITableCellElement> = {
   title: 'Layout/Table/Table Cell',
   component: 'uui-table-cell',
   id: 'uui-table-cell',
 };
 
-export const AAAOverview: Story<UUITableCellElement> = props =>
-  html`
+export default meta;
+
+const Template: StoryFn<UUITableCellElement> = props => {
+  return html`
     <uui-table
       aria-label="Random Umbraco Words"
       aria-describedby="table-description">
@@ -33,11 +36,20 @@ export const AAAOverview: Story<UUITableCellElement> = props =>
           ?disable-child-interaction=${props.disableChildInteraction}
           ?no-padding=${props.noPadding}
           ?clip-text=${props.clipText}>
+          <uui-input placeholder="Type your own thing"></uui-input>
+        </uui-table-cell>
+        <uui-table-cell
+          ?disable-child-interaction=${props.disableChildInteraction}
+          ?no-padding=${props.noPadding}
+          ?clip-text=${props.clipText}>
           ${props.slot}
         </uui-table-cell>
       </uui-table-row>
     </uui-table>
   `;
+};
+
+export const AAAOverview = Template.bind({});
 AAAOverview.storyName = 'Overview';
 AAAOverview.args = {
   slot: 'Very very very Very very very Very very very Very very very Very very very long sentence',

--- a/packages/uui-table/lib/uui-table-row.story.ts
+++ b/packages/uui-table/lib/uui-table-row.story.ts
@@ -1,28 +1,45 @@
-import '.';
-
-import { Story } from '@storybook/web-components';
+import { Meta, StoryFn } from '@storybook/web-components';
 import { html } from 'lit';
 
 import { ArrayOfUmbracoWords } from '../../../storyhelpers/UmbracoWordGenerator';
+import type { UUITableRowElement } from './uui-table-row.element';
 
-export default {
+import '@umbraco-ui/uui-input/lib';
+import './uui-table-row.element';
+
+const meta: Meta<typeof UUITableRowElement> = {
   title: 'Layout/Table/Table Row',
   component: 'uui-table-row',
   id: 'uui-table-row',
 };
 
-export const AAAOverview: Story = () =>
-  html`
-    <uui-table
-      aria-label="Random Umbraco Words"
-      aria-describedby="table-description">
-      <uui-table-row>
-        ${ArrayOfUmbracoWords(3).map(
+export default meta;
+
+const Template: StoryFn<UUITableRowElement> = props => {
+  return html`
+    <uui-table>
+      <uui-table-row
+        ?selectable=${props.selectable}
+        ?selectOnly=${props.selectOnly}>
+        ${ArrayOfUmbracoWords(5).map(
+          el => html`<uui-table-cell>${el}</uui-table-cell>`
+        )}
+      </uui-table-row>
+      <uui-table-row
+        ?selectable=${props.selectable}
+        ?selectOnly=${props.selectOnly}>
+        <uui-table-cell>
+          <uui-input placeholder="Type your own thing"></uui-input>
+        </uui-table-cell>
+        ${ArrayOfUmbracoWords(5).map(
           el => html`<uui-table-cell>${el}</uui-table-cell>`
         )}
       </uui-table-row>
     </uui-table>
   `;
+};
+
+export const AAAOverview = Template.bind({});
 AAAOverview.storyName = 'Overview';
 
 AAAOverview.parameters = {
@@ -43,24 +60,10 @@ AAAOverview.parameters = {
   },
 };
 
-export const SelectableRows: Story = () =>
-  html`
-    <div style="width: 100%;">
-      <uui-table>
-        <uui-table-row selectable>
-          ${ArrayOfUmbracoWords(5).map(
-            el => html`<uui-table-cell>${el}</uui-table-cell>`
-          )}
-        </uui-table-row>
-        <uui-table-row selectable>
-          ${ArrayOfUmbracoWords(5).map(
-            el => html`<uui-table-cell>${el}</uui-table-cell>`
-          )}
-        </uui-table-row>
-      </uui-table>
-    </div>
-  `;
-
+export const SelectableRows = Template.bind({});
+SelectableRows.args = {
+  selectable: true,
+};
 SelectableRows.parameters = {
   docs: {
     source: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #437

If an input field is placed inside a table cell, you cannot type spaces in the field due to the fact that the surrounding uui-table-row is listening on "keydown" events and preventing them from bubbling.

This PR aims to make all events in the SelectableMixin act the same way so that we do not interfer with native events.

However, one caveat is that placing a uui-input inside a uui-table-row that is selectable will **select** that row when you click inside the field. There does not seem to be a way to prevent this, since we can only check on the `composedPath()` to detect which element you clicked on due to the generics of how the SelectableMixin works. Nothing bad happens when you do this, but you need to be aware of this caveat.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?

1. There is a story set up to test this scenario in for uui-table-row and uui-table-cell

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
