### PR TITLE
Make color slider disabled state consistent with disabled color area

### DIFF
--- a/packages/uui-color-area/lib/uui-color-area.element.ts
+++ b/packages/uui-color-area/lib/uui-color-area.element.ts
@@ -24,11 +24,17 @@ export class UUIColorAreaElement extends LitElement {
         width: 280px;
         height: 200px;
       }
+
+      :host([disabled]) {
+        cursor: not-allowed;
+      }
+
       :host([disabled]) .color-area {
         user-select: none;
-        cursor: not-allowed;
+        pointer-events: none;
         opacity: 0.55;
       }
+
       .color-area {
         position: relative;
         height: 100%;

--- a/packages/uui-color-area/lib/uui-color-area.element.ts
+++ b/packages/uui-color-area/lib/uui-color-area.element.ts
@@ -24,8 +24,8 @@ export class UUIColorAreaElement extends LitElement {
         width: 280px;
         height: 200px;
       }
-      :host([disabled]) {
-        pointer-events: none;
+      :host([disabled]) .color-area {
+        user-select: none;
         cursor: not-allowed;
         opacity: 0.55;
       }

--- a/packages/uui-color-slider/lib/uui-color-slider.element.ts
+++ b/packages/uui-color-slider/lib/uui-color-slider.element.ts
@@ -95,9 +95,13 @@ export class UUIColorSliderElement extends LabelMixin('label', LitElement) {
         height: 300px;
       }
 
+      :host([disabled]) {
+        cursor: not-allowed;
+      }
+
       :host([disabled]) #color-slider {
         user-select: none;
-        cursor: not-allowed;
+        pointer-events: none;
         opacity: 0.55;
       }
 

--- a/packages/uui-color-slider/lib/uui-color-slider.element.ts
+++ b/packages/uui-color-slider/lib/uui-color-slider.element.ts
@@ -98,6 +98,7 @@ export class UUIColorSliderElement extends LabelMixin('label', LitElement) {
       :host([disabled]) #color-slider {
         user-select: none;
         cursor: not-allowed;
+        opacity: 0.55;
       }
 
       #color-slider__handle {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When `<uui-color-area>` has `disabled` attribute it has some opacity and `not-allowed` cursor.
The `<uui-color-slider>` did not, so it wasn't clear the slider was disabled besides it wasn't possible to drag handle.

This PR makes this more consistent.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
