### PR TITLE
docs: storybook color props

### DIFF
--- a/packages/uui-color-area/lib/uui-color-area.story.ts
+++ b/packages/uui-color-area/lib/uui-color-area.story.ts
@@ -1,11 +1,10 @@
-import '.';
-
-import { Meta, Story } from '@storybook/web-components';
-import { html } from 'lit-html';
-import { UUIColorAreaElement } from './uui-color-area.element';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import type { UUIColorAreaElement } from './uui-color-area.element';
 import readme from '../README.md?raw';
 
-export default {
+import './uui-color-area.element';
+
+const meta: Meta<UUIColorAreaElement> = {
   id: 'uui-color-area',
   title: 'Inputs/Color/Color Area',
   component: 'uui-color-area',
@@ -25,11 +24,10 @@ export default {
       handles: ['change'],
     },
   },
-} as Meta<UUIColorAreaElement>;
+};
 
-const Template: Story<UUIColorAreaElement> = props =>
-  html`<uui-color-area
-    .value=${props.value}
-    .disabled=${props.disabled}></uui-color-area>`;
+export default meta;
 
-export const Overview = Template.bind({});
+type Story = StoryObj<UUIColorAreaElement>;
+
+export const Overview: Story = {};

--- a/packages/uui-color-picker/lib/uui-color-picker.story.ts
+++ b/packages/uui-color-picker/lib/uui-color-picker.story.ts
@@ -8,12 +8,11 @@ import '@umbraco-ui/uui-button-group/lib';
 import '@umbraco-ui/uui-icon/lib';
 import '@umbraco-ui/uui-popover/lib';
 
-import '.';
-
-import { Meta, StoryFn } from '@storybook/web-components';
-import { html } from 'lit-html';
-import { UUIColorPickerElement } from './uui-color-picker.element';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import type { UUIColorPickerElement } from './uui-color-picker.element';
+import './uui-color-picker.element';
 import readme from '../README.md?raw';
+import { html } from 'lit';
 
 const defaultSwatches = [
   '#d0021b',
@@ -34,7 +33,7 @@ const defaultSwatches = [
   '#fff',
 ];
 
-export default {
+const meta: Meta<UUIColorPickerElement> = {
   id: 'uui-color-picker',
   title: 'Inputs/Color/Color Picker',
   component: 'uui-color-picker',
@@ -51,69 +50,65 @@ export default {
       handles: ['change'],
     },
   },
-} as Meta<UUIColorPickerElement>;
-
-const Template: StoryFn<UUIColorPickerElement> = props => html`
-  <uui-color-picker
-    .inline=${props.inline}
-    .value=${props.value}
-    .format=${props.format}
-    .disabled=${props.disabled}
-    .swatches=${props.swatches}
-    .size=${props.size}
-    .opacity=${props.opacity}
-    .uppercase=${props.uppercase}
-    .name=${props.name}
-    .noFormatToggle=${props.noFormatToggle}>
-  </uui-color-picker>
-`;
-
-export const AAAOverview = Template.bind({});
-AAAOverview.storyName = 'Overview';
-
-export const Inline = Template.bind({});
-Inline.args = {
-  inline: true,
 };
-Inline.parameters = {
-  docs: {
-    source: {
-      code: `<uui-color-picker inline="true"></uui-color-picker>`,
+
+export default meta;
+
+type Story = StoryObj<UUIColorPickerElement>;
+
+export const Overview: Story = {};
+
+export const Inline: Story = {
+  args: {
+    inline: true,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<uui-color-picker inline="true"></uui-color-picker>`,
+      },
     },
   },
 };
 
-export const WithOpacity = Template.bind({});
-WithOpacity.args = {
-  opacity: true,
-};
-WithOpacity.parameters = {
-  docs: {
-    source: {
-      code: `<uui-color-picker opacity></uui-color-picker>`,
+export const WithOpacity: Story = {
+  args: {
+    opacity: true,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<uui-color-picker opacity></uui-color-picker>`,
+      },
     },
   },
 };
 
 const formats = ['hex', 'rgb', 'hsl'];
 
-export const Formats: StoryFn = () => html`
-  <h4>Formats</h4>
-  ${formats.map(
-    format =>
-      html`
-        <h5>${format}</h5>
-        <uui-color-picker .format=${format as any} value="blue">
-        </uui-color-picker>
-      `
-  )}
-`;
-Formats.args = { format: 'hex' };
-Formats.parameters = {
-  docs: {
-    source: {
-      code: `
+export const Formats: Story = {
+  args: {
+    format: 'hex',
+    value: 'blue',
+  },
+  decorators: [
+    (story, props) => html`<div style="display: flex; flex-direction: column;">
+      <h5>${props.args.format}</h5>
+      ${story()}
+    </div> `,
+  ],
+  argTypes: {
+    format: {
+      options: formats,
+      control: { type: 'select' },
+    },
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
         <uui-color-picker format="hex"></uui-color-picker>`,
+      },
     },
   },
 };

--- a/packages/uui-color-slider/lib/uui-color-slider.story.ts
+++ b/packages/uui-color-slider/lib/uui-color-slider.story.ts
@@ -1,11 +1,10 @@
-import '.';
-
-import { Meta, Story } from '@storybook/web-components';
-import { html } from 'lit-html';
-import { UUIColorSliderElement } from './uui-color-slider.element';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import type { UUIColorSliderElement } from './uui-color-slider.element';
 import readme from '../README.md?raw';
 
-export default {
+import './uui-color-slider.element';
+
+const meta: Meta<UUIColorSliderElement> = {
   id: 'uui-color-slider',
   title: 'Inputs/Color/Color Slider',
   component: 'uui-color-slider',
@@ -30,52 +29,45 @@ export default {
       },
     },
   },
-} as Meta<UUIColorSliderElement>;
-
-const Template: Story<UUIColorSliderElement> = props => html`
-  <uui-color-slider
-    .vertical=${props.vertical}
-    .min=${props.min}
-    .max=${props.max}
-    .precision=${props.precision}
-    .label=${props.label}
-    .disabled=${props.disabled}
-    .value=${props.value}
-    .type=${props.type}
-    .color=${props.color}>
-  </uui-color-slider>
-`;
-
-export const AAAOverview = Template.bind({});
-AAAOverview.storyName = 'Overview';
-
-export const Disabled = Template.bind({});
-Disabled.args = {
-  disabled: true,
-  value: 50,
 };
-Disabled.parameters = {
-  docs: {
-    source: {
-      code: `<uui-color-slider label="Slider label" disabled="true"></uui-color-slider>`,
+
+export default meta;
+
+type Story = StoryObj<UUIColorSliderElement>;
+
+export const Overview: Story = {};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    value: 50,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<uui-color-slider label="Slider label" disabled="true"></uui-color-slider>`,
+      },
     },
   },
 };
 
-export const Opacity = Template.bind({});
-Opacity.args = {
-  type: 'opacity',
-  color: '#417505',
+export const Opacity: Story = {
+  args: {
+    type: 'opacity',
+    color: '#417505',
+  },
 };
 
-export const Vertical = Template.bind({});
-Vertical.args = {
-  vertical: true,
+export const Vertical: Story = {
+  args: {
+    vertical: true,
+  },
 };
 
-export const VerticalOpacity = Template.bind({});
-VerticalOpacity.args = {
-  type: 'opacity',
-  vertical: true,
-  color: '#417505',
+export const VerticalOpacity: Story = {
+  args: {
+    type: 'opacity',
+    vertical: true,
+    color: '#417505',
+  },
 };

--- a/packages/uui-color-swatch/lib/uui-color-swatch.element.ts
+++ b/packages/uui-color-swatch/lib/uui-color-swatch.element.ts
@@ -191,13 +191,13 @@ export class UUIColorSwatchElement extends LabelMixin(
   ];
 
   private _value: string | undefined = '';
+
   /**
    * Value of the swatch. Should be a valid hex, hexa, rgb, rgba, hsl or hsla string. Should fulfill this [css spec](https://www.w3.org/TR/css-color-4/#color-type). If not provided element will look at its text content.
-   * @type { string }
+   *
    * @attr
-   * @default ""
    */
-  @property({ type: String })
+  @property()
   get value(): string {
     return this._value ? this._value : this.textContent?.trim() || '';
   }
@@ -210,9 +210,8 @@ export class UUIColorSwatchElement extends LabelMixin(
 
   /**
    * Determines if the options is disabled. If true the option can't be selected
-   * @type { boolean }
+   *
    * @attr
-   * @default false
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
@@ -220,6 +219,7 @@ export class UUIColorSwatchElement extends LabelMixin(
   /**
    * When true shows element label below the color checkbox
    *
+   * @attr
    * @memberof UUIColorSwatchElement
    */
   @property({ type: Boolean, attribute: 'show-label' })
@@ -227,7 +227,6 @@ export class UUIColorSwatchElement extends LabelMixin(
   /**
    * Colord object instance based on the value provided to the element. If the value is not a valid color, it falls back to black (like Amy Winehouse). For more information about Colord, see [Colord](https://omgovich.github.io/colord/)
    *
-   * @type {(Colord | null)}
    * @memberof UUIColorSwatchElement
    */
   get color(): Colord | null {

--- a/packages/uui-color-swatch/lib/uui-color-swatch.story.ts
+++ b/packages/uui-color-swatch/lib/uui-color-swatch.story.ts
@@ -1,15 +1,21 @@
-import '.';
-
-import { Story } from '@storybook/web-components';
-import { html } from 'lit-html';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import type { UUIColorSwatchElement } from './uui-color-swatch.element';
 import readme from '../README.md?raw';
 
-const value = '#d0021b';
+import './uui-color-swatch.element';
 
-export default {
+const meta: Meta<UUIColorSwatchElement> = {
   id: 'uui-color-swatch',
   title: 'Inputs/Color/Color Swatch',
   component: 'uui-color-swatch',
+  args: {
+    value: '#d0021b',
+  },
+  argTypes: {
+    value: { control: 'color' },
+    color: { control: false },
+    isLight: { control: false },
+  },
   parameters: {
     readme: {
       markdown: readme,
@@ -17,59 +23,86 @@ export default {
   },
 };
 
-export const Overview: Story = () =>
-  html`<uui-color-swatch .value=${value} label=${value}></uui-color-swatch>`;
+export default meta;
 
-export const Selectable: Story = () =>
-  html`<uui-color-swatch
-    selectable
-    .value=${value}
-    label=${value}></uui-color-swatch>`;
+type Story = StoryObj<UUIColorSwatchElement>;
 
-export const InvalidValue: Story = () =>
-  html`<uui-color-swatch
-    .value=${'askjhsdiusyhdiudhg'}
-    label="Invalid color"></uui-color-swatch>`;
+export const Overview: Story = {};
 
-export const InvalidValue2: Story = () =>
-  html`<uui-color-swatch
-    .value=${'askjhsdiusyhdiudhg'}
-    label="Invalid color"
-    show-label></uui-color-swatch>`;
-
-export const Disabled: Story = () =>
-  html`<uui-color-swatch selectable disabled label=${value}
-    >${value}</uui-color-swatch
-  >`;
-
-export const DisabledSelected: Story = () =>
-  html`<uui-color-swatch selectable disabled selected label=${value}
-    >${value}</uui-color-swatch
-  >`;
-
-export const WithLabel: Story = () =>
-  html`<uui-color-swatch
-    selectable
-    show-label
-    label=${"This is the most beautiful color I've ever seen"}
-    >${value}</uui-color-swatch
-  >`;
-
-const Template: Story = props => html`
-  <uui-color-swatch
-    selectable
-    .value=${props.value}
-    label=${value}></uui-color-swatch>
-`;
-
-export const Transparent = Template.bind({});
-Transparent.args = {
-  value: 'rgba(53, 68, 177, 0.5)',
+export const Selectable: Story = {
+  args: {
+    selectable: true,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<uui-color-swatch selectable></uui-color-slider>`,
+      },
+    },
+  },
 };
-Transparent.parameters = {
-  docs: {
-    source: {
-      code: `<uui-color-swatch color="rgba(53, 68, 177, 0.5)"></uui-color-slider>`,
+
+export const InvalidValue: Story = {
+  args: {
+    value: 'askjhsdiusyhdiudhg',
+    label: 'Invalid color',
+    showLabel: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    selectable: true,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<uui-color-swatch disabled></uui-color-slider>`,
+      },
+    },
+  },
+};
+
+export const DisabledSelected: Story = {
+  args: {
+    disabled: true,
+    selectable: true,
+    selected: true,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<uui-color-swatch disabled selectable selected></uui-color-slider>`,
+      },
+    },
+  },
+};
+
+export const WithLabel: Story = {
+  args: {
+    label: "This is the most beautiful color I've ever seen",
+    showLabel: true,
+    selectable: true,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<uui-color-swatch label="This is the most beautiful color I've ever seen" show-label="true"></uui-color-slider>`,
+      },
+    },
+  },
+};
+
+export const Transparent: Story = {
+  args: {
+    value: 'rgba(53, 68, 177, 0.5)',
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<uui-color-swatch color="rgba(53, 68, 177, 0.5)"></uui-color-slider>`,
+      },
     },
   },
 };

--- a/packages/uui-color-swatches/lib/uui-color-swatches.element.ts
+++ b/packages/uui-color-swatches/lib/uui-color-swatches.element.ts
@@ -29,9 +29,8 @@ export class UUIColorSwatchesElement extends LabelMixin('label', LitElement) {
 
   /**
    * Value of selected option.
-   * @type { string }
+   *
    * @attr
-   * @default ""
    */
   @property()
   value = '';

--- a/packages/uui-color-swatches/lib/uui-color-swatches.story.ts
+++ b/packages/uui-color-swatches/lib/uui-color-swatches.story.ts
@@ -77,7 +77,7 @@ type Story = StoryObj<UUIColorSwatchesElement>;
 
 const Template: Story = {
   render: (args: any) => html`
-    <uui-color-swatches ?value=${args.value} label="my color pallette">
+    <uui-color-swatches .value=${args.value} label="my color pallette">
       ${repeat(args.swatchesColor, (swatch: any) => {
         const label = typeof swatch === 'string' ? swatch : swatch.label;
         const value = typeof swatch === 'string' ? swatch : swatch.value;

--- a/packages/uui-color-swatches/lib/uui-color-swatches.story.ts
+++ b/packages/uui-color-swatches/lib/uui-color-swatches.story.ts
@@ -1,10 +1,12 @@
-import '.';
-
-import { Story } from '@storybook/web-components';
-import { html } from 'lit-html';
+import { html } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import type { UUIColorSwatchesElement } from './uui-color-swatches.element';
 import readme from '../README.md?raw';
 
-const swatches = [
+import './uui-color-swatches.element';
+
+const swatchesColor = [
   { label: 'Blood Orange', value: '#d0021b' },
   { label: 'Marigold', value: '#f5a623' },
   { label: 'Yellow Sun', value: '#f8e71c' },
@@ -41,10 +43,22 @@ const swatchesTransparent = [
   'rgba(255, 255, 255, 0.5)',
 ];
 
-export default {
+const meta: Meta<typeof UUIColorSwatchesElement> = {
   id: 'uui-color-swatches',
   title: 'Inputs/Color/Color Swatches',
   component: 'uui-color-swatches',
+  args: {
+    swatchesColor,
+    showLabel: false,
+  } as any,
+  argTypes: {
+    swatchesColor: {
+      control: { type: 'array' },
+    },
+    showLabel: {
+      control: { type: 'boolean' },
+    },
+  } as any,
   parameters: {
     readme: {
       markdown: readme,
@@ -57,40 +71,41 @@ export default {
   },
 };
 
-const Template: Story = props => html`
-  <uui-color-swatches .value=${props.value ?? ''} label="my color pallette">
-    ${props.swatches.map((swatch: any) => {
-      const label = typeof swatch === 'string' ? swatch : swatch.label;
-      const value = typeof swatch === 'string' ? swatch : swatch.value;
+export default meta;
 
-      return html`<uui-color-swatch
-        label="${label}"
-        .showLabel=${props.showLabel}
-        >${value}</uui-color-swatch
-      >`;
-    })}
-  </uui-color-swatches>
-`;
+type Story = StoryObj<UUIColorSwatchesElement>;
 
-export const Overview: Story = Template.bind({});
-Overview.args = {
-  swatches,
-  showLabel: false,
+const Template: Story = {
+  render: (args: any) => html`
+    <uui-color-swatches ?value=${args.value} label="my color pallette">
+      ${repeat(args.swatchesColor, (swatch: any) => {
+        const label = typeof swatch === 'string' ? swatch : swatch.label;
+        const value = typeof swatch === 'string' ? swatch : swatch.value;
+
+        return html`<uui-color-swatch
+          label="${label}"
+          .showLabel=${args.showLabel}>
+          ${value}
+        </uui-color-swatch>`;
+      })}
+    </uui-color-swatches>
+  `,
 };
 
-export const WithLabels: Story = Template.bind({});
-WithLabels.args = {
-  swatches: swatches,
-  showLabel: true,
+export const Overview: Story = {
+  ...Template,
 };
 
-export const Preselected: Story = Template.bind({});
-Preselected.args = {
-  swatches: swatches,
-  value: '#7ed321',
+export const Preselected: Story = {
+  ...Template,
+  args: {
+    value: '#7ed321',
+  },
 };
 
-export const Transparent = Template.bind({});
-Transparent.args = {
-  swatches: swatchesTransparent,
+export const Transparent: Story = {
+  ...Template,
+  args: {
+    swatchesColor: swatchesTransparent,
+  } as any,
 };


### PR DESCRIPTION
# Description

Fixes #499 

Not all properties are mapped through Storybook for the uui-color-* components. This aims to rectify that by changing to the new StoryObj (CSF3) format, which automaps properties.

This PR also fixes a small error with web-component-analyzer output for the `@type` jsdoc parameter.