### PR TITLE
Modal backdrop z-index

### DIFF
--- a/packages/uui-modal/lib/uui-modal.element.ts
+++ b/packages/uui-modal/lib/uui-modal.element.ts
@@ -105,6 +105,7 @@ export class UUIModalElement extends LitElement {
         pointer-events: none;
         opacity: 1;
         transition: opacity var(--uui-modal-transition-duration, 250ms);
+        z-index: 1;
       }
       :host([index='0']) dialog::after {
         opacity: 0;


### PR DESCRIPTION
Adds z-index to the modal backdrop to prevent elements from overlaying.

Examples:
Currently:
<img width="1298" alt="image" src="https://github.com/umbraco/Umbraco.UI/assets/26099018/7b57718c-e87e-4f4a-9810-0c406f84b2a2">

Fix:
<img width="1298" alt="image" src="https://github.com/umbraco/Umbraco.UI/assets/26099018/5a2435bb-a806-4cec-b4b7-7f3819304e79">
