### PR TITLE
docs(storybook): add icon slot example for uui-tab element (#356)

### DIFF
--- a/packages/uui-tabs/lib/uui-tabs.story.ts
+++ b/packages/uui-tabs/lib/uui-tabs.story.ts
@@ -25,18 +25,9 @@ export default {
     docs: {
       source: {
         code: html`<uui-tab-group>
-          <uui-tab>
-            <uui-icon slot="icon" name="document"></uui-icon>
-            Content
-          </uui-tab>
-          <uui-tab active>
-            <uui-icon slot="icon" name="settings"></uui-icon>
-            Packages
-          </uui-tab>
-          <uui-tab>
-            <uui-icon slot="icon" name="picture"></uui-icon>
-            Media
-          </uui-tab>
+          <uui-tab>Tab A</uui-tab>
+          <uui-tab>Tab B</uui-tab>
+          <uui-tab>Tab C</uui-tab>
         </uui-tab-group>`.strings,
       },
     },

--- a/packages/uui-tabs/lib/uui-tabs.story.ts
+++ b/packages/uui-tabs/lib/uui-tabs.story.ts
@@ -112,3 +112,24 @@ export const WithIcons: Story = props => html`
     </uui-tab-group>
   </uui-icon-registry-essential>
 `;
+WithIcons.parameters = {
+  docs: {
+    source: {
+      code: `
+      <uui-tab-group>
+        <uui-tab>
+          <uui-icon slot="icon" name="document"></uui-icon>
+          Content
+        </uui-tab>
+        <uui-tab active>
+          <uui-icon slot="icon" name="settings"></uui-icon>
+          Packages
+        </uui-tab>
+        <uui-tab>
+          <uui-icon slot="icon" name="picture"></uui-icon>
+          Media
+        </uui-tab>
+      </uui-tab-group>`,
+    },
+  },
+};

--- a/packages/uui-tabs/lib/uui-tabs.story.ts
+++ b/packages/uui-tabs/lib/uui-tabs.story.ts
@@ -25,9 +25,18 @@ export default {
     docs: {
       source: {
         code: html`<uui-tab-group>
-          <uui-tab>Tab A</uui-tab>
-          <uui-tab>Tab B</uui-tab>
-          <uui-tab>Tab C</uui-tab>
+          <uui-tab>
+            <uui-icon slot="icon" name="document"></uui-icon>
+            Content
+          </uui-tab>
+          <uui-tab active>
+            <uui-icon slot="icon" name="settings"></uui-icon>
+            Packages
+          </uui-tab>
+          <uui-tab>
+            <uui-icon slot="icon" name="picture"></uui-icon>
+            Media
+          </uui-tab>
         </uui-tab-group>`.strings,
       },
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I've improved the `uui-tabs` Storybook documentation.
See issue #356 
<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and context
I saw [Julia's issue](https://github.com/umbraco/Umbraco.UI/issues/356) and decided that it was a quick fix. I did actually also stumble upon the issue myself, when searching Storybook for documentation regarding `uui-tabs`.

This fix makes it easier to copy the correct code.
<!--- Why is this change required? What problem does it solve? -->

## How to test?
Run the `npm run storybook` command and navigate to the **Tabs** section.
`Direct relative path is _/?path=/docs/buttons-tabs--docs#with-icons_

## Screenshots (if appropriate)
![uui-tabs-with-icons](https://github.com/umbraco/Umbraco.UI/assets/52758027/004a0156-f004-49e7-a885-b11531662314)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
