### PR TITLE
#443 fix : Button text color hover not taking effect

### DIFF
--- a/packages/uui-button/lib/uui-button.element.ts
+++ b/packages/uui-button/lib/uui-button.element.ts
@@ -171,9 +171,9 @@ export class UUIButtonElement extends FormControlMixin(
       }
 
       /* edge case for default color */
-      :host(:not([color]):not([look='primary'])) #button,
-      :host([color='']:not([look='primary'])) #button,
-      :host([color='default']:not([look='primary'])) #button {
+      :host(:not([color]):not([look='primary'])),
+      :host([color='']:not([look='primary'])),
+      :host([color='default']:not([look='primary'])) {
         --uui-button-contrast-hover: var(--uui-color-default-emphasis);
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

bug: https://github.com/umbraco/Umbraco.UI/issues/443

Change to the CSS styling so that the "--uui-button-contrast-hover" color is shown on button hover.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

Go to page: 
/docs/buttons-button--docs

add a color to the "--uui-button-contrast-hover"  field

hover over button to see if text color changes.

## Screenshots (if appropriate)

before fix:
![button-before](https://github.com/umbraco/Umbraco.UI/assets/82643045/eb5f1cb0-f669-435b-b9e0-ec40706fa2a2)


after fix:
![button-after](https://github.com/umbraco/Umbraco.UI/assets/82643045/032f8266-69b6-4e9a-8271-34327b5a628b)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
