### PR TITLE
uui-box: add a property to control the headline variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 ## editors
 /.idea
-/.vscode
-!/.vscode/settings.json
 
 ## system files
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ## editors
 /.idea
 /.vscode
+!/.vscode/settings.json
 
 ## system files
 .DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["combobox", "Umbraco"]
+}

--- a/packages/uui-base/lib/types/InterfaceHeading.ts
+++ b/packages/uui-base/lib/types/InterfaceHeading.ts
@@ -1,11 +1,10 @@
 export const InterfaceHeadingValues: Readonly<InterfaceHeading[]> = [
-    "h1",
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6"
-  ] as const;
-  
-  export type InterfaceHeading = "" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
-  
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+] as const;
+
+export type InterfaceHeading = '' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';

--- a/packages/uui-base/lib/types/InterfaceHeading.ts
+++ b/packages/uui-base/lib/types/InterfaceHeading.ts
@@ -1,0 +1,11 @@
+export const InterfaceHeadingValues: Readonly<InterfaceHeading[]> = [
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6"
+  ] as const;
+  
+  export type InterfaceHeading = "" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
+  

--- a/packages/uui-base/lib/types/index.ts
+++ b/packages/uui-base/lib/types/index.ts
@@ -1,2 +1,3 @@
 export * from './InterfaceLook';
 export * from './InterfaceColor';
+export * from './InterfaceHeading';

--- a/packages/uui-box/README.md
+++ b/packages/uui-box/README.md
@@ -31,3 +31,9 @@ import { UUIBoxElement } from '@umbraco-ui/uui-box';
 ```html
 <uui-box headline="Headline"> Content </uui-box>
 ```
+
+To specify a heading variant eg h2 use
+
+```html
+<uui-box headline="Headline" header-variant="h2"> Content </uui-box>
+```

--- a/packages/uui-box/README.md
+++ b/packages/uui-box/README.md
@@ -32,8 +32,8 @@ import { UUIBoxElement } from '@umbraco-ui/uui-box';
 <uui-box headline="Headline"> Content </uui-box>
 ```
 
-To specify a heading variant eg h2 use
+To specify a headline variant, eg. `h2` then use the `headline-variant` attribute:
 
 ```html
-<uui-box headline="Headline" header-variant="h2"> Content </uui-box>
+<uui-box headline="Headline" headline-variant="h2"> Content </uui-box>
 ```

--- a/packages/uui-box/lib/uui-box.element.ts
+++ b/packages/uui-box/lib/uui-box.element.ts
@@ -1,7 +1,9 @@
-import { LitElement, html, css } from 'lit';
+import { LitElement, css } from 'lit';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { property, state } from 'lit/decorators.js';
 import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
+import { InterfaceHeading } from '@umbraco-ui/uui-base';
+import { html, unsafeStatic } from 'lit/static-html.js';
 
 /**
  *  A box for grouping elements
@@ -46,6 +48,15 @@ export class UUIBoxElement extends LitElement {
   @property({ type: String })
   headline: string | null = null;
 
+  /**
+   * Changes the heading variant for accessibilty for this box
+   * @type {"h1" | "h2" | "h3" | "h4" | "h5" | "h6"}
+   * @attr
+   * @default "h5"
+   */
+  @property({ reflect: true, attribute: 'header-variant' })
+  headerVariant: InterfaceHeading = "h5"
+
   @state()
   private _headlineSlotHasContent = false;
   private _headlineSlotChanged = (e: Event) => {
@@ -70,19 +81,24 @@ export class UUIBoxElement extends LitElement {
     return html`<div
       id="header"
       class="uui-text"
-      style=${this._headerSlotHasContent ||
-      this._headlineSlotHasContent ||
-      this.headline !== null
-        ? ''
-        : 'display: none'}>
-      <h5
-        id="headline"
-        style=${this._headlineSlotHasContent || this.headline !== null
+      style=${
+        this._headerSlotHasContent ||
+        this._headlineSlotHasContent ||
+        this.headline !== null
           ? ''
-          : 'display: none'}>
+          : 'display: none'
+      }>
+      <${unsafeStatic(this.headerVariant)}
+        id="headline"
+        class="uui-h5"
+        style=${
+          this._headlineSlotHasContent || this.headline !== null
+            ? ''
+            : 'display: none'
+        }>
         ${this.headline}
         <slot name="headline" @slotchange=${this._headlineSlotChanged}></slot>
-      </h5>
+      </${unsafeStatic(this.headerVariant)}>
       <slot name="header" @slotchange=${this._headerSlotChanged}></slot>
     </div>`;
   }

--- a/packages/uui-box/lib/uui-box.element.ts
+++ b/packages/uui-box/lib/uui-box.element.ts
@@ -3,7 +3,7 @@ import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { property, state } from 'lit/decorators.js';
 import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
 import type { InterfaceHeading } from '@umbraco-ui/uui-base/lib';
-import { html, unsafeStatic } from 'lit/static-html.js';
+import { StaticValue, html, literal, unsafeStatic } from 'lit/static-html.js';
 
 /**
  *  A box for grouping elements
@@ -56,6 +56,16 @@ export class UUIBoxElement extends LitElement {
    * @default "h5"
    */
   @property({ attribute: 'headline-variant' })
+  set headlineVariant(value: InterfaceHeading) {
+    if (!value) {
+      this._headlineVariantTag = literal`h5`;
+    } else {
+      this._headlineVariantTag = unsafeStatic(value);
+    }
+  }
+
+  @state()
+  private _headlineVariantTag: StaticValue = literal`h5`;
 
   @state()
   private _headlineSlotHasContent = false;
@@ -78,7 +88,6 @@ export class UUIBoxElement extends LitElement {
    * @method
    */
   protected renderHeader() {
-    const headerTag = unsafeStatic(this.headerVariant);
     /* eslint-disable lit/no-invalid-html, lit/binding-positions */
     return html`<div
       id="header"
@@ -90,7 +99,7 @@ export class UUIBoxElement extends LitElement {
           ? ''
           : 'display: none'
       }>
-      <${headerTag}
+      <${this._headlineVariantTag}
         id="headline"
         class="uui-h5"
         style=${
@@ -100,7 +109,7 @@ export class UUIBoxElement extends LitElement {
         }>
         ${this.headline}
         <slot name="headline" @slotchange=${this._headlineSlotChanged}></slot>
-      </${headerTag}>
+      </${this._headlineVariantTag}>
       <slot name="header" @slotchange=${this._headerSlotChanged}></slot>
     </div>`;
     /* eslint-enable lit/no-invalid-html, lit/binding-positions */

--- a/packages/uui-box/lib/uui-box.element.ts
+++ b/packages/uui-box/lib/uui-box.element.ts
@@ -2,7 +2,7 @@ import { LitElement, css } from 'lit';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { property, state } from 'lit/decorators.js';
 import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
-import { InterfaceHeading } from '@umbraco-ui/uui-base';
+import type { InterfaceHeading } from '@umbraco-ui/uui-base/lib';
 import { html, unsafeStatic } from 'lit/static-html.js';
 
 /**
@@ -49,13 +49,14 @@ export class UUIBoxElement extends LitElement {
   headline: string | null = null;
 
   /**
-   * Changes the heading variant for accessibilty for this box
+   * Changes the heading variant for accessibility for this box.
+   * Notice this does not change the visual representation of the heading. (Umbraco does only recommend displaying a h5 sizes headline in the UUI-BOX)
    * @type {"h1" | "h2" | "h3" | "h4" | "h5" | "h6"}
    * @attr
    * @default "h5"
    */
   @property({ reflect: true, attribute: 'header-variant' })
-  headerVariant: InterfaceHeading = "h5"
+  headerVariant: InterfaceHeading = 'h5';
 
   @state()
   private _headlineSlotHasContent = false;
@@ -78,6 +79,8 @@ export class UUIBoxElement extends LitElement {
    * @method
    */
   protected renderHeader() {
+    const headerTag = unsafeStatic(this.headerVariant);
+    /* eslint-disable lit/no-invalid-html, lit/binding-positions */
     return html`<div
       id="header"
       class="uui-text"
@@ -88,7 +91,7 @@ export class UUIBoxElement extends LitElement {
           ? ''
           : 'display: none'
       }>
-      <${unsafeStatic(this.headerVariant)}
+      <${headerTag}
         id="headline"
         class="uui-h5"
         style=${
@@ -98,9 +101,10 @@ export class UUIBoxElement extends LitElement {
         }>
         ${this.headline}
         <slot name="headline" @slotchange=${this._headlineSlotChanged}></slot>
-      </${unsafeStatic(this.headerVariant)}>
+      </${headerTag}>
       <slot name="header" @slotchange=${this._headerSlotChanged}></slot>
     </div>`;
+    /* eslint-enable lit/no-invalid-html, lit/binding-positions */
   }
 
   render() {

--- a/packages/uui-box/lib/uui-box.element.ts
+++ b/packages/uui-box/lib/uui-box.element.ts
@@ -49,14 +49,13 @@ export class UUIBoxElement extends LitElement {
   headline: string | null = null;
 
   /**
-   * Changes the heading variant for accessibility for this box.
-   * Notice this does not change the visual representation of the heading. (Umbraco does only recommend displaying a h5 sizes headline in the UUI-BOX)
+   * Changes the headline variant for accessibility for this box.
+   * Notice this does not change the visual representation of the headline. (Umbraco does only recommend displaying a h5 sizes headline in the UUI-BOX)
    * @type {"h1" | "h2" | "h3" | "h4" | "h5" | "h6"}
    * @attr
    * @default "h5"
    */
-  @property({ reflect: true, attribute: 'header-variant' })
-  headerVariant: InterfaceHeading = 'h5';
+  @property({ attribute: 'headline-variant' })
 
   @state()
   private _headlineSlotHasContent = false;

--- a/packages/uui-box/lib/uui-box.story.ts
+++ b/packages/uui-box/lib/uui-box.story.ts
@@ -8,6 +8,18 @@ export default {
   title: 'Layout/Box',
   component: 'uui-box',
   id: 'uui-box',
+  args: {
+    headline: "Headline",
+    headerVariant: "h5"
+  },
+  argTypes: {
+    headerVariant: {
+      control: {
+        type: 'select',
+      },
+      options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+    },
+  },
   parameters: {
     readme: {
       markdown: readme,
@@ -15,21 +27,43 @@ export default {
   },
 };
 
-const Template: Story = () => html`
-  <uui-box headline="Headline">
+const Template: Story = props => {
+  return html`
+    <uui-box headline=${props.headline} header-variant=${props.headerVariant}>
     Some content of this box, appended in the default slot.
   </uui-box>
-`;
+  `;
+}
 
 export const AAAOverview = Template.bind({});
 AAAOverview.storyName = 'Overview';
+AAAOverview.parameters = {
+  docs: {
+    source: {
+      type: 'dynamic',
+    },
+  },
+};
 
 export const Slots: Story = () => html`
-  <uui-box>
-    <uui-button slot="headline" look="placeholder" style="font-weight:inherit;"
-      >Headline slot</uui-button
-    >
-    <uui-button slot="header" look="placeholder">Header slot</uui-button>
-    <uui-button look="placeholder">Default slot</uui-button>
-  </uui-box>
+<uui-box>
+  <uui-button slot="headline" look="placeholder" style="font-weight:inherit;"
+>Headline slot</uui-button
+>
+  <uui-button slot="header" look="placeholder">Header slot</uui-button>
+  <uui-button look="placeholder">Default slot</uui-button>
+</uui-box>
 `;
+
+
+export const WithHeaderVariant = Template.bind({});
+WithHeaderVariant.args = { headline: "H1 Headline", headerVariant: 'h1' };
+WithHeaderVariant.parameters = {
+  docs: {
+    source: {
+      code: `<uui-box headline="H1 Headline" header-variant="h1">
+  Some content of this box, appended in the default slot.
+</uui-box>`,
+    },
+  },
+};

--- a/packages/uui-box/lib/uui-box.story.ts
+++ b/packages/uui-box/lib/uui-box.story.ts
@@ -1,7 +1,9 @@
 import '.';
 
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit';
+import type { UUIBoxElement } from './uui-box.element';
+
 import readme from '../README.md?raw';
 
 export default {
@@ -9,11 +11,11 @@ export default {
   component: 'uui-box',
   id: 'uui-box',
   args: {
-    headline: "Headline",
-    headerVariant: "h5"
+    headline: 'Headline',
+    headlineVariant: 'h5',
   },
   argTypes: {
-    headerVariant: {
+    headlineVariant: {
       control: {
         type: 'select',
       },
@@ -25,15 +27,18 @@ export default {
       markdown: readme,
     },
   },
-};
+} as Meta<UUIBoxElement>;
 
 const Template: Story = props => {
   return html`
-    <uui-box headline=${props.headline} header-variant=${props.headerVariant}>
-    Some content of this box, appended in the default slot.
-  </uui-box>
+    <uui-box
+      .headline=${props.headline}
+      .headlineVariant=${props.headlineVariant}>
+      <p>Some content of this box, appended in the default slot.</p>
+      <p>The headline is currently rendered as a ${props.headlineVariant}.</p>
+    </uui-box>
   `;
-}
+};
 
 export const AAAOverview = Template.bind({});
 AAAOverview.storyName = 'Overview';
@@ -46,23 +51,23 @@ AAAOverview.parameters = {
 };
 
 export const Slots: Story = () => html`
-<uui-box>
-  <uui-button slot="headline" look="placeholder" style="font-weight:inherit;"
->Headline slot</uui-button
->
-  <uui-button slot="header" look="placeholder">Header slot</uui-button>
-  <uui-button look="placeholder">Default slot</uui-button>
-</uui-box>
+  <uui-box>
+    <uui-button slot="headline" look="placeholder" style="font-weight:inherit;"
+      >Headline slot</uui-button
+    >
+    <uui-button slot="header" look="placeholder">Header slot</uui-button>
+    <uui-button look="placeholder">Default slot</uui-button>
+  </uui-box>
 `;
 
-
-export const WithHeaderVariant = Template.bind({});
-WithHeaderVariant.args = { headline: "H1 Headline", headerVariant: 'h1' };
-WithHeaderVariant.parameters = {
+export const WithHeadlineVariant = Template.bind({});
+WithHeadlineVariant.args = { headline: 'H1 Headline', headerVariant: 'h1' };
+WithHeadlineVariant.parameters = {
   docs: {
     source: {
-      code: `<uui-box headline="H1 Headline" header-variant="h1">
-  Some content of this box, appended in the default slot.
+      code: `
+<uui-box headline="H1 Headline" headline-variant="h1">
+  The headline is rendered as a H1.
 </uui-box>`,
     },
   },

--- a/packages/uui-box/lib/uui-box.test.ts
+++ b/packages/uui-box/lib/uui-box.test.ts
@@ -17,7 +17,9 @@ describe('UUIBox', () => {
 
   it('passes the a11y audit', async () => {
     for (const headerVariant of InterfaceHeadingValues) {
-      element = await fixture(html` <uui-box headline="headline" header-variant="${headerVariant}">
+      element = await fixture(html` <uui-box
+        headline="headline"
+        header-variant="${headerVariant}">
         Main
       </uui-box>`);
       await expect(element).shadowDom.to.be.accessible();

--- a/packages/uui-box/lib/uui-box.test.ts
+++ b/packages/uui-box/lib/uui-box.test.ts
@@ -68,6 +68,20 @@ describe('UUIBox', () => {
       const slot = element.shadowRoot!.querySelector('slot[name=header]')!;
       expect(slot).to.exist;
     });
+
+    it('renders specified headline tag when headlineVariant is set', async () => {
+      element = await fixture(
+        html` <uui-box headline="headline" headline-variant="h2">Main</uui-box>`
+      );
+
+      // it should exist and it should be the only one
+      expect(element.shadowRoot!.querySelectorAll('h2')).to.have.lengthOf(1);
+
+      // and it should change when headlineVariant changes
+      element.headlineVariant = 'h3';
+      await element.updateComplete;
+      expect(element.shadowRoot!.querySelectorAll('h3')).to.have.lengthOf(1);
+    });
   });
 
   describe('UUIBox', () => {

--- a/packages/uui-box/lib/uui-box.test.ts
+++ b/packages/uui-box/lib/uui-box.test.ts
@@ -16,10 +16,10 @@ describe('UUIBox', () => {
   });
 
   it('passes the a11y audit', async () => {
-    for (const headerVariant of InterfaceHeadingValues) {
+    for (const headlineVariant of InterfaceHeadingValues) {
       element = await fixture(html` <uui-box
         headline="headline"
-        header-variant="${headerVariant}">
+        .headlineVariant="${headlineVariant}">
         Main
       </uui-box>`);
       await expect(element).shadowDom.to.be.accessible();
@@ -30,8 +30,8 @@ describe('UUIBox', () => {
     it('has a headline property', () => {
       expect(element).to.have.property('headline');
     });
-    it('has a header variant property', () => {
-      expect(element).to.have.property('header-variant');
+    it('has a headlineVariant property', () => {
+      expect(element).to.have.property('headlineVariant');
     });
   });
 

--- a/packages/uui-box/lib/uui-box.test.ts
+++ b/packages/uui-box/lib/uui-box.test.ts
@@ -1,6 +1,7 @@
 import { expect, fixture, html } from '@open-wc/testing';
 
 import { UUIBoxElement } from './uui-box.element';
+import { InterfaceHeadingValues } from '@umbraco-ui/uui-base/lib/types';
 
 describe('UUIBox', () => {
   let element: UUIBoxElement;
@@ -15,12 +16,20 @@ describe('UUIBox', () => {
   });
 
   it('passes the a11y audit', async () => {
-    await expect(element).shadowDom.to.be.accessible();
+    for (const headerVariant of InterfaceHeadingValues) {
+      element = await fixture(html` <uui-box headline="headline" header-variant="${headerVariant}">
+        Main
+      </uui-box>`);
+      await expect(element).shadowDom.to.be.accessible();
+    }
   });
 
   describe('properties', () => {
     it('has a headline property', () => {
       expect(element).to.have.property('headline');
+    });
+    it('has a header variant property', () => {
+      expect(element).to.have.property('header-variant');
     });
   });
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,6 +1,6 @@
 declare module '*.css';
 
-declare module '*.md?raw' {
+declare module '*?raw' {
   const content: string;
   export default content;
 }


### PR DESCRIPTION
## Description

fixes #447 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

## How to test?

Story at /docs/layout-box--docs been updated to include new property headerVariant

Change dropdown to a different H tag and inspect element to see component now renders with the H tag selected rather than then always h5

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
