### PR TITLE
select mode for highlight

### DIFF
--- a/packages/uui-base/lib/mixins/SelectableMixin.ts
+++ b/packages/uui-base/lib/mixins/SelectableMixin.ts
@@ -41,7 +41,10 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
       const oldVal = this._selectable;
       this._selectable = newVal;
       // Potentially problematic as a component might need focus for another feature when not selectable:
-      this.setAttribute('tabindex', `${newVal ? '0' : '-1'}`);
+      if (!this.selectableTarget) {
+        // If not selectable target, then make it self selectable. (A selectable target should be made focusable by the component itself)
+        this.setAttribute('tabindex', `${newVal ? '0' : '-1'}`);
+      }
       this.requestUpdate('selected', oldVal);
     }
 
@@ -63,12 +66,13 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
       this.addEventListener('keydown', this.handleSelectKeydown);
     }
 
-    private handleSelectKeydown(e: KeyboardEvent) {
-      if (e.composedPath().indexOf(this.selectableTarget) !== -1) {
+    private handleSelectKeydown = (e: KeyboardEvent) => {
+      //if (e.composedPath().indexOf(this.selectableTarget) !== -1) {
+      if (this.selectableTarget === this) {
         if (e.key !== ' ' && e.key !== 'Enter') return;
         this._toggleSelect();
       }
-    }
+    };
 
     private _select() {
       if (!this.selectable) return;

--- a/packages/uui-base/lib/mixins/SelectableMixin.ts
+++ b/packages/uui-base/lib/mixins/SelectableMixin.ts
@@ -95,6 +95,8 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
     }
 
     private _toggleSelect() {
+      // Only allow for select-interaction if selectable is true. Deselectable is ignorered in this case, we do not want a DX where only deselection is a possibility..
+      if (!this.selectable) return;
       if (this.deselectable === false) {
         this._select();
       } else {

--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -31,9 +31,9 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
   static styles = [
     css`
       :host {
+        box-sizing: border-box;
         display: block;
         --uui-menu-item-child-indent: calc(var(--uui-menu-item-indent, 0) + 1);
-
         user-select: none;
       }
 
@@ -46,7 +46,7 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         white-space: nowrap;
       }
 
-      :host(:not([active], [selected], [disabled]))
+      :host(:not([active], [selected], [disabled], [select-mode='highlight']))
         #menu-item
         #label-button:hover
         ~ #label-button-background,
@@ -81,8 +81,10 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
       :host([selected]) #label-button-background {
         background-color: var(--uui-color-selected);
       }
-      :host([selected]) #label-button:hover ~ #label-button-background,
-      :host([selected]) #caret-button:hover {
+      :host([selected]:not([select-mode='highlight']))
+        #label-button:hover
+        ~ #label-button-background,
+      :host([selected]:not([select-mode='highlight'])) #caret-button:hover {
         background-color: var(--uui-color-selected-emphasis);
       }
 
@@ -90,6 +92,98 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         color: var(--uui-color-disabled-contrast);
         background-color: var(--uui-color-disabled);
       }
+
+      /** Highlight mode colors */
+
+      :host([select-mode='highlight'][active]:not([disabled]))
+        #menu-item
+        #label-button-background {
+        border-radius: var(--uui-border-radius);
+        background-color: var(--uui-color-current);
+      }
+
+      :host([select-mode='highlight'][selected]:not([disabled], [active]))
+        #menu-item
+        #label-button-background {
+        background-color: transparent;
+      }
+
+      :host([select-mode='highlight'][active][selected]:not([disabled]))
+        #menu-item
+        #label-button:hover
+        ~ #label-button-background {
+        border-radius: var(--uui-border-radius);
+        background-color: var(--uui-color-current-emphasis);
+      }
+
+      :host([select-mode='highlight'][selected]:not([disabled]))
+        #menu-item
+        #label-button,
+      :host([select-mode='highlight'][selected]:not([disabled]))
+        #menu-item
+        #caret-button {
+        color: var(--uui-color-interactive);
+      }
+      :host([select-mode='highlight'][selectable][selected]:not([disabled]))
+        #menu-item
+        #label-button:hover {
+        color: var(--uui-color-interactive-emphasis);
+      }
+
+      :host([selected][selectable][select-mode='highlight']:not([active]))
+        #menu-item
+        #caret-button:hover {
+        border-radius: var(--uui-border-radius);
+        background-color: var(--uui-color-surface-emphasis);
+        color: var(--uui-color-interactive-emphasis);
+      }
+
+      /** Highlight borders */
+
+      :host([select-mode='highlight']:not([disabled]))
+        #menu-item
+        #label-button-background::after {
+        border-radius: var(--uui-border-radius);
+        position: absolute;
+        content: '';
+        inset: 1px;
+        border: 2px solid var(--uui-color-selected);
+        opacity: 0;
+      }
+
+      :host([select-mode='highlight'][selectable][selected]:not([disabled]))
+        #menu-item
+        #caret-button:hover::after {
+        border-top-left-radius: var(--uui-border-radius);
+        border-bottom-left-radius: var(--uui-border-radius);
+        position: absolute;
+        content: '';
+        inset: 1px 0 1px 1px;
+        border: 2px solid var(--uui-color-selected);
+        border-right: none;
+      }
+
+      :host([select-mode='highlight'][selected]:not([disabled]))
+        #menu-item
+        #label-button-background::after {
+        opacity: 1;
+      }
+
+      :host([select-mode='highlight'][selectable]:not([disabled]))
+        #menu-item
+        #label-button:hover
+        ~ #label-button-background::after {
+        opacity: 0.33;
+      }
+      :host([select-mode='highlight'][selected]:not([disabled]))
+        #menu-item
+        #label-button:hover
+        ~ #label-button-background::after {
+        opacity: 0.66;
+      }
+
+      /** Buttons */
+
       :host([disabled]) #label-button {
         cursor: default;
       }
@@ -112,6 +206,7 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
       }
 
       #label-button {
+        position: relative;
         flex-grow: 1;
         grid-column-start: 2;
         white-space: nowrap;
@@ -139,6 +234,7 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
       }
 
       #caret-button {
+        position: relative;
         width: 100%;
         height: 100%;
         display: flex;
@@ -185,6 +281,41 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         display: block;
         margin-left: 6px;
       }
+
+      /** Focus styling */
+
+      :host([select-mode='highlight']:focus-visible) {
+        border-radius: var(--uui-border-radius);
+        outline: 2px solid var(--uui-color-focus);
+      }
+
+      :host([select-mode='highlight']) #label-button:focus-visible {
+        outline: none;
+      }
+
+      :host([select-mode='highlight']) #label-button:focus-visible::after {
+        content: '';
+        border-radius: var(--uui-border-radius);
+        z-index: 2;
+        position: absolute;
+        inset: 3px 3px 3px 0;
+        border: 2px solid var(--uui-color-focus);
+      }
+
+      :host([select-mode='highlight']) #caret-button:focus-visible {
+        outline: none;
+      }
+
+      :host([select-mode='highlight']) #caret-button:focus-visible::after {
+        content: '';
+        position: absolute;
+        inset: 3px;
+        z-index: 2;
+        border-radius: var(--uui-border-radius);
+        border: 2px solid var(--uui-color-focus);
+      }
+
+      /** Slots */
 
       slot:not([name]) {
         position: relative;
@@ -258,6 +389,15 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
    */
   @property({ type: String })
   public target?: '_blank' | '_parent' | '_self' | '_top';
+
+  /**
+   * Sets the selection mode.
+   * @type {string}
+   * @attr
+   * @default undefined
+   */
+  @property({ type: String, attribute: 'select-mode', reflect: true })
+  public selectMode?: 'highlight' | 'persisting';
 
   @state()
   private iconSlotHasContent = false;

--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -83,19 +83,22 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
       }
 
       /** Selected */
-      :host([selected]:not([select-mode='highlight'])) #label-button,
-      :host([selected]:not([select-mode='highlight'])) #caret-button {
+      :host([selected]:not([select-mode='highlight'], [disabled]))
+        #label-button,
+      :host([selected]:not([select-mode='highlight'], [disabled]))
+        #caret-button {
         color: var(--uui-color-selected-contrast);
       }
-      :host([selected]:not([select-mode='highlight']))
+      :host([selected]:not([select-mode='highlight'], [disabled]))
         #label-button-background {
         background-color: var(--uui-color-selected);
       }
       /** Selected, not highlight mode */
-      :host([selected]:not([select-mode='highlight']))
+      :host([selected]:not([select-mode='highlight'], [disabled]))
         #label-button:hover
         ~ #label-button-background,
-      :host([selected]:not([select-mode='highlight'])) #caret-button:hover {
+      :host([selected]:not([select-mode='highlight'], [disabled]))
+        #caret-button:hover {
         background-color: var(--uui-color-selected-emphasis);
       }
 
@@ -293,34 +296,29 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
 
       /** Focus styling */
 
-      :host([select-mode='highlight']:focus-visible) {
-        border-radius: var(--uui-border-radius);
-        outline: 2px solid var(--uui-color-focus);
-      }
-
       :host([select-mode='highlight']) #label-button:focus-visible {
         outline: none;
+        overflow: initial;
       }
 
       :host([select-mode='highlight']) #label-button:focus-visible::after {
         content: '';
-        border-radius: var(--uui-border-radius);
-        z-index: 2;
+        border-radius: calc(var(--uui-border-radius) - 1px);
         position: absolute;
-        inset: 3px 3px 3px 0;
+        inset: 3px 3px 3px -5px;
         border: 2px solid var(--uui-color-focus);
       }
 
       :host([select-mode='highlight']) #caret-button:focus-visible {
         outline: none;
+        overflow: initial;
       }
 
       :host([select-mode='highlight']) #caret-button:focus-visible::after {
         content: '';
         position: absolute;
         inset: 3px;
-        z-index: 2;
-        border-radius: var(--uui-border-radius);
+        border-radius: calc(var(--uui-border-radius) - 1px);
         border: 2px solid var(--uui-color-focus);
       }
 

--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -46,6 +46,7 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         white-space: nowrap;
       }
 
+      /** Not active, not selected, not disabled: */
       :host(:not([active], [selected], [disabled], [select-mode='highlight']))
         #menu-item
         #label-button:hover
@@ -62,6 +63,7 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         color: var(--uui-color-interactive-emphasis);
       }
 
+      /** Active */
       :host([active]) #label-button,
       :host([active]) #caret-button {
         color: var(--uui-color-current-contrast);
@@ -74,6 +76,13 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         background-color: var(--uui-color-current-emphasis);
       }
 
+      /** Disabled */
+      :host([disabled]) #menu-item {
+        color: var(--uui-color-disabled-contrast);
+        background-color: var(--uui-color-disabled);
+      }
+
+      /** Selected */
       :host([selected]) #label-button,
       :host([selected]) #caret-button {
         color: var(--uui-color-selected-contrast);
@@ -81,6 +90,7 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
       :host([selected]) #label-button-background {
         background-color: var(--uui-color-selected);
       }
+      /** Selected, not highlight mode */
       :host([selected]:not([select-mode='highlight']))
         #label-button:hover
         ~ #label-button-background,
@@ -88,13 +98,7 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         background-color: var(--uui-color-selected-emphasis);
       }
 
-      :host([disabled]) #menu-item {
-        color: var(--uui-color-disabled-contrast);
-        background-color: var(--uui-color-disabled);
-      }
-
-      /** Highlight mode colors */
-
+      /** Selected, highlight mode */
       :host([select-mode='highlight'][active]:not([disabled]))
         #menu-item
         #label-button-background {

--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -142,6 +142,7 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         color: var(--uui-color-interactive-emphasis);
       }
 
+      /** highlight mode, selected, selectable caret hover */
       :host([selected][selectable][select-mode='highlight']:not([active]))
         #menu-item
         #caret-button:hover {

--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -108,6 +108,14 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         background-color: transparent;
       }
 
+      :host([select-mode='highlight']:not([disabled], [active], [selectable]))
+        #menu-item
+        #label-button:hover
+        ~ #label-button-background {
+        border-radius: var(--uui-border-radius);
+        background-color: var(--uui-color-surface-emphasis);
+      }
+
       :host([select-mode='highlight'][active][selected]:not([disabled]))
         #menu-item
         #label-button:hover

--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -83,12 +83,11 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
       }
 
       /** Selected */
-      :host([selected]:not([select-mode='highlight'])) #label-button,
-      :host([selected]:not([select-mode='highlight'])) #caret-button {
+      :host([selected]) #label-button,
+      :host([selected]) #caret-button {
         color: var(--uui-color-selected-contrast);
       }
-      :host([selected]:not([select-mode='highlight']))
-        #label-button-background {
+      :host([selected]) #label-button-background {
         background-color: var(--uui-color-selected);
       }
       /** Selected, not highlight mode */
@@ -99,7 +98,20 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         background-color: var(--uui-color-selected-emphasis);
       }
 
-      /** highlight mode, default */
+      /** Selected, highlight mode */
+      :host([select-mode='highlight'][active]:not([disabled]))
+        #menu-item
+        #label-button-background {
+        border-radius: var(--uui-border-radius);
+        background-color: var(--uui-color-current);
+      }
+
+      :host([select-mode='highlight'][selected]:not([disabled], [active]))
+        #menu-item
+        #label-button-background {
+        background-color: transparent;
+      }
+
       :host([select-mode='highlight']:not([disabled], [active], [selectable]))
         #menu-item
         #label-button:hover
@@ -108,14 +120,6 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         background-color: var(--uui-color-surface-emphasis);
       }
 
-      /** highlight mode, active */
-      :host([select-mode='highlight'][active]:not([disabled]))
-        #menu-item
-        #label-button-background {
-        border-radius: var(--uui-border-radius);
-      }
-
-      /** highlight mode, active & selected */
       :host([select-mode='highlight'][active][selected]:not([disabled]))
         #menu-item
         #label-button:hover
@@ -124,7 +128,6 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         background-color: var(--uui-color-current-emphasis);
       }
 
-      /** highlight mode, selected */
       :host([select-mode='highlight'][selected]:not([disabled]))
         #menu-item
         #label-button,

--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -83,11 +83,12 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
       }
 
       /** Selected */
-      :host([selected]) #label-button,
-      :host([selected]) #caret-button {
+      :host([selected]:not([select-mode='highlight'])) #label-button,
+      :host([selected]:not([select-mode='highlight'])) #caret-button {
         color: var(--uui-color-selected-contrast);
       }
-      :host([selected]) #label-button-background {
+      :host([selected]:not([select-mode='highlight']))
+        #label-button-background {
         background-color: var(--uui-color-selected);
       }
       /** Selected, not highlight mode */
@@ -98,20 +99,7 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         background-color: var(--uui-color-selected-emphasis);
       }
 
-      /** Selected, highlight mode */
-      :host([select-mode='highlight'][active]:not([disabled]))
-        #menu-item
-        #label-button-background {
-        border-radius: var(--uui-border-radius);
-        background-color: var(--uui-color-current);
-      }
-
-      :host([select-mode='highlight'][selected]:not([disabled], [active]))
-        #menu-item
-        #label-button-background {
-        background-color: transparent;
-      }
-
+      /** highlight mode, default */
       :host([select-mode='highlight']:not([disabled], [active], [selectable]))
         #menu-item
         #label-button:hover
@@ -120,6 +108,14 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         background-color: var(--uui-color-surface-emphasis);
       }
 
+      /** highlight mode, active */
+      :host([select-mode='highlight'][active]:not([disabled]))
+        #menu-item
+        #label-button-background {
+        border-radius: var(--uui-border-radius);
+      }
+
+      /** highlight mode, active & selected */
       :host([select-mode='highlight'][active][selected]:not([disabled]))
         #menu-item
         #label-button:hover
@@ -128,6 +124,7 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         background-color: var(--uui-color-current-emphasis);
       }
 
+      /** highlight mode, selected */
       :host([select-mode='highlight'][selected]:not([disabled]))
         #menu-item
         #label-button,

--- a/packages/uui-menu-item/lib/uui-menu-item.story.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.story.ts
@@ -476,6 +476,7 @@ const renderCombinationOfStates = (
   </uui-menu-item> `;
 };
 // show combination of states: active, disabled, selected, selectable, select-mode
+// Notice, this implementation sets selectable to false in all cases of begin disabled.
 export const CombinationOfStates = () =>
   html`
     ${renderCombinationOfStates('Active', true, false, false, false, false)}
@@ -554,7 +555,7 @@ export const CombinationOfStates = () =>
     <br />
     <b>All selected & selectable (Default mode)</b>
     ${renderCombinationOfStates('Active', true, false, true, true, false)}
-    ${renderCombinationOfStates('Disabled', false, true, true, true, false)}
+    ${renderCombinationOfStates('Disabled', false, true, true, false, false)}
     ${renderCombinationOfStates('Selected', false, false, true, true, false)}
     ${renderCombinationOfStates('Selectable', false, false, true, true, false)}
     ${renderCombinationOfStates(
@@ -569,7 +570,7 @@ export const CombinationOfStates = () =>
     <br />
     <b>All Selected & selectable (Highlight mode)</b>
     ${renderCombinationOfStates('Active', true, false, true, true, true)}
-    ${renderCombinationOfStates('Disabled', false, true, true, true, true)}
+    ${renderCombinationOfStates('Disabled', false, true, true, false, true)}
     ${renderCombinationOfStates('Selected', false, false, true, true, true)}
     ${renderCombinationOfStates('Selectable', false, false, true, true, true)}
     ${renderCombinationOfStates(
@@ -584,7 +585,7 @@ export const CombinationOfStates = () =>
     <br />
     <b>All selectable</b>
     ${renderCombinationOfStates('Active', true, false, false, true, false)}
-    ${renderCombinationOfStates('Disabled', false, true, false, true, false)}
+    ${renderCombinationOfStates('Disabled', false, true, false, false, false)}
     ${renderCombinationOfStates('Selected', false, false, true, true, false)}
     ${renderCombinationOfStates('Selectable', false, false, false, true, false)}
     ${renderCombinationOfStates(

--- a/packages/uui-menu-item/lib/uui-menu-item.story.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.story.ts
@@ -8,6 +8,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { UUIMenuItemElement } from './uui-menu-item.element';
 import { UUIMenuItemEvent } from './UUIMenuItemEvent';
 import readme from '../README.md?raw';
+import '@umbraco-ui/uui-symbol-expand/lib';
 
 export default {
   title: 'Buttons/Menu Item',
@@ -27,9 +28,16 @@ export default {
     selectable: false,
     href: undefined,
     target: undefined,
+    selectMode: undefined,
   },
   argTypes: {
     '--uui-menu-item-indent': { control: { type: 'text' } },
+    selectMode: {
+      control: {
+        type: 'select',
+      },
+      options: ['persisting', 'highlight', undefined],
+    },
   },
   parameters: {
     readme: { markdown: readme },
@@ -209,17 +217,21 @@ function disabledStoryOnClick(e: UUIMenuItemEvent) {
   e.target.active = !e.target.active;
 }
 
-export const Disabled = () =>
+export const Disabled = (props: any) =>
   html`
     ${MenuItems.map(
       menuItem =>
         html`
           <uui-menu-item
             @click-label=${disabledStoryOnClick}
-            label="${menuItem.title}"></uui-menu-item>
+            label="${menuItem.title}"
+            ?disabled=${props.disabled}></uui-menu-item>
         `
     )}
   `;
+Disabled.args = {
+  disabled: true,
+};
 Disabled.parameters = {
   docs: {
     source: {
@@ -396,6 +408,42 @@ ItemIndentation.parameters = {
   docs: {
     source: {
       code: `<uui-menu-item label="Menu Item 1" style="--uui-menu-item-indent: 1"></uui-menu-item>`,
+    },
+  },
+};
+
+export const SelectMode = (props: any) =>
+  html`<uui-menu-item
+    label="Parent"
+    has-children
+    show-children
+    ?selectable=${props.selectable}
+    select-mode=${props.selectMode}>
+    ${MenuItems.map(
+      (menuItem, i) =>
+        html`<uui-menu-item
+          label="${menuItem.title}"
+          ?selected=${i == 1 ? true : false}
+          ?selectable=${props.selectable}
+          select-mode=${props.selectMode}></uui-menu-item>`
+    )}
+  </uui-menu-item> `;
+SelectMode.args = {
+  selectable: true,
+  selectMode: 'highlight',
+};
+SelectMode.parameters = {
+  controls: {
+    include: ['selectable', 'selectMode'],
+  },
+  docs: {
+    source: {
+      code: html`
+        <uui-menu-item
+          label="Menu Item"
+          select-mode="highlight"
+          selectable></uui-menu-item>
+      `.strings,
     },
   },
 };

--- a/packages/uui-menu-item/lib/uui-menu-item.story.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.story.ts
@@ -447,3 +447,122 @@ SelectMode.parameters = {
     },
   },
 };
+
+const renderCombinationOfStates = (
+  label: string,
+  active: boolean,
+  disabled: boolean,
+  selected: boolean,
+  selectable: boolean,
+  highlightSelectMode: boolean
+) => {
+  return html`<uui-menu-item
+    label=${label}
+    has-children
+    show-children
+    ?active=${active}
+    ?disabled=${disabled}
+    ?selected=${selected}
+    ?selectable=${selectable}
+    select-mode=${ifDefined(highlightSelectMode ? 'highlight' : undefined)}>
+    <uui-menu-item
+      label=${label}
+      ?active=${active}
+      ?disabled=${disabled}
+      ?selected=${selected}
+      ?selectable=${selectable}
+      select-mode=${ifDefined(highlightSelectMode ? 'highlight' : undefined)}>
+    </uui-menu-item>
+  </uui-menu-item> `;
+};
+// show combination of states: active, disabled, selected, selectable, select-mode
+export const CombinationOfStates = () =>
+  html`
+    ${renderCombinationOfStates('Active', true, false, false, false, false)}
+    ${renderCombinationOfStates('Disabled', false, true, false, false, false)}
+    ${renderCombinationOfStates('Selected', false, false, true, false, false)}
+    ${renderCombinationOfStates('Selectable', false, false, false, true, false)}
+    ${renderCombinationOfStates(
+      'Highlight select mode',
+      false,
+      false,
+      false,
+      false,
+      true
+    )}
+
+    <br />
+    <b>All active</b>
+    ${renderCombinationOfStates('Active', true, false, false, false, false)}
+    ${renderCombinationOfStates('Disabled', true, true, false, false, false)}
+    ${renderCombinationOfStates('Selected', true, false, true, false, false)}
+    ${renderCombinationOfStates('Selectable', true, false, false, true, false)}
+    ${renderCombinationOfStates(
+      'Highlight select mode',
+      true,
+      false,
+      false,
+      false,
+      true
+    )}
+
+    <br />
+    <b>All disabled</b>
+    ${renderCombinationOfStates('Active', true, true, false, false, false)}
+    ${renderCombinationOfStates('Disabled', false, true, false, false, false)}
+    ${renderCombinationOfStates('Selected', false, true, true, false, false)}
+    ${renderCombinationOfStates('Selectable', false, true, false, true, false)}
+    ${renderCombinationOfStates(
+      'Highlight select mode',
+      false,
+      true,
+      false,
+      false,
+      true
+    )}
+
+    <br />
+    <b>All selected</b>
+    ${renderCombinationOfStates('Active', true, false, true, false, false)}
+    ${renderCombinationOfStates('Disabled', false, true, true, false, false)}
+    ${renderCombinationOfStates('Selected', false, false, true, false, false)}
+    ${renderCombinationOfStates('Selectable', false, false, true, true, false)}
+    ${renderCombinationOfStates(
+      'Highlight select mode',
+      false,
+      false,
+      true,
+      false,
+      true
+    )}
+
+    <br />
+    <b>All selectable</b>
+    ${renderCombinationOfStates('Active', true, false, false, true, false)}
+    ${renderCombinationOfStates('Disabled', false, true, false, true, false)}
+    ${renderCombinationOfStates('Selected', false, false, true, true, false)}
+    ${renderCombinationOfStates('Selectable', false, false, false, true, false)}
+    ${renderCombinationOfStates(
+      'Highlight select mode',
+      false,
+      false,
+      false,
+      true,
+      true
+    )}
+
+    <br />
+    <b>Highlight select Mode</b>
+    ${renderCombinationOfStates('Active', true, false, false, false, true)}
+    ${renderCombinationOfStates('Disabled', false, true, false, false, true)}
+    ${renderCombinationOfStates('Selected', false, false, true, false, true)}
+    ${renderCombinationOfStates('Selectable', false, false, false, true, true)}
+    ${renderCombinationOfStates(
+      'Highlight select mode',
+      false,
+      false,
+      false,
+      false,
+      true
+    )}
+  `;

--- a/packages/uui-menu-item/lib/uui-menu-item.story.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.story.ts
@@ -522,7 +522,7 @@ export const CombinationOfStates = () =>
     )}
 
     <br />
-    <b>All selected</b>
+    <b>All selected (Default mode)</b>
     ${renderCombinationOfStates('Active', true, false, true, false, false)}
     ${renderCombinationOfStates('Disabled', false, true, true, false, false)}
     ${renderCombinationOfStates('Selected', false, false, true, false, false)}
@@ -532,6 +532,51 @@ export const CombinationOfStates = () =>
       false,
       false,
       true,
+      false,
+      true
+    )}
+
+    <br />
+    <b>All Selected (Highlight mode)</b>
+    ${renderCombinationOfStates('Active', true, false, true, false, true)}
+    ${renderCombinationOfStates('Disabled', false, true, true, false, true)}
+    ${renderCombinationOfStates('Selected', false, false, true, false, true)}
+    ${renderCombinationOfStates('Selectable', false, false, true, true, true)}
+    ${renderCombinationOfStates(
+      'Highlight select mode',
+      false,
+      false,
+      false,
+      false,
+      true
+    )}
+
+    <br />
+    <b>All selected & selectable (Default mode)</b>
+    ${renderCombinationOfStates('Active', true, false, true, true, false)}
+    ${renderCombinationOfStates('Disabled', false, true, true, true, false)}
+    ${renderCombinationOfStates('Selected', false, false, true, true, false)}
+    ${renderCombinationOfStates('Selectable', false, false, true, true, false)}
+    ${renderCombinationOfStates(
+      'Highlight select mode',
+      false,
+      false,
+      true,
+      false,
+      true
+    )}
+
+    <br />
+    <b>All Selected & selectable (Highlight mode)</b>
+    ${renderCombinationOfStates('Active', true, false, true, true, true)}
+    ${renderCombinationOfStates('Disabled', false, true, true, true, true)}
+    ${renderCombinationOfStates('Selected', false, false, true, true, true)}
+    ${renderCombinationOfStates('Selectable', false, false, true, true, true)}
+    ${renderCombinationOfStates(
+      'Highlight select mode',
+      false,
+      false,
+      false,
       false,
       true
     )}

--- a/packages/uui-menu-item/lib/uui-menu-item.test.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.test.ts
@@ -64,6 +64,14 @@ describe('UUIMenuItemElement', () => {
     it('has a target property', () => {
       expect(element).to.have.property('target');
     });
+
+    it('has a select-mode property', () => {
+      expect(element).to.have.property('selectMode');
+    });
+
+    it('select-mode property defaults to undefined', () => {
+      expect(element.selectMode).to.undefined;
+    });
   });
 
   describe('events', () => {


### PR DESCRIPTION
## Description
This PR adds a select-mode property for the uui-menu-item to differentiate between persisting selection and highlight selection.
The default is undefined (persisting), where highlight changes style of menu-item when selected and selectable.

Also a small fix where it didn't show the caret symbol in storybook 😄 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)
Highlight
![highlight](https://github.com/umbraco/Umbraco.UI/assets/108085781/911141c2-6bb8-4b37-8975-533582938fbe)

Persisting
![persisting](https://github.com/umbraco/Umbraco.UI/assets/108085781/aa3c61d5-8bb8-467e-93bb-04d6f69d41b0)
