### PR TITLE
Typo in story for uui-loader-bar

### DIFF
--- a/packages/uui-loader-bar/lib/uui-loader-bar.story.ts
+++ b/packages/uui-loader-bar/lib/uui-loader-bar.story.ts
@@ -2,7 +2,7 @@ import '.';
 
 import { Story } from '@storybook/web-components';
 import { html } from 'lit';
-import readme from '../README.md?raw';
+import readme from '../README.md';
 
 export default {
   title: 'Loaders/Loader Bar',
@@ -43,7 +43,7 @@ AAAOverview.argTypes = {
 AAAOverview.parameters = {
   docs: {
     source: {
-      code: '<uui-loader animationDuration="1.5" style="color: black"></uui-loader>',
+      code: '<uui-loader-bar animationDuration="1.5" style="color: black"></uui-loader-bar>',
     },
   },
 };
@@ -56,7 +56,7 @@ Color.argTypes = {
 Color.parameters = {
   docs: {
     source: {
-      code: '<uui-loader style="color: blue"></uui-loader>',
+      code: '<uui-loader-bar style="color: blue"></uui-loader-bar>',
     },
   },
 };
@@ -66,7 +66,7 @@ Progress.args = { progress: 75 };
 Progress.parameters = {
   docs: {
     source: {
-      code: '<uui-loader progress="75"></uui-loader>',
+      code: '<uui-loader-bar progress="75"></uui-loader-bar>',
     },
   },
 };

--- a/packages/uui-loader-bar/lib/uui-loader-bar.story.ts
+++ b/packages/uui-loader-bar/lib/uui-loader-bar.story.ts
@@ -2,7 +2,7 @@ import '.';
 
 import { Story } from '@storybook/web-components';
 import { html } from 'lit';
-import readme from '../README.md';
+import readme from '../README.md?raw';
 
 export default {
   title: 'Loaders/Loader Bar',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Just noticed that the uui-loader-bar showed the uui-loader in the code examples, so I fixed the typo in the story.
https://uui.umbraco.com/?path=/docs/loaders-loader-bar--docs

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context
I was trying to use the `<uui-loader-bar>` and noticed the code example in the story was the same as `<uui-loader>`
<!--- Why is this change required? What problem does it solve? -->

## How to test?
Check the story here:
https://uui.umbraco.com/?path=/docs/loaders-loader-bar--docs

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
