### PR TITLE
Autowidth feature on uui input

### DIFF
--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -1,7 +1,7 @@
 import { FormControlMixin, LabelMixin } from '@umbraco-ui/uui-base/lib/mixins';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
-import { css, html, LitElement, PropertyValueMap } from 'lit';
-import { property, query } from 'lit/decorators.js';
+import { css, html, LitElement, nothing, PropertyValueMap } from 'lit';
+import { property, query, queryAssignedNodes } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { UUIInputEvent } from './UUIInputEvent';
@@ -57,6 +57,29 @@ export class UUIInputElement extends FormControlMixin(
 
         --uui-button-height: 100%;
       }
+
+      #control {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        justify-content: center;
+      }
+
+      #auto {
+        border: 1px solid transparent;
+        visibility: hidden;
+        white-space: pre;
+        z-index: -1;
+        height: 0px;
+        padding: 0 var(--uui-size-space-3);
+      }
+
+      :host([auto-width]) #input {
+        width: 10px;
+        min-width: 100%;
+      }
+
       :host(:hover) {
         border-color: var(
           --uui-input-border-color-hover,
@@ -249,6 +272,15 @@ export class UUIInputElement extends FormControlMixin(
   autocomplete?: string;
 
   /**
+   * Sets the input width to fit the value or placeholder if empty
+   * @type {boolean}
+   * @attr
+   * @default undefined
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'auto-width' })
+  autoWidth?: boolean;
+
+  /**
    * This property specifies the type of input that will be rendered.
    * @type {'text' | 'tel'| 'url'| 'email'| 'password'| 'date'| 'month'| 'week'| 'time'| 'datetime-local'| 'number'| 'color'}
    * @attr
@@ -357,6 +389,7 @@ export class UUIInputElement extends FormControlMixin(
   protected onChange(e: Event) {
     e.stopPropagation();
     this.pristine = false;
+
     this.dispatchEvent(new UUIInputEvent(UUIInputEvent.CHANGE));
   }
 
@@ -371,26 +404,39 @@ export class UUIInputElement extends FormControlMixin(
   render() {
     return html`
       ${this.renderPrepend()}
-      <input
-        id="input"
-        .type=${this.type}
-        .value=${this.value as string}
-        .name=${this.name}
-        pattern=${ifDefined(this.pattern)}
-        min=${ifDefined(this.min)}
-        max=${ifDefined(this.max)}
-        step=${ifDefined(this.step)}
-        spellcheck=${ifDefined(this.spellcheck)}
-        autocomplete=${ifDefined(this.autocomplete as any)}
-        placeholder=${this.placeholder}
-        aria-label=${this.label}
-        .disabled=${this.disabled}
-        ?required=${this.required}
-        ?readonly=${this.readonly}
-        @input=${this.onInput}
-        @change=${this.onChange} />
+      <div id="control">
+        <input
+          id="input"
+          .type=${this.type}
+          .value=${this.value as string}
+          .name=${this.name}
+          pattern=${ifDefined(this.pattern)}
+          min=${ifDefined(this.min)}
+          max=${ifDefined(this.max)}
+          step=${ifDefined(this.step)}
+          spellcheck=${ifDefined(this.spellcheck)}
+          autocomplete=${ifDefined(this.autocomplete as any)}
+          placeholder=${this.placeholder}
+          aria-label=${this.label}
+          .disabled=${this.disabled}
+          ?required=${this.required}
+          ?readonly=${this.readonly}
+          @input=${this.onInput}
+          @change=${this.onChange} />
+        ${this.autoWidth ? this.renderAutoWidth() : nothing}
+      </div>
       ${this.renderAppend()}
     `;
+  }
+
+  private renderAutoWidth() {
+    return html` <div id="auto" aria-hidden="true">${this.renderText()}</div>`;
+  }
+
+  private renderText() {
+    return html`${(this.value as string).length > 0
+      ? this.value
+      : this.placeholder}`;
   }
 }
 

--- a/packages/uui-input/lib/uui-input.story.ts
+++ b/packages/uui-input/lib/uui-input.story.ts
@@ -316,3 +316,40 @@ export const MultipleInputs: Story = props =>
       </uui-input>
     </uui-input>
   `;
+
+export const AutoWidth: Story = props => html`<uui-input
+    .min=${props.min}
+    .max=${props.max}
+    .step=${props.step}
+    .disabled=${props.disabled}
+    .readonly=${props.readonly}
+    .error=${props.error}
+    .label=${props.label}
+    .type=${props.type}
+    .name=${props.name}
+    .placeholder=${props.placeholder}
+    .value=${props.value}
+    auto-width>
+  </uui-input>
+  <br /><br />
+  <uui-input
+    .min=${props.min}
+    .max=${props.max}
+    .step=${props.step}
+    .disabled=${props.disabled}
+    .readonly=${props.readonly}
+    .error=${props.error}
+    .label=${props.label}
+    .type=${props.type}
+    .name=${props.name}
+    .placeholder=${props.placeholder}
+    .value=${props.value}
+    auto-width>
+    <uui-input
+      slot="prepend"
+      placeholder="Prepend auto-width"
+      auto-width></uui-input>
+    <uui-input slot="append" placeholder="Append auto-width false"></uui-input>
+  </uui-input>`;
+
+AutoWidth.args = { placeholder: 'Start typing...' };


### PR DESCRIPTION
## Description
`uui-input` has a new property `auto-width` which enables the component's width to expand automatically as the value changes. When the value is empty, the width is matching the value of the placeholder property. If both values are empty, the width is 10px.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Screenshots
![image](https://github.com/umbraco/Umbraco.UI/assets/108085781/5b6f03a4-2d89-48d2-9561-aaf6e823f037)
![image](https://github.com/umbraco/Umbraco.UI/assets/108085781/d61ec3b8-952e-45c2-b274-d169625e1c0a)

## How to test?
See the "Auto Width" story under Input 
