### PR TITLE
uui-color: add better support for touch screens

### DIFF
--- a/packages/uui-base/lib/utils/drag.ts
+++ b/packages/uui-base/lib/utils/drag.ts
@@ -15,11 +15,19 @@ export const drag = (
   container: HTMLElement,
   options?: Partial<DragOptions>
 ) => {
-  function move(pointerEvent: PointerEvent) {
+  function move(event: PointerEvent | TouchEvent) {
     const dims = container.getBoundingClientRect();
     const defaultView = container.ownerDocument.defaultView!;
-    const offsetX = dims.left + defaultView.pageXOffset;
-    const offsetY = dims.top + defaultView.pageYOffset;
+    const offsetX = dims.left + defaultView.scrollX;
+    const offsetY = dims.top + defaultView.scrollY;
+
+    let pointerEvent: PointerEvent | Touch;
+    if (event instanceof TouchEvent) {
+      pointerEvent = event.touches[0];
+    } else {
+      pointerEvent = event;
+    }
+
     const x = pointerEvent.pageX - offsetX;
     const y = pointerEvent.pageY - offsetY;
 

--- a/packages/uui-color-area/lib/uui-color-area.element.ts
+++ b/packages/uui-color-area/lib/uui-color-area.element.ts
@@ -181,6 +181,9 @@ export class UUIColorAreaElement extends LitElement {
 
     drag(grid, {
       onMove: (x, y) => {
+        // check if coordinates are not NaN (can happen when dragging outside of the grid)
+        if (isNaN(x) || isNaN(y)) return;
+
         this.saturation = clamp((x / width) * 100, 0, 100);
         this.brightness = clamp(100 - (y / height) * 100, 0, 100);
         this.lightness = this.getLightness(this.brightness);


### PR DESCRIPTION
## Description

Fixes #509 

Update the move() function to handle `TouchEvent` as well as `PointerEvent`. When initially "clicking" on a touch screen, it will pass a `TouchEvent` that does not match the signature of a `PointerEvent`, specifically it will not contain the `pageX` and `pageY` coordinates that the move() function expects. By analyzing the event with `instanceof TouchEvent`, we can pull out the `.touches[0]` object which is of type `Touch` and matches the signature of `PointerEvent` as far as we are concerned.

## How to test

Spin up Storybook, go to either the uui-color-picker or uui-color-area stories and perform click, drag, and touch actions and see that it forwards a CHANGE event in the Actions tab. Specifically, the `saturation` and `lightness` properties of the `srcElement` should reflect what has happened, and visually the dot should have moved to where you clicked in the color area.