### PR TITLE
uui-button: content align css variable

### DIFF
--- a/packages/uui-button/lib/uui-button.element.ts
+++ b/packages/uui-button/lib/uui-button.element.ts
@@ -39,6 +39,7 @@ export type UUIButtonType = 'submit' | 'button' | 'reset';
  *  @cssprop --uui-button-contrast - overwrite the text color
  *  @cssprop --uui-button-contrast-hover - overwrite the text color for hover state
  *  @cssprop --uui-button-contrast-disabled - overwrite the text color for disabled state
+ *  @cssprop --uui-button-content-align - Overwrite justify-content alignment. Possible values: 'left', 'right', 'center'.
  */
 @defineElement('uui-button')
 export class UUIButtonElement extends FormControlMixin(
@@ -110,7 +111,7 @@ export class UUIButtonElement extends FormControlMixin(
 
         display: inline-flex;
         align-items: center;
-        justify-content: center;
+        justify-content: var(--uui-button-content-align, center);
 
         /* for anchor tag: */
         text-decoration: none;

--- a/packages/uui-button/lib/uui-button.story.ts
+++ b/packages/uui-button/lib/uui-button.story.ts
@@ -40,12 +40,6 @@ export default {
       options: ['', 'submit', 'button', 'reset'],
       control: { type: 'select' },
     },
-    '--uui-button-content-align': {
-      control: {
-        type: 'select',
-      },
-      options: ['left', 'center', 'right'],
-    },
     state: {
       options: [null, 'waiting', 'success', 'failed'],
       control: { type: 'select' },
@@ -63,6 +57,10 @@ export default {
     '--uui-button-contrast-hover': { control: { type: 'color' } },
     '--uui-button-background-color-disabled': { control: { type: 'color' } },
     '--uui-button-contrast-disabled': { control: { type: 'color' } },
+    '--uui-button-content-align': {
+      control: { type: 'select' },
+      options: ['left', 'center', 'right'],
+    },
   },
   parameters: {
     readme: {
@@ -435,3 +433,30 @@ export const MultiLine: Story = props => {
 };
 
 MultiLine.args = { look: 'primary' };
+
+export const ContentAlignment = props => html`
+  <uui-button
+    style="max-width: 400px; width: 100%;
+      --uui-button-content-align: ${props['--uui-button-content-align']}"
+    look="primary"
+    color="danger"
+    label="A11Y proper label">
+    Content alignment
+  </uui-button>
+`;
+ContentAlignment.args = { '--uui-button-content-align': 'left' };
+ContentAlignment.parameters = {
+  controls: { include: ['--uui-button-content-align'] },
+  docs: {
+    source: {
+      code: `
+<uui-button style="max-width: 400px; width: 100%; --uui-button-content-align: left}"
+  look="primary"
+  color="danger"
+  label="A11Y proper label">
+  Content alignment
+</uui-button>
+      `,
+    },
+  },
+};

--- a/packages/uui-button/lib/uui-button.story.ts
+++ b/packages/uui-button/lib/uui-button.story.ts
@@ -40,6 +40,12 @@ export default {
       options: ['', 'submit', 'button', 'reset'],
       control: { type: 'select' },
     },
+    '--uui-button-content-align': {
+      control: {
+        type: 'select',
+      },
+      options: ['left', 'center', 'right'],
+    },
     state: {
       options: [null, 'waiting', 'success', 'failed'],
       control: { type: 'select' },
@@ -79,6 +85,7 @@ const cssProps = [
   '--uui-button-contrast-hover',
   '--uui-button-background-color-disabled',
   '--uui-button-contrast-disabled',
+  '--uui-button-content-align',
 ];
 
 const reducer = (prev: string, next: string, i: number) =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a css variable to adjust alignment of content in the button. `--uui-button-content-align` which accepts the following values: `left` `right` `center`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context
Some buttons needs to have left aligned content. An example is the external login providers on the login screen.

## Screenshots (if appropriate)
<img width="432" alt="image" src="https://github.com/umbraco/Umbraco.UI/assets/26099018/fca8c4d5-6d26-424b-aeb2-ddcf0af04147">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
