### PR TITLE
Add href to cards

### DIFF
--- a/packages/uui-card-content-node/lib/uui-card-content-node.element.ts
+++ b/packages/uui-card-content-node/lib/uui-card-content-node.element.ts
@@ -113,21 +113,37 @@ export class UUICardContentNodeElement extends UUICardElement {
     return html`<uui-icon .svg="${this.fallbackIcon}"></uui-icon>`;
   }
 
+  // This is deprecated - use href instead
+  #renderDeprecatedButton() {
+    return html`<div
+      id="open-part"
+      tabindex=${this.disabled ? (nothing as any) : 0}
+      @click=${this.handleOpenClick}
+      @keydown=${this.handleOpenKeydown}>
+      <span id="icon">
+        <slot name="icon" @slotchange=${this._onSlotIconChange}></slot>
+        ${this._iconSlotHasContent === false ? this._renderFallbackIcon() : ''}
+      </span>
+      <span id="name"> ${this.name} </span>
+    </div>`;
+  }
+
+  #renderLink() {
+    return html`<a
+      id="open-part"
+      tabindex=${this.disabled ? (nothing as any) : 0}
+      href=${this.href}>
+      <span id="icon">
+        <slot name="icon" @slotchange=${this._onSlotIconChange}></slot>
+        ${this._iconSlotHasContent === false ? this._renderFallbackIcon() : ''}
+      </span>
+      <span id="name"> ${this.name} </span>
+    </a>`;
+  }
+
   public render() {
     return html`
-      <div
-        id="open-part"
-        tabindex=${this.disabled ? (nothing as any) : 0}
-        @click=${this.handleOpenClick}
-        @keydown=${this.handleOpenKeydown}>
-        <span id="icon">
-          <slot name="icon" @slotchange=${this._onSlotIconChange}></slot>
-          ${this._iconSlotHasContent === false
-            ? this._renderFallbackIcon()
-            : ''}
-        </span>
-        <span id="name"> ${this.name} </span>
-      </div>
+      ${this.href ? this.#renderLink() : this.#renderDeprecatedButton()}
       <!-- Select border must be right after #open-part -->
       <div id="select-border"></div>
 

--- a/packages/uui-card-content-node/lib/uui-card-content-node.element.ts
+++ b/packages/uui-card-content-node/lib/uui-card-content-node.element.ts
@@ -113,8 +113,7 @@ export class UUICardContentNodeElement extends UUICardElement {
     return html`<uui-icon .svg="${this.fallbackIcon}"></uui-icon>`;
   }
 
-  // This is deprecated - use href instead
-  #renderDeprecatedButton() {
+  #renderButton() {
     return html`<div
       id="open-part"
       tabindex=${this.disabled ? (nothing as any) : 0}
@@ -143,7 +142,7 @@ export class UUICardContentNodeElement extends UUICardElement {
 
   public render() {
     return html`
-      ${this.href ? this.#renderLink() : this.#renderDeprecatedButton()}
+      ${this.href ? this.#renderLink() : this.#renderButton()}
       <!-- Select border must be right after #open-part -->
       <div id="select-border"></div>
 

--- a/packages/uui-card-content-node/lib/uui-card-content-node.element.ts
+++ b/packages/uui-card-content-node/lib/uui-card-content-node.element.ts
@@ -3,6 +3,7 @@ import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
 import { UUICardElement } from '@umbraco-ui/uui-card/lib';
 import { css, html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 /**
  *  @element uui-card-content-node
@@ -131,7 +132,11 @@ export class UUICardContentNodeElement extends UUICardElement {
     return html`<a
       id="open-part"
       tabindex=${this.disabled ? (nothing as any) : 0}
-      href=${this.href}>
+      href=${ifDefined(!this.disabled ? this.href : undefined)}
+      target=${ifDefined(this.target || undefined)}
+      rel=${ifDefined(
+        this.target === '_blank' ? 'noopener noreferrer' : undefined
+      )}>
       <span id="icon">
         <slot name="icon" @slotchange=${this._onSlotIconChange}></slot>
         ${this._iconSlotHasContent === false ? this._renderFallbackIcon() : ''}

--- a/packages/uui-card-content-node/lib/uui-card-content-node.story.ts
+++ b/packages/uui-card-content-node/lib/uui-card-content-node.story.ts
@@ -46,7 +46,9 @@ export const AAAOverview: Story = props => html`
     ?selectable=${props.selectable}
     ?selected=${props.selected}
     ?error=${props.error}
-    ?disabled=${props.disabled}>
+    ?disabled=${props.disabled}
+    href=${props.href}
+    target=${props.target}>
     <uui-tag size="s" slot="tag" color="positive">Published</uui-tag>
     ${cardContent}
   </uui-card-content-node>

--- a/packages/uui-card-media/lib/uui-card-media.element.ts
+++ b/packages/uui-card-media/lib/uui-card-media.element.ts
@@ -163,8 +163,7 @@ export class UUICardMediaElement extends UUICardElement {
       type="${this.fileExt}"></uui-symbol-file>`;
   }
 
-  // This is deprecated - use href instead
-  #renderDeprecatedButton() {
+  #renderButton() {
     return html`
       <button
         id="open-part"
@@ -206,7 +205,7 @@ export class UUICardMediaElement extends UUICardElement {
   public render() {
     return html` ${this.renderMedia()}
       <slot @slotchange=${this.queryPreviews}></slot>
-      ${this.href ? this.#renderLink() : this.#renderDeprecatedButton()}
+      ${this.href ? this.#renderLink() : this.#renderButton()}
       <!-- Select border must be right after .open-part -->
       <div id="select-border"></div>
 

--- a/packages/uui-card-media/lib/uui-card-media.element.ts
+++ b/packages/uui-card-media/lib/uui-card-media.element.ts
@@ -163,9 +163,9 @@ export class UUICardMediaElement extends UUICardElement {
       type="${this.fileExt}"></uui-symbol-file>`;
   }
 
-  public render() {
-    return html` ${this.renderMedia()}
-      <slot @slotchange=${this.queryPreviews}></slot>
+  // This is deprecated - use href instead
+  #renderDeprecatedButton() {
+    return html`
       <button
         id="open-part"
         tabindex=${this.disabled ? (nothing as any) : '0'}
@@ -181,6 +181,32 @@ export class UUICardMediaElement extends UUICardElement {
         -->
         <span>${this.name}</span>
       </button>
+    `;
+  }
+
+  #renderLink() {
+    return html`
+      <a
+        id="open-part"
+        href=${this.href}
+        tabindex=${this.disabled ? (nothing as any) : '0'}>
+        <!--
+        TODO: Implement when pop-out is ready
+        <uui-icon
+          id="info-icon"
+          name="info"
+          style="color: currentColor">
+        </uui-icon>
+        -->
+        <span>${this.name}</span>
+      </a>
+    `;
+  }
+
+  public render() {
+    return html` ${this.renderMedia()}
+      <slot @slotchange=${this.queryPreviews}></slot>
+      ${this.href ? this.#renderLink() : this.#renderDeprecatedButton()}
       <!-- Select border must be right after .open-part -->
       <div id="select-border"></div>
 

--- a/packages/uui-card-media/lib/uui-card-media.element.ts
+++ b/packages/uui-card-media/lib/uui-card-media.element.ts
@@ -3,6 +3,7 @@ import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
 import { UUICardElement } from '@umbraco-ui/uui-card/lib';
 import { css, html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 import '@umbraco-ui/uui-symbol-folder/lib';
 import '@umbraco-ui/uui-symbol-file/lib';
@@ -187,8 +188,12 @@ export class UUICardMediaElement extends UUICardElement {
     return html`
       <a
         id="open-part"
-        href=${this.href}
-        tabindex=${this.disabled ? (nothing as any) : '0'}>
+        tabindex=${this.disabled ? (nothing as any) : '0'}
+        href=${ifDefined(!this.disabled ? this.href : undefined)}
+        target=${ifDefined(this.target || undefined)}
+        rel=${ifDefined(
+          this.target === '_blank' ? 'noopener noreferrer' : undefined
+        )}>
         <!--
         TODO: Implement when pop-out is ready
         <uui-icon

--- a/packages/uui-card-media/lib/uui-card-media.story.ts
+++ b/packages/uui-card-media/lib/uui-card-media.story.ts
@@ -26,7 +26,9 @@ export const AAAOverview: Story = props => html`
     ?selectable=${props.selectable}
     ?selected=${props.selected}
     ?error=${props.error}
-    ?disabled=${props.disabled}></uui-card-media>
+    ?disabled=${props.disabled}
+    href=${props.href}
+    target=${props.target}></uui-card-media>
 `;
 AAAOverview.storyName = 'Overview';
 

--- a/packages/uui-card-user/lib/uui-card-user.element.ts
+++ b/packages/uui-card-user/lib/uui-card-user.element.ts
@@ -3,6 +3,7 @@ import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
 import { UUICardElement } from '@umbraco-ui/uui-card/lib';
 import { css, html, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 /**
  *  @element uui-card-user
@@ -119,7 +120,11 @@ export class UUICardUserElement extends UUICardElement {
     return html`<a
       id="open-part"
       tabindex=${this.disabled ? (nothing as any) : '0'}
-      href=${this.href}>
+      href=${ifDefined(!this.disabled ? this.href : undefined)}
+      target=${ifDefined(this.target || undefined)}
+      rel=${ifDefined(
+        this.target === '_blank' ? 'noopener noreferrer' : undefined
+      )}>
       <span>${this.name}</span>
     </a>`;
   }

--- a/packages/uui-card-user/lib/uui-card-user.element.ts
+++ b/packages/uui-card-user/lib/uui-card-user.element.ts
@@ -105,16 +105,30 @@ export class UUICardUserElement extends UUICardElement {
     demandCustomElement(this, 'uui-avatar');
   }
 
+  // This is deprecated - use href instead
+  #renderDeprecatedButton() {
+    return html`<div
+      id="open-part"
+      tabindex=${this.disabled ? (nothing as any) : '0'}
+      @click=${this.handleOpenClick}
+      @keydown=${this.handleOpenKeydown}>
+      <span> ${this.name} </span>
+    </div>`;
+  }
+
+  #renderLink() {
+    return html`<a
+      id="open-part"
+      tabindex=${this.disabled ? (nothing as any) : '0'}
+      href=${this.href}>
+      <span>${this.name}</span>
+    </a>`;
+  }
+
   public render() {
     return html`
       <uui-avatar id="avatar" name=${this.name} size="m"></uui-avatar>
-      <div
-        id="open-part"
-        tabindex=${this.disabled ? (nothing as any) : '0'}
-        @click=${this.handleOpenClick}
-        @keydown=${this.handleOpenKeydown}>
-        <span> ${this.name} </span>
-      </div>
+      ${this.href ? this.#renderLink() : this.#renderDeprecatedButton()}
       <slot></slot>
       <slot name="tag"></slot>
       <slot name="actions"></slot>

--- a/packages/uui-card-user/lib/uui-card-user.element.ts
+++ b/packages/uui-card-user/lib/uui-card-user.element.ts
@@ -105,8 +105,7 @@ export class UUICardUserElement extends UUICardElement {
     demandCustomElement(this, 'uui-avatar');
   }
 
-  // This is deprecated - use href instead
-  #renderDeprecatedButton() {
+  #renderButton() {
     return html`<div
       id="open-part"
       tabindex=${this.disabled ? (nothing as any) : '0'}
@@ -128,7 +127,7 @@ export class UUICardUserElement extends UUICardElement {
   public render() {
     return html`
       <uui-avatar id="avatar" name=${this.name} size="m"></uui-avatar>
-      ${this.href ? this.#renderLink() : this.#renderDeprecatedButton()}
+      ${this.href ? this.#renderLink() : this.#renderButton()}
       <slot></slot>
       <slot name="tag"></slot>
       <slot name="actions"></slot>

--- a/packages/uui-card-user/lib/uui-card-user.story.ts
+++ b/packages/uui-card-user/lib/uui-card-user.story.ts
@@ -34,7 +34,9 @@ const Template: StoryFn = props => html`
     ?select-only=${props.selectOnly}
     ?selected=${props.selected}
     ?error=${props.error}
-    ?disabled=${props.disabled}>
+    ?disabled=${props.disabled}
+    href=${props.href}
+    target=${props.target}>
     ${cardContent}
   </uui-card-user>
 `;

--- a/packages/uui-card/lib/uui-card.element.ts
+++ b/packages/uui-card/lib/uui-card.element.ts
@@ -97,6 +97,11 @@ export class UUICardElement extends SelectOnlyMixin(
       :host([select-only]) ::slotted(*) {
         pointer-events: none;
       }
+
+      a {
+        text-decoration: none;
+        color: inherit;
+      }
     `,
   ];
 
@@ -119,12 +124,23 @@ export class UUICardElement extends SelectOnlyMixin(
   @property({ type: Boolean, reflect: true })
   error = false;
 
+  /**
+   * Determines the path to navigate to when certain part of card is clicked.
+   * @type {string}
+   * @attr href
+   * @default '''
+   */
+  @property({ type: String, reflect: true })
+  href = '';
+
+  // This is deprecated - use href instead
   protected handleOpenClick(e: Event) {
     if (this.disabled) return;
 
     e.stopPropagation();
     this.dispatchEvent(new UUICardEvent(UUICardEvent.OPEN));
   }
+  // This is deprecated - use href instead
   protected handleOpenKeydown(e: KeyboardEvent) {
     if (this.disabled) return;
     if (e.key !== 'Enter') return;

--- a/packages/uui-card/lib/uui-card.element.ts
+++ b/packages/uui-card/lib/uui-card.element.ts
@@ -125,13 +125,22 @@ export class UUICardElement extends SelectOnlyMixin(
   error = false;
 
   /**
-   * Determines the path to navigate to when certain part of card is clicked.
+   * Set an href, this will turns the name of the card into an anchor tag.
    * @type {string}
-   * @attr href
-   * @default '''
+   * @attr
+   * @default undefined
    */
-  @property({ type: String, reflect: true })
-  href = '';
+  @property({ type: String })
+  public href?: string;
+
+  /**
+   * Set an anchor tag target, only used when using href.
+   * @type {string}
+   * @attr
+   * @default undefined
+   */
+  @property({ type: String })
+  public target?: '_blank' | '_parent' | '_self' | '_top';
 
   // This is deprecated - use href instead
   protected handleOpenClick(e: Event) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds  href property to all cards, which should be used instead of the button click event. However this is non-breaking so already implemented still works.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
