### PR TITLE
Remove Microsoft Edge "Reveal" icon from password field

### DIFF
--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -163,6 +163,10 @@ export class UUIInputElement extends FormControlMixin(
         display: none;
       }
 
+      input[type='password']::-ms-reveal {
+        display: none;
+      }
+
       :host(:not([readonly])) input:focus::placeholder {
         opacity: 0;
       }

--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -158,6 +158,11 @@ export class UUIInputElement extends FormControlMixin(
       input::placeholder {
         transition: opacity 120ms;
       }
+
+      input[type='password']::-ms-reveal {
+        display: none;
+      }
+
       :host(:not([readonly])) input:focus::placeholder {
         opacity: 0;
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Toying with the new backoffice I discovered that a custom "Reveal" password icon is being shown in Edge making it a weird "double" feature thing. I've added a the ::ms-reveal pseudo selector to ensure it's hidden and only the custom "Eye" icon will be displayed in Edge.

**Before**
![edge-password-reveal](https://github.com/umbraco/Umbraco.UI/assets/1932158/d0ae8e1b-fa7d-4996-bd14-c3a5ce2df727)

**After**
![edge-password-reveal-removed](https://github.com/umbraco/Umbraco.UI/assets/1932158/330345d4-2a21-42a9-9baa-82b1d2a4e2d0)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
