### PR TITLE
Bugfix/modal missing close event

### DIFF
--- a/packages/uui-modal/lib/uui-modal.element.ts
+++ b/packages/uui-modal/lib/uui-modal.element.ts
@@ -18,11 +18,11 @@ export class UUIModalElement extends LitElement {
 
   private _transitionDuration = 250;
 
-  @property()
+  @property({ type: Number, attribute: 'transition-duration' })
   public get transitionDuration() {
     return this._transitionDuration;
   }
-  public set transitionDuration(value) {
+  public set transitionDuration(value: number) {
     this._transitionDuration = value;
     this.style.setProperty(
       '--uui-modal-transition-duration',
@@ -45,7 +45,6 @@ export class UUIModalElement extends LitElement {
     event?.stopImmediatePropagation();
 
     const openEvent = new CustomEvent('open', {
-      bubbles: true,
       cancelable: true,
     });
 
@@ -60,7 +59,6 @@ export class UUIModalElement extends LitElement {
     event?.stopImmediatePropagation();
 
     const closeEvent = new CustomEvent('close', {
-      bubbles: true,
       cancelable: true,
     });
     this.dispatchEvent(closeEvent);
@@ -81,11 +79,7 @@ export class UUIModalElement extends LitElement {
     this.isOpen = false;
     this._dialogElement?.close();
 
-    const closeEndEvent = new CustomEvent('close-end', {
-      bubbles: true,
-      cancelable: true,
-    });
-    this.dispatchEvent(closeEndEvent);
+    this.dispatchEvent(new CustomEvent('close-end'));
 
     this.remove();
   }

--- a/packages/uui-modal/lib/uui-modal.element.ts
+++ b/packages/uui-modal/lib/uui-modal.element.ts
@@ -80,6 +80,13 @@ export class UUIModalElement extends LitElement {
     this.isClosing = true;
     this.isOpen = false;
     this._dialogElement?.close();
+
+    const closeEndEvent = new CustomEvent('close-end', {
+      bubbles: true,
+      cancelable: true,
+    });
+    this.dispatchEvent(closeEndEvent);
+
     this.remove();
   }
 

--- a/packages/uui-modal/lib/uui-modal.mdx
+++ b/packages/uui-modal/lib/uui-modal.mdx
@@ -91,6 +91,10 @@ Dispatched on first render. This will set open to true and show the modal. Can b
 Dispatched when the modal is closed. Can be cancelled if you want to prevent the modal from closing. But then you'll have to manually call `_closeModal()` when you want to close the modal.
 This is used in the `uui-modal-sidebar` to wait for the animation to finish before removing the modal from the DOM.
 
+#### `close-end`
+
+This event is triggered before removing the component from the DOM, either after animations or delays or when `_closeModal()` is manually invoked.
+
 ### CSS Variables
 
 ---


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Reinstates the close-end event, which is dispatched after close animations or delays right before the component is removed from the dom

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
