### PR TITLE
#599 Fix : Incorrect links from readme to components in Storybook 

### DIFF
--- a/packages/uui-action-bar/README.md
+++ b/packages/uui-action-bar/README.md
@@ -6,7 +6,7 @@ Umbraco style action-bar component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-action-bar)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-action-bar--docs)
 
 ## Installation
 

--- a/packages/uui-avatar-group/README.md
+++ b/packages/uui-avatar-group/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-avatar-group)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-avatar-group--docs)
 
 ## Installation
 

--- a/packages/uui-avatar/README.md
+++ b/packages/uui-avatar/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-avatar)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-avatar--docs)
 
 ## Installation
 

--- a/packages/uui-badge/README.md
+++ b/packages/uui-badge/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-badge)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-badge--docs)
 
 ## Installation
 

--- a/packages/uui-box/README.md
+++ b/packages/uui-box/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-box)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-box--docs)
 
 ## Installation
 

--- a/packages/uui-breadcrumbs/README.md
+++ b/packages/uui-breadcrumbs/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-breadcrumbs)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-breadcrumbs--docs)
 
 ## Installation
 

--- a/packages/uui-button-group/README.md
+++ b/packages/uui-button-group/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-button-group)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-button-group--docs)
 
 ## Installation
 

--- a/packages/uui-button-inline-create/README.md
+++ b/packages/uui-button-inline-create/README.md
@@ -6,7 +6,7 @@ Umbraco style button-inline-create component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-button-inline-create)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-button-inline-create--docs)
 
 ## Installation
 

--- a/packages/uui-button/README.md
+++ b/packages/uui-button/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-button)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-button--docs)
 
 ## Installation
 

--- a/packages/uui-card-content-node/README.md
+++ b/packages/uui-card-content-node/README.md
@@ -6,7 +6,7 @@ Umbraco style card-content-node component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-card-content-node)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-card-content-node--docs)
 
 ## Installation
 

--- a/packages/uui-card-media/README.md
+++ b/packages/uui-card-media/README.md
@@ -6,7 +6,7 @@ Umbraco style card-media component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-card-media)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-card-media--docs)
 
 ## Installation
 

--- a/packages/uui-card-user/README.md
+++ b/packages/uui-card-user/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-card-user)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-card-user--docs)
 
 ## Usage
 

--- a/packages/uui-card/README.md
+++ b/packages/uui-card/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-card)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-card--docs)
 
 ## Installation
 

--- a/packages/uui-caret/README.md
+++ b/packages/uui-caret/README.md
@@ -6,7 +6,7 @@ Umbraco style caret component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-caret)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-caret--docs)
 
 ## Installation
 

--- a/packages/uui-checkbox/README.md
+++ b/packages/uui-checkbox/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-checkbox)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-checkbox--docs)
 
 ## Installation
 

--- a/packages/uui-combobox-list/README.md
+++ b/packages/uui-combobox-list/README.md
@@ -6,7 +6,7 @@ Umbraco style combobox-list component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-combobox-list)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-combobox-list--docs)
 
 ## Installation
 

--- a/packages/uui-combobox/README.md
+++ b/packages/uui-combobox/README.md
@@ -6,7 +6,7 @@ Umbraco style combo-box component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-combobox)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-combobox--docs)
 
 ## Installation
 

--- a/packages/uui-css/README.md
+++ b/packages/uui-css/README.md
@@ -15,7 +15,7 @@ Bundle:
 
 ### See it in action
 
-Preview on [Storybook](https://uui.umbraco.com/?path=/story/uui-)
+Preview on [Storybook](https://uui.umbraco.com/?path=/docs/uui-)
 
 # Usage in your project
 

--- a/packages/uui-dialog-layout/README.md
+++ b/packages/uui-dialog-layout/README.md
@@ -6,7 +6,7 @@ Umbraco style dialog-layout component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-dialog-layout)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-dialog-layout--docs)
 
 ## Installation
 

--- a/packages/uui-dialog/README.md
+++ b/packages/uui-dialog/README.md
@@ -6,7 +6,7 @@ Umbraco style dialog component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-dialog)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-dialog--docs)
 
 ## Installation
 

--- a/packages/uui-file-dropzone/README.md
+++ b/packages/uui-file-dropzone/README.md
@@ -6,7 +6,7 @@ Umbraco style file-dropzone component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-file-dropzone)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-file-dropzone--docs)
 
 ## Installation
 

--- a/packages/uui-file-preview/README.md
+++ b/packages/uui-file-preview/README.md
@@ -6,7 +6,7 @@ Umbraco style file-preview component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-file-preview)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-file-preview--docs)
 
 ## Installation
 

--- a/packages/uui-form-layout-item/README.md
+++ b/packages/uui-form-layout-item/README.md
@@ -6,7 +6,7 @@ Umbraco style uui-form-layout-item component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-form-layout-item)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-form-layout-item--docs)
 
 ## Installation
 

--- a/packages/uui-form-validation-message/README.md
+++ b/packages/uui-form-validation-message/README.md
@@ -6,7 +6,7 @@ Umbraco style form-validation-message component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-form-validation-message)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-form-validation-message--docs)
 
 ## Installation
 

--- a/packages/uui-form/README.md
+++ b/packages/uui-form/README.md
@@ -6,7 +6,7 @@ Umbraco style form component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-form)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-form--docs)
 
 ## Installation
 

--- a/packages/uui-icon-registry-essential/README.md
+++ b/packages/uui-icon-registry-essential/README.md
@@ -6,7 +6,7 @@ Umbraco style icon-registry-essential component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-icon-registry-essential)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-icon-registry-essential--docs)
 
 ## Installation
 

--- a/packages/uui-icon-registry/README.md
+++ b/packages/uui-icon-registry/README.md
@@ -6,7 +6,7 @@ Umbraco style icon-registry component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-icon-registry)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-icon-registry--docs)
 
 ## Installation
 

--- a/packages/uui-icon/README.md
+++ b/packages/uui-icon/README.md
@@ -6,7 +6,7 @@ Umbraco style icon component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-icon)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-icon--docs)
 
 ## Installation
 

--- a/packages/uui-input-file/README.md
+++ b/packages/uui-input-file/README.md
@@ -6,7 +6,7 @@ Umbraco style input-file component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-input-file)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-input-file--docs)
 
 ## Installation
 

--- a/packages/uui-input-lock/README.md
+++ b/packages/uui-input-lock/README.md
@@ -6,7 +6,7 @@ Umbraco style input-lock component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-input-lock)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-input-lock--docs)
 
 ## Installation
 

--- a/packages/uui-input-password/README.md
+++ b/packages/uui-input-password/README.md
@@ -6,7 +6,7 @@ Umbraco style input-password component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-input-password)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-input-password--docs)
 
 ## Installation
 

--- a/packages/uui-input/README.md
+++ b/packages/uui-input/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-input)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-input--docs)
 
 ## Installation
 

--- a/packages/uui-keyboard-shortcut/README.md
+++ b/packages/uui-keyboard-shortcut/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-keyboard-shortcut)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-keyboard-shortcut--docs)
 
 ## Installation
 

--- a/packages/uui-label/README.md
+++ b/packages/uui-label/README.md
@@ -6,7 +6,7 @@ Umbraco style label component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-label)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-label--docs)
 
 ## Installation
 

--- a/packages/uui-loader-bar/README.md
+++ b/packages/uui-loader-bar/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-loader-bar)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-loader-bar--docs)
 
 ## Installation
 

--- a/packages/uui-loader-circle/README.md
+++ b/packages/uui-loader-circle/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-loader-circle)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-loader-circle--docs)
 
 ## Installation
 

--- a/packages/uui-loader/README.md
+++ b/packages/uui-loader/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-loader)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-loader--docs)
 
 ## Installation
 

--- a/packages/uui-menu-item/README.md
+++ b/packages/uui-menu-item/README.md
@@ -6,7 +6,7 @@ Umbraco style menu-item component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-menu-item)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-menu-item--docs)
 
 ## Installation
 

--- a/packages/uui-pagination/README.md
+++ b/packages/uui-pagination/README.md
@@ -6,7 +6,7 @@ Umbraco style pagination component. By implementing a resizeObserver it changes 
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-pagination)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-pagination--docs)
 
 ## Installation
 

--- a/packages/uui-popover/README.md
+++ b/packages/uui-popover/README.md
@@ -6,7 +6,7 @@ Umbraco style popover component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-popover)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-popover--docs)
 
 ## Installation
 

--- a/packages/uui-progress-bar/README.md
+++ b/packages/uui-progress-bar/README.md
@@ -6,7 +6,7 @@ Umbraco style progress-bar component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-progress-bar)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-progress-bar--docs)
 
 ## Installation
 

--- a/packages/uui-radio/README.md
+++ b/packages/uui-radio/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-radio)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-radio--docs)
 
 ## Installation
 

--- a/packages/uui-ref-list/README.md
+++ b/packages/uui-ref-list/README.md
@@ -6,7 +6,7 @@ Umbraco style ref-list component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-ref-list)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/displays-reference-list--docs)
 
 ## Installation
 

--- a/packages/uui-ref-node-data-type/README.md
+++ b/packages/uui-ref-node-data-type/README.md
@@ -6,7 +6,7 @@ Umbraco style ref-node-data-type component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-ref-node-data-type)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-ref-node-data-type--docs)
 
 ## Installation
 

--- a/packages/uui-ref-node-document-type/README.md
+++ b/packages/uui-ref-node-document-type/README.md
@@ -6,7 +6,7 @@ Umbraco style ref-node-document-type component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-ref-node-document-type)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-ref-node-document-type--docs)
 
 ## Installation
 

--- a/packages/uui-ref-node-form/README.md
+++ b/packages/uui-ref-node-form/README.md
@@ -6,7 +6,7 @@ Umbraco style ref-node-form component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-ref-node-form)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-ref-node-form--docs)
 
 ## Installation
 

--- a/packages/uui-ref-node-member/README.md
+++ b/packages/uui-ref-node-member/README.md
@@ -6,7 +6,7 @@ Umbraco style ref-node-member component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-ref-node-member)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-ref-node-member--docs)
 
 ## Installation
 

--- a/packages/uui-ref-node-package/README.md
+++ b/packages/uui-ref-node-package/README.md
@@ -6,7 +6,7 @@ Umbraco style ref-node-package component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-ref-node-package)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-ref-node-package--docs)
 
 ## Installation
 

--- a/packages/uui-ref-node-user/README.md
+++ b/packages/uui-ref-node-user/README.md
@@ -6,7 +6,7 @@ Umbraco style ref-node-user component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-ref-node-user)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-ref-node-user--docs)
 
 ## Installation
 

--- a/packages/uui-ref-node/README.md
+++ b/packages/uui-ref-node/README.md
@@ -6,7 +6,7 @@ Umbraco style ref-node component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-ref-node)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-ref-node--docs)
 
 ## Installation
 

--- a/packages/uui-ref/README.md
+++ b/packages/uui-ref/README.md
@@ -6,7 +6,7 @@ Umbraco style ref component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-ref)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-ref--docs)
 
 ## Installation
 

--- a/packages/uui-scroll-container/README.md
+++ b/packages/uui-scroll-container/README.md
@@ -6,7 +6,7 @@ Umbraco style scroll-container component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-scroll-container)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-scroll-container--docs)
 
 ## Installation
 

--- a/packages/uui-select/README.md
+++ b/packages/uui-select/README.md
@@ -6,7 +6,7 @@ Umbraco style select component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-select)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-select--docs)
 
 ## Installation
 

--- a/packages/uui-slider/README.md
+++ b/packages/uui-slider/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-slider)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-slider--docs)
 
 ## Installation
 

--- a/packages/uui-symbol-expand/README.md
+++ b/packages/uui-symbol-expand/README.md
@@ -6,7 +6,7 @@ Umbraco style expand symbol component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-symbol-expand)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-symbol-expand--docs)
 
 ## Installation
 

--- a/packages/uui-symbol-file/README.md
+++ b/packages/uui-symbol-file/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-symbol-file)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-symbol-file--docs)
 
 ## Usage
 

--- a/packages/uui-symbol-folder/README.md
+++ b/packages/uui-symbol-folder/README.md
@@ -6,7 +6,7 @@ Umbraco style symbol-folder component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-symbol-folder)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-symbol-folder--docs)
 
 ## Usage
 

--- a/packages/uui-symbol-more/README.md
+++ b/packages/uui-symbol-more/README.md
@@ -6,7 +6,7 @@ Umbraco style symbol-more component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-symbol-more)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-symbol-more--docs)
 
 ## Installation
 

--- a/packages/uui-symbol-sort/README.md
+++ b/packages/uui-symbol-sort/README.md
@@ -6,7 +6,7 @@ Umbraco style sort-symbol component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-symbol-sort)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-symbol-sort--docs)
 
 ## Installation
 

--- a/packages/uui-table/README.md
+++ b/packages/uui-table/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-table)
+Preview the component on [Storybook](hhttps://uui.umbraco.com/?path=/docs/uui-table--docs)
 
 ## Installation
 

--- a/packages/uui-tabs/README.md
+++ b/packages/uui-tabs/README.md
@@ -4,7 +4,7 @@
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-tabs)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-tabs--docs)
 
 ## Installation
 

--- a/packages/uui-tag/README.md
+++ b/packages/uui-tag/README.md
@@ -6,7 +6,7 @@ Tag component from Umbraco UI components library.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-tag)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-tag--docs)
 
 ## Installation
 

--- a/packages/uui-textarea/README.md
+++ b/packages/uui-textarea/README.md
@@ -6,7 +6,7 @@ Umbraco style textarea component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-textarea)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-textarea--docs)
 
 ## Installation
 

--- a/packages/uui-toast-notification-container/README.md
+++ b/packages/uui-toast-notification-container/README.md
@@ -6,7 +6,7 @@ Umbraco style toast-notification-container component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-toast-notification-container)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-toast-notification-container--docs)
 
 ## Installation
 

--- a/packages/uui-toast-notification-layout/README.md
+++ b/packages/uui-toast-notification-layout/README.md
@@ -6,7 +6,7 @@ Umbraco style toast-notification-layout component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-toast-notification-layout)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-toast-notification-layout--docs)
 
 ## Installation
 

--- a/packages/uui-toast-notification/README.md
+++ b/packages/uui-toast-notification/README.md
@@ -6,7 +6,7 @@ Umbraco style toast-notification component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-toast-notification)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-toast-notification--docs)
 
 ## Installation
 

--- a/packages/uui-toggle/README.md
+++ b/packages/uui-toggle/README.md
@@ -6,7 +6,7 @@ Umbraco style toggle component.
 
 ### See it in action
 
-Preview the component on [Storybook](https://uui.umbraco.com/?path=/story/uui-toggle)
+Preview the component on [Storybook](https://uui.umbraco.com/?path=/docs/uui-toggle--docs)
 
 ## Installation
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe the changes in detail -->

Example: change of URL from 'https://uui.umbraco.com/?path=/story/uui-box' to 'https://uui.umbraco.com/?path=/docs/uui-box--docs' in the uui-box readme file

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Bug: https://github.com/umbraco/Umbraco.UI/issues/599

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
