### PR TITLE
Remove whitespace before semicolon when generating new package

### DIFF
--- a/templates/plop-templates/component.ts.hbs
+++ b/templates/plop-templates/component.ts.hbs
@@ -23,6 +23,6 @@ export class {{className name}} extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    '{{> tagnamePartial }}': {{className name}} ;
+    '{{> tagnamePartial }}': {{className name}};
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I noticed when generating a new package the component has a whitespace, but later the linter warns about the formatting here.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
