### PR TITLE
Set aria-hidden if no label has been set

### DIFF
--- a/packages/uui-icon/lib/uui-icon.element.ts
+++ b/packages/uui-icon/lib/uui-icon.element.ts
@@ -44,6 +44,15 @@ export class UUIIconElement extends LitElement {
   private _nameSvg: string | null = null;
 
   /**
+   * An alternate description to use for assistive devices.
+   * If omitted, the icon will be considered presentational and ignored by assistive devices.
+   * @type {string}
+   * @attr
+   * @default
+   */
+  @property() label = '';
+
+  /**
    * Icon name is used to retrieve the icon from a parent Icon Registry.
    * If no Icon Registry responds to the given name, the fallback svg will be used.
    * @type {string}
@@ -60,6 +69,7 @@ export class UUIIconElement extends LitElement {
       this.requestIcon();
     }
   }
+
   private requestIcon() {
     if (this._name !== '' && this._name !== null) {
       const event = new UUIIconRequestEvent(UUIIconRequestEvent.ICON_REQUEST, {
@@ -116,6 +126,19 @@ export class UUIIconElement extends LitElement {
     if (this._retrievedNameIcon === false) {
       this.requestIcon();
     }
+
+    const hasLabel = typeof this.label === 'string' && this.label.length > 0;
+
+    if (hasLabel) {
+      this.setAttribute('role', 'img');
+      this.setAttribute('aria-label', this.label);
+      this.removeAttribute('aria-hidden');
+    } else {
+      this.removeAttribute('role');
+      this.removeAttribute('aria-label');
+      this.setAttribute('aria-hidden', 'true');
+    }
+    
   }
 
   render() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add option to set alternative label of icon. If no label has been set, it will set `aria-hidden` attribute.
Discussed in https://github.com/umbraco/Umbraco-CMS/pull/14780#discussion_r1341254646

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
