### PR TITLE
Make radiobutton focusable

### DIFF
--- a/packages/uui-radio/lib/uui-radio.element.ts
+++ b/packages/uui-radio/lib/uui-radio.element.ts
@@ -155,7 +155,7 @@ export class UUIRadioElement extends LitElement {
   }
 
   render() {
-    return html` <label>
+    return html `<label>
       <input
         id="input"
         type="radio"
@@ -278,6 +278,10 @@ export class UUIRadioElement extends LitElement {
       input:focus + #button {
         outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
           var(--uui-color-focus);
+      }
+
+      :host(:focus) {
+        outline: none;
       }
 
       :host([disabled]) label {

--- a/packages/uui-radio/lib/uui-radio.element.ts
+++ b/packages/uui-radio/lib/uui-radio.element.ts
@@ -49,13 +49,13 @@ export class UUIRadioElement extends LitElement {
     const oldValue = this._checked;
     this._checked = value;
     if (value === true) {
-      this.setAttribute('aria-checked', '');
+      this.setAttribute('aria-checked', 'true');
       if (!this.disabled) {
         this.setAttribute('tabindex', '0');
       }
     } else {
-      this.setAttribute('tabindex', '-1');
-      this.removeAttribute('aria-checked');
+      //this.setAttribute('tabindex', '-1');
+      this.setAttribute('aria-checked', 'false');
     }
     this.requestUpdate('checked', oldValue);
   }
@@ -76,7 +76,7 @@ export class UUIRadioElement extends LitElement {
     this._disabled = newVal;
 
     this.setAttribute('aria-hidden', newVal ? 'true' : 'false');
-    this.setAttribute('tabindex', newVal ? '-1' : '0');
+    //this.setAttribute('tabindex', newVal ? '-1' : '0');
     this.requestUpdate('disabled', oldVal);
   }
   private _disabled = false;
@@ -113,7 +113,7 @@ export class UUIRadioElement extends LitElement {
   }
 
   /**
-   * Call to uncheck the element. This method changes the tabindex and aria -checked attributes.
+   * Call to uncheck the element. This method changes the tabindex and aria-checked attributes.
    * @method uncheck
    */
   public uncheck() {
@@ -151,7 +151,7 @@ export class UUIRadioElement extends LitElement {
     //if (!this.hasAttribute('role')) this.setAttribute('role', 'radio');
     if (!this.hasAttribute('tabindex')) this.setAttribute('tabindex', '-1');
     if (!this.hasAttribute('aria-checked'))
-      this.removeAttribute('aria-checked');
+      this.setAttribute('aria-checked', 'false');
   }
 
   render() {
@@ -229,16 +229,34 @@ export class UUIRadioElement extends LitElement {
         transition: all 0.15s ease-in-out;
       }
 
-      :host(:hover) #button {
-        border: 1px solid var(--uui-color-border-emphasis);
+      label:hover input:not([disabled]) + #button {
+        border-color: var(
+          --uui-checkbox-border-color-hover,
+          var(--uui-color-border-emphasis)
+        );
+        background-color: var(
+          --uui-checkbox-background-color-hover,
+          var(--uui-color-surface-emphasis)
+        );
       }
-
-      :host(:focus) {
-        outline: none;
+      label:focus #button {
+        border-color: var(
+          --uui-checkbox-border-color-focus,
+          var(--uui-color-border-emphasis)
+        );
+        background-color: var(
+          --uui-checkbox-background-color-focus,
+          var(--uui-color-surface-emphasis)
+        );
       }
-      :host(:focus) #button {
-        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
-          var(--uui-color-focus);
+      input:checked:not([disabled]) + #button {
+        border-color: var(--uui-color-selected);
+      }
+      label:hover input:checked:not([disabled]) + #button {
+        border-color: var(--uui-color-selected-emphasis);
+      }
+      label:focus input:checked + #button {
+        border-color: var(--uui-color-selected-emphasis);
       }
 
       input:checked ~ #button::after {
@@ -255,6 +273,11 @@ export class UUIRadioElement extends LitElement {
 
       input:checked:hover ~ #button::after {
         background-color: var(--uui-color-selected-emphasis);
+      }
+
+      input:focus + #button {
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+          var(--uui-color-focus);
       }
 
       :host([disabled]) label {

--- a/packages/uui-radio/lib/uui-radio.element.ts
+++ b/packages/uui-radio/lib/uui-radio.element.ts
@@ -149,7 +149,7 @@ export class UUIRadioElement extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     //if (!this.hasAttribute('role')) this.setAttribute('role', 'radio');
-    if (!this.hasAttribute('tabindex')) this.setAttribute('tabindex', '-1');
+    //if (!this.hasAttribute('tabindex')) this.setAttribute('tabindex', '-1');
     if (!this.hasAttribute('aria-checked'))
       this.setAttribute('aria-checked', 'false');
   }

--- a/packages/uui-radio/lib/uui-radio.element.ts
+++ b/packages/uui-radio/lib/uui-radio.element.ts
@@ -54,7 +54,7 @@ export class UUIRadioElement extends LitElement {
         this.setAttribute('tabindex', '0');
       }
     } else {
-      //this.setAttribute('tabindex', '-1');
+      this.setAttribute('tabindex', '-1');
       this.setAttribute('aria-checked', 'false');
     }
     this.requestUpdate('checked', oldValue);
@@ -76,7 +76,7 @@ export class UUIRadioElement extends LitElement {
     this._disabled = newVal;
 
     this.setAttribute('aria-hidden', newVal ? 'true' : 'false');
-    //this.setAttribute('tabindex', newVal ? '-1' : '0');
+    this.setAttribute('tabindex', newVal ? '-1' : '0');
     this.requestUpdate('disabled', oldVal);
   }
   private _disabled = false;
@@ -127,6 +127,7 @@ export class UUIRadioElement extends LitElement {
   public check() {
     this.checked = true;
   }
+
   /**
    * Call to make the element focusable, this sets tabindex to 0.
    * @method makeFocusable
@@ -136,8 +137,9 @@ export class UUIRadioElement extends LitElement {
       this.setAttribute('tabindex', '0');
     }
   }
+
   /**
-   * Call to make the element focusable, this sets tabindex to 0.
+   * Call to make the element focusable, this sets tabindex to -1.
    * @method makeUnfocusable
    */
   public makeUnfocusable() {
@@ -149,7 +151,7 @@ export class UUIRadioElement extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     //if (!this.hasAttribute('role')) this.setAttribute('role', 'radio');
-    //if (!this.hasAttribute('tabindex')) this.setAttribute('tabindex', '-1');
+    if (!this.hasAttribute('tabindex')) this.setAttribute('tabindex', '-1');
     if (!this.hasAttribute('aria-checked'))
       this.setAttribute('aria-checked', 'false');
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

~~Not sure why the radiobutton is different from checkbox and set `tabindex="-1"` which mean it isn't focusable when none of the radiobuttons are checked.
So it wasn't possible to set focus on radiobutton and check this via space key.~~
It seems there a single radiobutton isn't focusable because of `tabindex="-1"` on host element unlike checkbox, but use in radiobutton group to focus only a single element (first or selected item).

I think much of the styling could be cleaned up (maybe there should be some base styling to import, so we don't need to write the same CSS regarding much of the custom outline styling).

In both radiobutton and checkbox (extending boolean input) the structure is like the following:

```
<label>
    <input
      id="input"
      type="checkbox|radio"
      name=${this.name}
      value=${this.value}
      .checked=${this.checked}
      .disabled=${this.disabled}
      @change=${this._onChange} />
    <div id="button|ticker"></div>
    Label text here...
</label>
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
