### PR TITLE
Added missing bracket to uui-radio story

### DIFF
--- a/packages/uui-radio/lib/uui-radio.story.ts
+++ b/packages/uui-radio/lib/uui-radio.story.ts
@@ -161,7 +161,7 @@ RadioGroup.parameters = {
       label="Other (Please state)"
       >
   </uui-radio>
-</uui-radio-group
+</uui-radio-group>
 `,
     },
   },


### PR DESCRIPTION
## Description

While going through the storybook I noticed a missing bracket in one of the radio button code examples.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

The missing bracket was causing the example code to not be correctly highlighted and if you used the "copy" functionality you would be copying malformed html.

## How to test?

https://uui.umbraco.com/?path=/docs/uui-radio--docs#radio-group

## Screenshots (if appropriate)

![image](https://github.com/umbraco/Umbraco.UI/assets/12862535/4d9e3ccb-6737-46b2-866f-a57f2894e09b)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/dev/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
