### PR TITLE
text area autoheight fix

### DIFF
--- a/packages/uui-textarea/lib/uui-textarea.element.ts
+++ b/packages/uui-textarea/lib/uui-textarea.element.ts
@@ -304,6 +304,7 @@ export class UUITextareaElement extends FormControlMixin(LitElement) {
 
       textarea {
         font-family: inherit;
+        line-height: var(--uui-size-6);
         box-sizing: border-box;
         min-width: 100%;
         max-width: 100%;


### PR DESCRIPTION
## Description

Fixes the issue where the height of textarea would render incorrectly on initial load, if textarea is set to "auto-height" and the initial value is multiple lines long.

The bug was caused by something related to the font family inherited. Fixed the issue by setting an initial line height of textarea.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
