### PR TITLE
Align uui-select with other inputs

### DIFF
--- a/packages/uui-form/lib/uui-form.story.ts
+++ b/packages/uui-form/lib/uui-form.story.ts
@@ -8,6 +8,12 @@ import '@umbraco-ui/uui-slider/lib';
 import '@umbraco-ui/uui-radio/lib';
 import '@umbraco-ui/uui-toggle/lib';
 import '@umbraco-ui/uui-button/lib';
+import '@umbraco-ui/uui-input/lib';
+import '@umbraco-ui/uui-input-password/lib';
+import '@umbraco-ui/uui-combobox/lib';
+import '@umbraco-ui/uui-combobox-list/lib';
+import '@umbraco-ui/uui-textarea/lib';
+import '@umbraco-ui/uui-select/lib';
 import { UUIRadioGroupEvent } from '@umbraco-ui/uui-radio/lib/UUIRadioGroupEvent';
 import readme from '../README.md?raw';
 
@@ -43,6 +49,15 @@ const _onSubmit = (e: SubmitEvent) => {
     console.log(value);
   }
 };
+
+const options: Array<Option> = [
+  { name: 'Carrot', value: 'orange', selected: true },
+  { name: 'Cucumber', value: 'green' },
+  { name: 'Aubergine', value: 'purple' },
+  { name: 'Blueberry', value: 'Blue' },
+  { name: 'Banana', value: 'yellow' },
+  { name: 'Strawberry', value: 'red' },
+];
 
 // TODO: Find a good way to have stories with both HTML and javascript
 export const Overview: Story = () => {
@@ -105,9 +120,9 @@ export const Overview: Story = () => {
         </uui-form-layout-item>
 
         <uui-form-layout-item>
-          <uui-label for="MyPasswordInput" slot="label" required
-            >Password</uui-label
-          >
+          <uui-label for="MyPasswordInput" slot="label" required>
+            Password
+          </uui-label>
           <uui-input-password
             id="MyPasswordInput"
             name="password"
@@ -144,21 +159,27 @@ export const Overview: Story = () => {
         </uui-form-layout-item>
 
         <uui-form-layout-item>
+          <uui-label for="MySelect" slot="label" required>Select</uui-label>
+          <uui-select id="MySelect" name="select" required .options=${options}>
+          </uui-select>
+        </uui-form-layout-item>
+
+        <uui-form-layout-item>
           <uui-label for="MyCombobox" slot="label" required>Combobox</uui-label>
           <uui-combobox id="MyCombobox" name="combobox" required>
             <uui-combobox-list>
-              <uui-combobox-list-option value="1"
-                >Option 1</uui-combobox-list-option
-              >
-              <uui-combobox-list-option value="2"
-                >Option 2</uui-combobox-list-option
-              >
-              <uui-combobox-list-option value="3"
-                >Option 3</uui-combobox-list-option
-              >
-              <uui-combobox-list-option value="4"
-                >Option 4</uui-combobox-list-option
-              >
+              <uui-combobox-list-option value="1">
+                Option 1
+              </uui-combobox-list-option>
+              <uui-combobox-list-option value="2">
+                Option 2
+              </uui-combobox-list-option>
+              <uui-combobox-list-option value="3">
+                Option 3
+              </uui-combobox-list-option>
+              <uui-combobox-list-option value="4">
+                Option 4
+              </uui-combobox-list-option>
             </uui-combobox-list>
           </uui-combobox>
         </uui-form-layout-item>

--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -321,7 +321,7 @@ export class UUIInputElement extends FormControlMixin(
         position: relative;
         display: inline-flex;
         align-items: stretch;
-        height: var(--uui-size-11);
+        height: var(--uui-input-height, var(--uui-size-11));
         text-align: left;
         box-sizing: border-box;
         background-color: var(
@@ -425,6 +425,7 @@ export class UUIInputElement extends FormControlMixin(
         border: none;
         background: none;
         width: 100%;
+        height: inherit;
         text-align: inherit;
         outline: none;
       }

--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -31,6 +31,16 @@ export type InputType =
  * @fires UUIInputEvent#change on change
  * @fires InputEvent#input on input
  * @fires KeyboardEvent#keyup on keyup
+ * @cssprop --uui-input-height - Height of the element
+ * @cssprop --uui-input-background-color - Background color of the element
+ * @cssprop --uui-input-background-color-disabled - Background color when disabled
+ * @cssprop --uui-input-background-color-readonly - Background color when readonly
+ * @cssprop --uui-input-border-width - Border width
+ * @cssprop --uui-input-border-color - Border color
+ * @cssprop --uui-input-border-color-hover - Border color on hover
+ * @cssprop --uui-input-border-color-focus - Border color on focus
+ * @cssprop --uui-input-border-color-disabled - Border color when disabled
+ * @cssprop --uui-input-border-color-readonly - Border color when readonly
  */
 @defineElement('uui-input')
 export class UUIInputElement extends FormControlMixin(

--- a/packages/uui-select/lib/uui-select.element.ts
+++ b/packages/uui-select/lib/uui-select.element.ts
@@ -21,6 +21,16 @@ declare global {
  * This is a formAssociated element, meaning it can participate in a native HTMLForm. A name:value pair will be submitted.
  * @element uui-select
  * @fires change - when the user changes value
+ * @cssprop --uui-select-height - Height of the element
+ * @cssprop --uui-select-font-size - Font size of the element
+ * @cssprop --uui-select-padding-y - Padding on the y axis
+ * @cssprop --uui-select-padding-x - Padding on the x axis
+ * @cssprop --uui-select-border-color - Border color
+ * @cssprop --uui-select-border-color-hover - Border color on hover
+ * @cssprop --uui-select-selected-option-background-color - Background color of the selected option
+ * @cssprop --uui-select-selected-option-color - Color of the selected option
+ * @cssprop --uui-select-outline-color - Outline color
+ * @cssprop --uui-select-disabled-background-color - Background color when disabled
  */
 // TODO: Consider if this should use child items instead of an array.
 @defineElement('uui-select')

--- a/packages/uui-select/lib/uui-select.element.ts
+++ b/packages/uui-select/lib/uui-select.element.ts
@@ -250,7 +250,6 @@ export class UUISelectElement extends FormControlMixin(LitElement) {
         color: currentColor;
         border-radius: 0;
         box-sizing: border-box;
-        background-color: transparent;
         border: 1px solid
           var(--uui-select-border-color, var(--uui-color-border));
         transition: all 150ms ease;

--- a/packages/uui-select/lib/uui-select.element.ts
+++ b/packages/uui-select/lib/uui-select.element.ts
@@ -238,13 +238,14 @@ export class UUISelectElement extends FormControlMixin(LitElement) {
         display: inline-block;
         position: relative;
         font-family: inherit;
+        height: var(--uui-select-height, var(--uui-size-11));
       }
 
       #native {
         display: inline-block;
         font-family: inherit;
         font-size: var(--uui-select-font-size, var(--uui-size-5));
-        height: var(--uui-select-height, var(--uui-size-11));
+        height: inherit;
         width: 100%;
         padding: var(--uui-select-padding-y, var(--uui-size-1))
           var(--uui-select-padding-x, var(--uui-size-2));

--- a/packages/uui-select/lib/uui-select.element.ts
+++ b/packages/uui-select/lib/uui-select.element.ts
@@ -235,6 +235,7 @@ export class UUISelectElement extends FormControlMixin(LitElement) {
   static styles = [
     css`
       :host {
+        display: inline-block;
         position: relative;
         font-family: inherit;
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This aligns uui-select and uui-input with each other, so they work well together in a form having the same height and background-color properties.

We also now document the custom CSS properties in both elements and the story for a combined form has been fixed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

