### PR TITLE
fix: uui-dropzone should set the 'accept' attribute

### DIFF
--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
@@ -21,6 +21,7 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
 
   private _acceptedFileExtensions: string[] = [];
   private _acceptedMimeTypes: string[] = [];
+  private _accept = '';
 
   /**
    * Comma-separated list of accepted mime types or file extensions (denoted with a `.`).
@@ -57,6 +58,12 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
       this._acceptedMimeTypes = [];
       this._acceptedFileExtensions = [];
     }
+    const old = this._accept;
+    this._accept = value;
+    this.requestUpdate('accept', old);
+  }
+  public get accept(): string {
+    return this._accept;
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Small bugfix where the accept string didnt get added to the actual element

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
