### PR TITLE
uui-menu-item: add flatten css var to hide chevron column

### DIFF
--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -200,13 +200,17 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         display: block;
         --uui-menu-item-child-indent: calc(var(--uui-menu-item-indent, 0) + 1);
         user-select: none;
+        --flat-structure: 0;
+        --flat-structure-reversed: calc(1 - var(--flat-structure));
       }
 
       #menu-item {
         position: relative;
         padding-left: calc(var(--uui-menu-item-indent, 0) * var(--uui-size-4));
         display: grid;
-        grid-template-columns: var(--uui-size-8) 1fr;
+        grid-template-columns:
+          calc(var(--flat-structure-reversed) * var(--uui-size-8))
+          1fr;
         grid-template-rows: 1fr;
         white-space: nowrap;
       }

--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -16,6 +16,7 @@ import { UUIMenuItemEvent } from './UUIMenuItemEvent';
 /**
  *  @element uui-menu-item
  *  @cssprop --uui-menu-item-indent - set indentation of the menu items
+ *  @cssprop --uui-menu-item-flat-structure - set to 1 to remove the indentation of the chevron. Use this when you have a flat menu structure.
  *  @fires {UUIMenuItemEvent} show-children - fires when the expand icon is clicked to show nested menu items
  *  @fires {UUIMenuItemEvent} hide-children - fires when the expend icon is clicked to hide nested menu items
  *  @fires {UUIMenuItemEvent} click-label - fires when the label is clicked
@@ -200,8 +201,9 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         display: block;
         --uui-menu-item-child-indent: calc(var(--uui-menu-item-indent, 0) + 1);
         user-select: none;
-        --flat-structure: 0;
-        --flat-structure-reversed: calc(1 - var(--flat-structure));
+        --flat-structure-reversed: calc(
+          1 - var(--uui-menu-item-flat-structure, 0)
+        );
       }
 
       #menu-item {
@@ -393,7 +395,10 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         grid-column-start: 2;
         white-space: nowrap;
         overflow: hidden;
-
+        padding-right: var(--uui-size-space-3);
+        padding-left: calc(
+          var(--uui-menu-item-flat-structure) * var(--uui-size-space-3)
+        );
         display: inline-flex;
         align-items: center;
         text-decoration: none;
@@ -409,10 +414,6 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
       }
       span#label-button {
         pointer-events: none; /* avoid hovering state on this. */
-      }
-
-      #caret-button + #label-button {
-        padding-left: 0;
       }
 
       #caret-button {

--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -16,7 +16,7 @@ import { UUIMenuItemEvent } from './UUIMenuItemEvent';
 /**
  *  @element uui-menu-item
  *  @cssprop --uui-menu-item-indent - set indentation of the menu items
- *  @cssprop --uui-menu-item-flat-structure - set to 1 to remove the indentation of the chevron. Use this when you have a flat menu structure.
+ *  @cssprop --uui-menu-item-flat-structure - set to 1 to remove the indentation of the chevron. Use this when you have a flat menu structure
  *  @fires {UUIMenuItemEvent} show-children - fires when the expand icon is clicked to show nested menu items
  *  @fires {UUIMenuItemEvent} hide-children - fires when the expend icon is clicked to hide nested menu items
  *  @fires {UUIMenuItemEvent} click-label - fires when the label is clicked

--- a/packages/uui-menu-item/lib/uui-menu-item.story.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.story.ts
@@ -397,6 +397,36 @@ ItemIndentation.parameters = {
   },
 };
 
+export const FlatStructure: Story = (props: any) => html`
+  <uui-icon-registry-essential>
+    <uui-menu-item
+      style="--uui-menu-item-flat-structure: 1"
+      label=${props.label}
+      ?loading=${props.loading}
+      ?disabled=${props.disabled}
+      ?has-children=${props.hasChildren}
+      ?show-children=${props.showChildren}
+      ?selected=${props.selected}
+      ?active=${props.active}
+      ?selectable=${props.selectable}
+      href=${props.href}
+      target=${props.target}>
+    </uui-menu-item>
+  </uui-icon-registry-essential>
+`;
+FlatStructure.parameters = {
+  docs: {
+    source: {
+      code: html`
+        <uui-menu-item
+          style="--uui-menu-item-flat-structure: 1"
+          label="Menu Item 1">
+        </uui-menu-item>
+      `.strings,
+    },
+  },
+};
+
 export const SelectMode = (props: any) =>
   html`<uui-menu-item
     label="Parent"

--- a/packages/uui-menu-item/lib/uui-menu-item.story.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.story.ts
@@ -32,6 +32,7 @@ export default {
   },
   argTypes: {
     '--uui-menu-item-indent': { control: { type: 'text' } },
+    '--uui-menu-item-flat-structure': { control: { type: 'text' } },
     selectMode: {
       control: {
         type: 'select',


### PR DESCRIPTION
Adds a css var: `--uui-menu-item-flat-structure` to menu item to remove the indentation of the chevron for when you know you won't have nesting (a flat structure)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
