### PR TITLE
fix: padding fixes for uui-combobox

### DIFF
--- a/packages/uui-combobox-list/lib/uui-combobox-list-option.element.ts
+++ b/packages/uui-combobox-list/lib/uui-combobox-list-option.element.ts
@@ -85,11 +85,13 @@ export class UUIComboboxListOptionElement extends SelectableMixin(
       :host {
         position: relative;
         cursor: pointer;
-        margin: 0 6px;
+        margin: 0 4px;
         border-radius: var(--uui-border-radius);
         outline: 2px solid transparent;
         outline-offset: -2px;
+        padding-left: 4px;
       }
+
       :host(:first-child) {
         margin-top: 6px;
       }
@@ -130,6 +132,7 @@ export class UUIComboboxListOptionElement extends SelectableMixin(
         color: var(--uui-color-disabled-contrast);
         background-color: var(--uui-color-disabled);
       }
+
       :host([disabled]:hover) {
         background-color: var(--uui-color-disabled);
       }
@@ -142,6 +145,7 @@ export class UUIComboboxListOptionElement extends SelectableMixin(
         color: var(--uui-color-selected-contrast);
         background-color: var(--uui-color-selected);
       }
+
       :host([selected]:hover) {
         color: var(--uui-color-selected-contrast);
         background-color: var(--uui-color-selected-emphasis);


### PR DESCRIPTION
Fixing padding according to this issue: https://github.com/umbraco/Umbraco.UI/issues/666

Before and after:

![image](https://github.com/umbraco/Umbraco.UI/assets/1782524/ab71c84d-8fc3-4553-bf3f-06209d7b2c28)


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
