### PR TITLE
fix: uui-combobox should correctly handle the active item

### DIFF
--- a/packages/uui-combobox/lib/uui-combobox.element.ts
+++ b/packages/uui-combobox/lib/uui-combobox.element.ts
@@ -147,6 +147,7 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
     demandCustomElement(this, 'uui-combobox-list');
     demandCustomElement(this, 'uui-scroll-container');
     demandCustomElement(this, 'uui-popover-container');
+    demandCustomElement(this, 'uui-symbol-expand');
   }
 
   disconnectedCallback(): void {
@@ -286,15 +287,12 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
       @input=${this.#onInput}
       @keydown=${this.#onKeyDown}>
       <slot name="input-prepend" slot="prepend"></slot>
-      ${this.disabled ? '' : this.#renderClearButton()} ${this.#renderCaret()}
+      ${this.disabled ? '' : this.#renderClearButton()}
+      <div id="expand-symbol-wrapper" slot="append">
+        <uui-symbol-expand .open=${this._isOpen}></uui-symbol-expand>
+      </div>
       <slot name="input-append" slot="append"></slot>
     </uui-input>`;
-  };
-
-  #renderCaret = () => {
-    return html`<svg id="caret" slot="append" viewBox="0 0 512 512">
-      <path d="M 255.125 400.35 L 88.193 188.765 H 422.055 Z"></path>
-    </svg>`;
   };
 
   #renderClearButton = () => {
@@ -361,6 +359,12 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
         width: 100%;
         max-height: var(--uui-combobox-popover-max-height, 500px);
       }
+      #expand-symbol-wrapper {
+        height: 100%;
+        padding-right: var(--uui-size-space-3);
+        display: flex;
+        justify-content: center;
+      }
 
       #dropdown {
         overflow: hidden;
@@ -375,14 +379,6 @@ export class UUIComboboxElement extends FormControlMixin(LitElement) {
         height: 100%;
         box-sizing: border-box;
         box-shadow: var(--uui-shadow-depth-3);
-      }
-
-      #caret {
-        margin-right: var(--uui-size-3, 9px);
-        display: flex;
-        width: 1.15em;
-        flex-shrink: 0;
-        margin-top: -1px;
       }
 
       :host([disabled]) #caret {

--- a/packages/uui-combobox/lib/uui-combobox.story.ts
+++ b/packages/uui-combobox/lib/uui-combobox.story.ts
@@ -3,6 +3,7 @@ import '@umbraco-ui/uui-icon/lib';
 import '@umbraco-ui/uui-input/lib';
 import '@umbraco-ui/uui-button/lib';
 import '@umbraco-ui/uui-popover-container/lib';
+import '@umbraco-ui/uui-symbol-expand';
 
 import '.';
 import './uui-combobox-async-example';

--- a/packages/uui-combobox/package.json
+++ b/packages/uui-combobox/package.json
@@ -35,7 +35,8 @@
     "@umbraco-ui/uui-combobox-list": "1.6.0-rc.1",
     "@umbraco-ui/uui-icon": "1.6.0-rc.1",
     "@umbraco-ui/uui-scroll-container": "1.6.0-rc.1",
-    "@umbraco-ui/uui-popover-container": "1.6.0-rc.1"
+    "@umbraco-ui/uui-popover-container": "1.6.0-rc.1",
+    "@umbraco-ui/uui-symbol-expand": "1.6.0-rc.1"
   },
   "scripts": {
     "build": "npm run analyze && tsc --build --force && rollup -c rollup.config.js",


### PR DESCRIPTION
This PR Fixes issues with how the combobox handles the active item. Meaning the one that gets highlighted when you navigate with the arrow keys or click an item.
Before the active item was unreliable and not correctly shown visually.

This PR also correctly sets the first item as active when you open the combobox, or make changes to the children, eg. when you search. Example: If you search for "ora" and the first item is orange, pressing space will now pick orange.
Before you would have to click the item, or navigate to it using the arrow keys before pressing enter.

Also adds the expand symbol instead of the custom svg implementation.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
