### PR TITLE
Ensure defineElement is used instead of customElement

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,15 @@ module.exports = {
         'lit/prefer-nothing': 'error',
         'local-rules/uui-class-prefix': 'warn',
         'local-rules/prefer-static-styles-last': 'warn',
+        'no-restricted-syntax': [
+          'warn',
+          {
+            message:
+              'Elements should not be defined with customElement, use defineElement instead.',
+            selector:
+              'ClassDeclaration > Decorator[expression.callee.name="customElement"]',
+          },
+        ],
       },
       parserOptions: {
         project: './tsconfig.json',

--- a/packages/uui-combobox/lib/uui-combobox-async-example.ts
+++ b/packages/uui-combobox/lib/uui-combobox-async-example.ts
@@ -1,5 +1,6 @@
+import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { css, html, LitElement, nothing } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { state } from 'lit/decorators.js';
 
 interface Fruit {
   name: string;
@@ -26,7 +27,7 @@ const data: Array<Fruit> = [
   { name: 'Lime', value: 'lime' },
 ];
 
-@customElement('uui-combobox-async-example')
+@defineElement('uui-combobox-async-example')
 export class UUIComboboxAsyncExampleElement extends LitElement {
   @state()
   _options: any[] = [];

--- a/packages/uui-combobox/lib/uui-combobox-async-options-example.ts
+++ b/packages/uui-combobox/lib/uui-combobox-async-options-example.ts
@@ -1,5 +1,6 @@
+import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { html, LitElement } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 
 interface Fruit {
   name: string;
@@ -30,7 +31,7 @@ async function getFruits() {
   return Promise.resolve(data);
 }
 
-@customElement('uui-combobox-async-options-example')
+@defineElement('uui-combobox-async-options-example')
 export class UUIComboboxAsyncOptionsExampleElement extends LitElement {
   @state()
   _options: any[] = [];

--- a/packages/uui-modal/lib/modal-example.element.ts
+++ b/packages/uui-modal/lib/modal-example.element.ts
@@ -1,10 +1,11 @@
 import { LitElement, css, html, TemplateResult } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { state } from 'lit/decorators.js';
 import './uui-modal-container';
 import { ref, createRef } from 'lit/directives/ref.js';
 import { UUIModalElement } from './uui-modal.element';
+import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 
-@customElement('modal-example')
+@defineElement('modal-example')
 export class ModalExampleElement extends LitElement {
   @state()
   private _modals: TemplateResult<1>[] = [];

--- a/packages/uui-modal/lib/uui-modal-container.ts
+++ b/packages/uui-modal/lib/uui-modal-container.ts
@@ -1,8 +1,10 @@
 import { LitElement, PropertyValueMap, css, html } from 'lit';
-import { customElement, property, query, state } from 'lit/decorators.js';
+import { property, query, state } from 'lit/decorators.js';
 import { UUIModalSidebarElement } from './uui-modal-sidebar.element';
 import { UUIModalElement } from './uui-modal.element';
-@customElement('uui-modal-container')
+import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+
+@defineElement('uui-modal-container')
 export class UUIModalContainerElement extends LitElement {
   @query('slot')
   modalSlot?: HTMLSlotElement;

--- a/packages/uui-modal/lib/uui-modal-dialog.element.ts
+++ b/packages/uui-modal/lib/uui-modal-dialog.element.ts
@@ -1,8 +1,8 @@
 import { css, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import { UUIModalElement } from './uui-modal.element';
+import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 
-@customElement('uui-modal-dialog')
+@defineElement('uui-modal-dialog')
 export class UUIModalDialogElement extends UUIModalElement {
   render() {
     return html`

--- a/packages/uui-modal/lib/uui-modal-sidebar.element.ts
+++ b/packages/uui-modal/lib/uui-modal-sidebar.element.ts
@@ -1,10 +1,11 @@
 import { css, html, PropertyValueMap } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
 import { UUIModalElement } from './uui-modal.element';
+import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 
 export type UUIModalSidebarSize = 'small' | 'medium' | 'large' | 'full';
 
-@customElement('uui-modal-sidebar')
+@defineElement('uui-modal-sidebar')
 export class UUIModalSidebarElement extends UUIModalElement {
   /**
    * @attr

--- a/packages/uui-table/lib/uui-table-advanced-example.ts
+++ b/packages/uui-table/lib/uui-table-advanced-example.ts
@@ -8,8 +8,9 @@ import '@umbraco-ui/uui-tag/lib';
 
 import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
 import { css, html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
+import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 
 interface TableColumn {
   name: string;
@@ -25,7 +26,7 @@ interface TableItem {
   newsletter: boolean;
 }
 
-@customElement('uui-table-with-selection-example')
+@defineElement('uui-table-with-selection-example')
 export class UUITableWithSelectionExampleElement extends LitElement {
   @state()
   private _columns: Array<TableColumn> = [];


### PR DESCRIPTION
## Description

The custom `defineElement` decorator is now used instead of the default lit `customElement`.
Also adds an ESLint rule configured as a warning, to try to prevent this in the future.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

The custom `defineElement` decorator prevents elements from being registered multiple times.
This is partially related to https://github.com/umbraco/Umbraco-CMS/issues/15397.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
