### PR TITLE
fix: direct imports are not allowed

### DIFF
--- a/packages/uui-card-media/lib/uui-card-media.element.ts
+++ b/packages/uui-card-media/lib/uui-card-media.element.ts
@@ -5,9 +5,6 @@ import { css, html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
-import '@umbraco-ui/uui-symbol-folder/lib';
-import '@umbraco-ui/uui-symbol-file/lib';
-
 /**
  *  @element uui-card-media
  *  @description - Card component for displaying a media item.

--- a/packages/uui-combobox/lib/uui-combobox.element.ts
+++ b/packages/uui-combobox/lib/uui-combobox.element.ts
@@ -6,6 +6,7 @@ import {
   UUIComboboxListEvent,
 } from '@umbraco-ui/uui-combobox-list/lib';
 import { iconRemove } from '@umbraco-ui/uui-icon-registry-essential/lib/svgs';
+import type { UUIPopoverContainerElement } from '@umbraco-ui/uui-popover-container/lib';
 import { css, html, LitElement } from 'lit';
 import {
   property,
@@ -15,8 +16,6 @@ import {
 } from 'lit/decorators.js';
 
 import { UUIComboboxEvent } from './UUIComboboxEvent';
-
-import type { UUIPopoverContainerElement } from '@umbraco-ui/uui-popover-container/lib';
 
 /**
  * @element uui-combobox

--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -1,19 +1,16 @@
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
+import type { UUIButtonElement } from '@umbraco-ui/uui-button/lib';
+import type { UUIPopoverContainerElement } from '@umbraco-ui/uui-popover-container/lib';
 import { css, html, LitElement } from 'lit';
 import { property, query, queryAssignedElements } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
-import type { UUIButtonElement } from '@umbraco-ui/uui-button/lib';
-import '@umbraco-ui/uui-button/lib';
-import '@umbraco-ui/uui-popover-container/lib';
-import '@umbraco-ui/uui-symbol-more/lib';
-
-import { UUITabElement } from './uui-tab.element';
-import { UUIPopoverContainerElement } from '@umbraco-ui/uui-popover-container/lib';
+import type { UUITabElement } from './uui-tab.element';
 
 /**
- *  @element uui-tab-group
- *  @slot - Default slot for the tab group
+ * @element uui-tab-group
+ * @slot - Default slot for the tab group
  * @cssprop --uui-tab-group-dropdown-tab-text - Define the tab text color in the dropdown
  * @cssprop --uui-tab-group-dropdown-tab-text-hover - Define the tab text hover color in the dropdown
  * @cssprop --uui-tab-group-dropdown-tab-text-active - Define the tab text active color in the dropdown
@@ -53,12 +50,15 @@ export class UUITabGroupElement extends LitElement {
 
   #visibilityBreakpoints: number[] = [];
 
-  #resizeObserver: ResizeObserver = new ResizeObserver(
-    this.#onResize.bind(this)
-  );
+  #resizeObserver = new ResizeObserver(this.#onResize.bind(this));
 
   connectedCallback() {
     super.connectedCallback();
+
+    demandCustomElement(this, 'uui-button');
+    demandCustomElement(this, 'uui-popover-container');
+    demandCustomElement(this, 'uui-symbol-more');
+
     this.#resizeObserver.observe(this);
     if (!this.hasAttribute('role')) this.setAttribute('role', 'tablist');
   }
@@ -205,7 +205,9 @@ export class UUITabGroupElement extends LitElement {
   }
 
   #isElementTabLike(el: any): el is UUITabElement {
-    return el instanceof UUITabElement || 'active' in el;
+    return (
+      typeof el === 'object' && 'active' in el && typeof el.active === 'boolean'
+    );
   }
 
   render() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Elements should not import other elements directly but instead utilize the `demandCustomElement` function. This fixes a few components that were doing this as well as organizing the imports.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
