### PR TITLE
Add uui-tab-group flex gap story

### DIFF
--- a/packages/uui-tabs/lib/uui-tabs.story.ts
+++ b/packages/uui-tabs/lib/uui-tabs.story.ts
@@ -172,3 +172,52 @@ WithIcons.parameters = {
     },
   },
 };
+
+export const WitchSpacing: Story = props => html`
+  <h3>Tabs with Spacing</h3>
+  <uui-icon-registry-essential>
+    <div style="display: flex;">
+      <uui-tab-group
+        dropdown-direction="horizontal"
+        style="
+        gap: 70px;
+        margin: 0 auto;
+        font-size: 12px;
+        ${props.inlineStyles}">
+        <uui-tab>
+          <uui-icon slot="icon" name="document"></uui-icon>
+          Content
+        </uui-tab>
+        <uui-tab active>
+          <uui-icon slot="icon" name="settings"></uui-icon>
+          Packages
+        </uui-tab>
+        <uui-tab>
+          <uui-icon slot="icon" name="picture"></uui-icon>
+          Media
+        </uui-tab>
+      </uui-tab-group>
+    </div>
+  </uui-icon-registry-essential>
+`;
+WitchSpacing.parameters = {
+  docs: {
+    source: {
+      code: `
+      <uui-tab-group>
+        <uui-tab>
+          <uui-icon slot="icon" name="document"></uui-icon>
+          Content
+        </uui-tab>
+        <uui-tab active>
+          <uui-icon slot="icon" name="settings"></uui-icon>
+          Packages
+        </uui-tab>
+        <uui-tab>
+          <uui-icon slot="icon" name="picture"></uui-icon>
+          Media
+        </uui-tab>
+      </uui-tab-group>`,
+    },
+  },
+};


### PR DESCRIPTION
This PR adds a story that reproduces a specific use case of uui-tabs from Cloud Portal, where tabs are used with a spacing between them. 1.6.0-rc3 version does not support that and it breaks the layout. 

## Description

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

This is to illustrate an issue #707 

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
