### PR TITLE
uui-tab-group does not support having a gap between tabs

### DIFF
--- a/packages/uui-button/lib/uui-button.story.ts
+++ b/packages/uui-button/lib/uui-button.story.ts
@@ -332,6 +332,7 @@ WaitingState.parameters = {
       <uui-button state="waiting" label="A11Y proper label">Loading button</uui-button>`,
     },
   },
+  chromatic: { disableSnapshot: true },
 };
 
 export const AnchorTag = Template.bind({});

--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -15,6 +15,7 @@ import type { UUITabElement } from './uui-tab.element';
  * @cssprop --uui-tab-group-dropdown-tab-text-hover - Define the tab text hover color in the dropdown
  * @cssprop --uui-tab-group-dropdown-tab-text-active - Define the tab text active color in the dropdown
  * @cssprop --uui-tab-group-dropdown-background - Define the background color of the dropdown
+ * @cssprop --uui-tab-group-gap - Define the gap between elements dropdown. Only pixel values are valid
  */
 @defineElement('uui-tab-group')
 export class UUITabGroupElement extends LitElement {
@@ -185,11 +186,15 @@ export class UUITabGroupElement extends LitElement {
     // Whenever a tab is added or removed, we need to recalculate the breakpoints
 
     await this.updateComplete; // Wait for the tabs to be rendered
+    const gap = Number.parseFloat(
+      this.style.getPropertyValue('--uui-tab-group-gap')
+    );
     let childrenWidth = 0;
 
     for (let i = 0; i < this.#tabElements.length; i++) {
+      const isLast = i === this.#tabElements.length - 1 ? 0 : 1;
       this.#tabElements[i].style.display = '';
-      childrenWidth += this.#tabElements[i].offsetWidth;
+      childrenWidth += this.#tabElements[i].offsetWidth + gap * isLast; // Add gap to calculation except for last element.
       this.#visibilityBreakpoints[i] = childrenWidth;
     }
 
@@ -244,6 +249,7 @@ export class UUITabGroupElement extends LitElement {
         min-height: 48px;
         overflow: hidden;
         text-wrap: nowrap;
+        gap: var(--uui-tab-group-gap, 0);
       }
 
       #popover-container {

--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -212,15 +212,17 @@ export class UUITabGroupElement extends LitElement {
 
   render() {
     return html`
-      <slot @slotchange=${this.#onSlotChange}></slot>
-      <uui-button
-        popovertarget="popover-container"
-        style="display: none"
-        id="more-button"
-        label="More"
-        compact>
-        <uui-symbol-more></uui-symbol-more>
-      </uui-button>
+      <div id="main">
+        <slot @slotchange=${this.#onSlotChange}></slot>
+        <uui-button
+          popovertarget="popover-container"
+          style="display: none"
+          id="more-button"
+          label="More"
+          compact>
+          <uui-symbol-more></uui-symbol-more>
+        </uui-button>
+      </div>
       <uui-popover-container
         id="popover-container"
         popover
@@ -234,7 +236,7 @@ export class UUITabGroupElement extends LitElement {
 
   static styles = [
     css`
-      :host {
+      #main {
         display: flex;
         flex-wrap: nowrap;
         color: var(--uui-tab-text);

--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -149,6 +149,9 @@ export class UUITabGroupElement extends LitElement {
       childrenWidth += gap;
     }
 
+    const tolerance = 2;
+    this.style.maxWidth = childrenWidth - gap + tolerance + 'px';
+
     this.#updateCollapsibleTabs(this.offsetWidth);
   }
 

--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -244,12 +244,11 @@ export class UUITabGroupElement extends LitElement {
     css`
       #main {
         display: flex;
-        flex-wrap: nowrap;
-        color: var(--uui-tab-text);
         height: 100%;
         min-height: 48px;
         overflow: hidden;
         text-wrap: nowrap;
+        color: var(--uui-tab-text);
         gap: var(--uui-tab-group-gap, 0);
       }
 

--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -186,9 +186,10 @@ export class UUITabGroupElement extends LitElement {
     // Whenever a tab is added or removed, we need to recalculate the breakpoints
 
     await this.updateComplete; // Wait for the tabs to be rendered
-    const gap = Number.parseFloat(
+    const gapCSSVar = Number.parseFloat(
       this.style.getPropertyValue('--uui-tab-group-gap')
     );
+    const gap = Number.isNaN(gapCSSVar) ? 0 : gapCSSVar;
     let childrenWidth = 0;
 
     for (let i = 0; i < this.#tabElements.length; i++) {

--- a/packages/uui-tabs/lib/uui-tab.element.ts
+++ b/packages/uui-tabs/lib/uui-tab.element.ts
@@ -115,7 +115,7 @@ export class UUITabElement extends ActiveMixin(LabelMixin('', LitElement)) {
         height: 100%;
         min-height: var(--uui-size-12);
         min-width: 70px;
-        padding: var(--uui-size-2)
+        padding: var(--uui-size-3)
           var(--uui-tab-padding-horizontal, var(--uui-size-5));
         border: none;
         font-size: inherit;

--- a/packages/uui-tabs/lib/uui-tabs.story.ts
+++ b/packages/uui-tabs/lib/uui-tabs.story.ts
@@ -138,15 +138,15 @@ export const WithIcons: Story = props => html`
         height: 70px;
         font-size: 12px;
         ${props.inlineStyles}">
-        <uui-tab>
+        <uui-tab label="content">
           <uui-icon slot="icon" name="document"></uui-icon>
           Content
         </uui-tab>
-        <uui-tab active>
+        <uui-tab active label="packages">
           <uui-icon slot="icon" name="settings"></uui-icon>
           Packages
         </uui-tab>
-        <uui-tab>
+        <uui-tab label="media">
           <uui-icon slot="icon" name="picture"></uui-icon>
           Media
         </uui-tab>
@@ -183,19 +183,19 @@ export const WitchSpacing: Story = props => html`
       <uui-tab-group
         dropdown-direction="horizontal"
         style="
-        gap: 70px;
+        --uui-tab-group-gap: 70px;
         margin: 0 auto;
         font-size: 12px;
         ${props.inlineStyles}">
-        <uui-tab>
+        <uui-tab label="content">
           <uui-icon slot="icon" name="document"></uui-icon>
           Content
         </uui-tab>
-        <uui-tab active>
+        <uui-tab active label="packages">
           <uui-icon slot="icon" name="settings"></uui-icon>
           Packages
         </uui-tab>
-        <uui-tab>
+        <uui-tab label="media">
           <uui-icon slot="icon" name="picture"></uui-icon>
           Media
         </uui-tab>

--- a/packages/uui-tabs/lib/uui-tabs.story.ts
+++ b/packages/uui-tabs/lib/uui-tabs.story.ts
@@ -183,7 +183,7 @@ export const WitchSpacing: Story = props => html`
       <uui-tab-group
         dropdown-direction="horizontal"
         style="
-        --uui-tab-group-gap: 70px;
+        --uui-tab-group-gap: 180px;
         margin: 0 auto;
         font-size: 12px;
         ${props.inlineStyles}">

--- a/packages/uui-tabs/lib/uui-tabs.story.ts
+++ b/packages/uui-tabs/lib/uui-tabs.story.ts
@@ -4,6 +4,7 @@ import '@umbraco-ui/uui-icon-registry-essential/lib';
 import '@umbraco-ui/uui-button/lib';
 import '@umbraco-ui/uui-popover-container/lib';
 import '@umbraco-ui/uui-symbol-more/lib';
+import '@umbraco-ui/uui-input/lib';
 
 import { Story } from '@storybook/web-components';
 import { html } from 'lit';
@@ -204,6 +205,57 @@ export const WitchSpacing: Story = props => html`
   </uui-icon-registry-essential>
 `;
 WitchSpacing.parameters = {
+  docs: {
+    source: {
+      code: `
+      <uui-tab-group>
+        <uui-tab>
+          <uui-icon slot="icon" name="document"></uui-icon>
+          Content
+        </uui-tab>
+        <uui-tab active>
+          <uui-icon slot="icon" name="settings"></uui-icon>
+          Packages
+        </uui-tab>
+        <uui-tab>
+          <uui-icon slot="icon" name="picture"></uui-icon>
+          Media
+        </uui-tab>
+      </uui-tab-group>`,
+    },
+  },
+};
+
+export const FlexLayout: Story = props => html`
+  <h3>Tabs with Spacing</h3>
+  <p>We want the input to grow and the tabs to take up the remaining space.</p>
+  <uui-icon-registry-essential>
+    <div
+      style="display: flex; outline: 1px solid black; max-width: 800px; height: 100% ">
+      <uui-input style="flex-grow: 1;"></uui-input>
+      <uui-tab-group
+        dropdown-direction="horizontal"
+        style="
+        --uui-tab-group-gap: 50px;
+        font-size: 12px;
+        ${props.inlineStyles}">
+        <uui-tab label="content">
+          <uui-icon slot="icon" name="document"></uui-icon>
+          Content
+        </uui-tab>
+        <uui-tab active label="packages">
+          <uui-icon slot="icon" name="settings"></uui-icon>
+          Packages
+        </uui-tab>
+        <uui-tab label="media">
+          <uui-icon slot="icon" name="picture"></uui-icon>
+          Media
+        </uui-tab>
+      </uui-tab-group>
+    </div>
+  </uui-icon-registry-essential>
+`;
+FlexLayout.parameters = {
   docs: {
     source: {
       code: `

--- a/packages/uui-tabs/lib/uui-tabs.story.ts
+++ b/packages/uui-tabs/lib/uui-tabs.story.ts
@@ -1,6 +1,9 @@
 import '.';
 import '@umbraco-ui/uui-icon/lib';
 import '@umbraco-ui/uui-icon-registry-essential/lib';
+import '@umbraco-ui/uui-button/lib';
+import '@umbraco-ui/uui-popover-container/lib';
+import '@umbraco-ui/uui-symbol-more/lib';
 
 import { Story } from '@storybook/web-components';
 import { html } from 'lit';

--- a/packages/uui-tabs/lib/uui-tabs.story.ts
+++ b/packages/uui-tabs/lib/uui-tabs.story.ts
@@ -231,12 +231,13 @@ export const FlexLayout: Story = props => html`
   <p>We want the input to grow and the tabs to take up the remaining space.</p>
   <uui-icon-registry-essential>
     <div
-      style="display: flex; outline: 1px solid black; max-width: 800px; height: 100% ">
-      <uui-input style="flex-grow: 1;"></uui-input>
+      style="display: flex; outline: 1px solid black; max-width: 800px; height: 100%; align-items: center; padding-left: 12px;">
+      <uui-input style="flex-grow: 1; min-width: 200px"></uui-input>
       <uui-tab-group
         dropdown-direction="horizontal"
         style="
-        --uui-tab-group-gap: 50px;
+        flex-grow: 1;
+        --uui-tab-group-gap: 25px;
         font-size: 12px;
         ${props.inlineStyles}">
         <uui-tab label="content">

--- a/packages/uui-tabs/lib/uui-tabs.story.ts
+++ b/packages/uui-tabs/lib/uui-tabs.story.ts
@@ -85,7 +85,7 @@ export const Navbar: Story = () => html`
     style="
     display: flex;
     height: 60px;
-    font-size: 16px;
+    font-size: var(--uui-type-default-size);
     ">
     <uui-tab-group style="display: flex;">
       <uui-tab label="content"> Content </uui-tab>
@@ -104,7 +104,7 @@ export const UsingHref: Story = () => html`
     style="
     display: flex;
     height: 60px;
-    font-size: 16px;
+    font-size: var(--uui-type-default-size);
     ">
     <uui-tab-group>
       <uui-tab label="content" href="http://www.umbraco.com/#content">
@@ -136,8 +136,7 @@ export const WithIcons: Story = props => html`
       <uui-tab-group
         dropdown-direction="horizontal"
         style="
-        height: 70px;
-        font-size: 12px;
+        font-size: var(--uui-type-small-size);
         ${props.inlineStyles}">
         <uui-tab label="content">
           <uui-icon slot="icon" name="document"></uui-icon>
@@ -177,8 +176,8 @@ WithIcons.parameters = {
   },
 };
 
-export const WitchSpacing: Story = props => html`
-  <h3>Tabs with Spacing</h3>
+export const WithGap: Story = props => html`
+  <h3>Tabs with custom gap</h3>
   <uui-icon-registry-essential>
     <div style="display: flex;">
       <uui-tab-group
@@ -186,7 +185,7 @@ export const WitchSpacing: Story = props => html`
         style="
         --uui-tab-group-gap: 180px;
         margin: 0 auto;
-        font-size: 12px;
+        font-size: var(--uui-type-small-size);
         ${props.inlineStyles}">
         <uui-tab label="content">
           <uui-icon slot="icon" name="document"></uui-icon>
@@ -204,7 +203,7 @@ export const WitchSpacing: Story = props => html`
     </div>
   </uui-icon-registry-essential>
 `;
-WitchSpacing.parameters = {
+WithGap.parameters = {
   docs: {
     source: {
       code: `
@@ -227,8 +226,11 @@ WitchSpacing.parameters = {
 };
 
 export const FlexLayout: Story = props => html`
-  <h3>Tabs with Spacing</h3>
-  <p>We want the input to grow and the tabs to take up the remaining space.</p>
+  <h3>Tabs implemented into Flex-box scenario</h3>
+  <p>
+    In this case we want the input to grow and the tabs to take up the remaining
+    space:
+  </p>
   <uui-icon-registry-essential>
     <div
       style="display: flex; outline: 1px solid black; max-width: 800px; height: 100%; align-items: center; padding-left: 12px;">
@@ -238,7 +240,7 @@ export const FlexLayout: Story = props => html`
         style="
         flex-grow: 1;
         --uui-tab-group-gap: 25px;
-        font-size: 12px;
+        font-size: var(--uui-type-small-size);
         ${props.inlineStyles}">
         <uui-tab label="content">
           <uui-icon slot="icon" name="document"></uui-icon>


### PR DESCRIPTION
Adds CSS variable to add gaps between tab items.
`--uui-tab-group-gap`

Only pixel values are valid. Any other value will be converted to pixels if possible. Invalid number values will fallback to 0
Examples `20em => 20px` `25% => 25px` `10 => 10px` `100whatever => 100px` `sdh10 => NaN => 0px`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
