### PR TITLE
Bugfix/popover container scroll event

### DIFF
--- a/packages/uui-popover-container/lib/uui-popover-container.element.ts
+++ b/packages/uui-popover-container/lib/uui-popover-container.element.ts
@@ -69,7 +69,7 @@ export class UUIPopoverContainerElement extends LitElement {
   _actualPlacement: PopoverContainerPlacement = this._placement;
 
   #targetElement: HTMLElement | null = null;
-  private _scrollParents: Element[] = [];
+  #scrollParents: Element[] = [];
 
   connectedCallback(): void {
     //TODO: Remove this polyfill when firefox supports the new popover API
@@ -97,7 +97,7 @@ export class UUIPopoverContainerElement extends LitElement {
       this.id
     );
 
-    this._getScrollParents();
+    this.#getScrollParents();
 
     // Dispatch a custom event that can be listened to by the popover target.
     // Mostly used for UUIButton.
@@ -113,13 +113,11 @@ export class UUIPopoverContainerElement extends LitElement {
     );
 
     if (!this._open) {
-      this._stopScrollListener();
-      // document.removeEventListener('scroll', this.#initUpdate);
+      this.#stopScrollListener();
       return;
     }
 
-    this._startScrollListener();
-    // document.addEventListener('scroll', this.#initUpdate);
+    this.#startScrollListener();
 
     requestAnimationFrame(() => {
       this.#initUpdate();
@@ -310,20 +308,20 @@ export class UUIPopoverContainerElement extends LitElement {
       `${oppositeDirection}-${position}` as PopoverContainerPlacement;
   }
 
-  private _startScrollListener() {
-    this._scrollParents.forEach(el => {
+  #startScrollListener() {
+    this.#scrollParents.forEach(el => {
       el.addEventListener('scroll', this.#initUpdate);
     });
     document.addEventListener('scroll', this.#initUpdate);
   }
-  private _stopScrollListener() {
-    this._scrollParents.forEach(el => {
+  #stopScrollListener() {
+    this.#scrollParents.forEach(el => {
       el.removeEventListener('scroll', this.#initUpdate);
     });
     document.removeEventListener('scroll', this.#initUpdate);
   }
 
-  private _getScrollParents(): any {
+  #getScrollParents(): any {
     if (!this.#targetElement) return;
 
     let style = getComputedStyle(this.#targetElement);
@@ -347,13 +345,13 @@ export class UUIPopoverContainerElement extends LitElement {
       if (
         overflowRegex.test(style.overflow + style.overflowY + style.overflowX)
       ) {
-        this._scrollParents.push(el);
+        this.#scrollParents.push(el);
       }
       if (style.position === 'fixed') {
         return;
       }
     }
-    this._scrollParents.push(document.body);
+    this.#scrollParents.push(document.body);
   }
 
   render() {

--- a/packages/uui-popover-container/lib/uui-popover-container.element.ts
+++ b/packages/uui-popover-container/lib/uui-popover-container.element.ts
@@ -86,6 +86,7 @@ export class UUIPopoverContainerElement extends LitElement {
   disconnectedCallback(): void {
     super.disconnectedCallback();
     this.removeEventListener('beforetoggle', this.#onBeforeToggle);
+    this.#stopScrollListener();
   }
 
   #onBeforeToggle = (event: any) => {
@@ -310,9 +311,9 @@ export class UUIPopoverContainerElement extends LitElement {
 
   #startScrollListener() {
     this.#scrollParents.forEach(el => {
-      el.addEventListener('scroll', this.#initUpdate);
+      el.addEventListener('scroll', this.#initUpdate, { passive: true });
     });
-    document.addEventListener('scroll', this.#initUpdate);
+    document.addEventListener('scroll', this.#initUpdate, { passive: true });
   }
   #stopScrollListener() {
     this.#scrollParents.forEach(el => {

--- a/packages/uui-popover-container/lib/uui-popover-container.story.ts
+++ b/packages/uui-popover-container/lib/uui-popover-container.story.ts
@@ -187,34 +187,32 @@ export const InsideScrollContainer: Story = {
     },
   },
   render: args => html`
-    <div
-      style="width: 300px; height: 300px; outline: 1px solid black; overflow: auto;">
-      <div style="height: 150px"></div>
-      <uui-button
-        id="popover-button"
-        popovertarget="popover-container"
-        look="primary"
-        label="Open popover">
-        Open popover
-      </uui-button>
-      <uui-popover-container
-        id="popover-container"
-        popover
-        placement=${args.placement}
-        margin=${args.margin}>
-        <div
-          style="background-color: var(--uui-color-surface); max-width: 150px; box-shadow: var(--uui-shadow-depth-4); padding: var(--uui-size-space-4); border-radius: var(--uui-border-radius); font-size: 0.9rem;">
-          <h2>Scrolling should trigger an update</h2>
-          <p>
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Quis ex
-            fuga pariatur dolorum, in natus. Ipsa, veritatis minus. Dolore saepe
-            modi libero voluptates provident consequatur ex illo a, eligendi
-            enim?
-          </p>
-        </div>
-      </uui-popover-container>
-      <div style="height: 150px"></div>
-      <div style="height: 150px"></div>
+    <div style="height: 500px; overflow: auto; outline: 1px solid black">
+      <div
+        style="width: 300px; height: 300px; outline: 1px solid black; overflow: auto;">
+        <div style="height: 150px"></div>
+        <uui-button
+          id="popover-button"
+          popovertarget="popover-container"
+          look="primary"
+          label="Open popover">
+          Open popover
+        </uui-button>
+        <div style="height: 150px"></div>
+        <div style="height: 150px"></div>
+      </div>
+      <div style="height: 400px"></div>
     </div>
+    <uui-popover-container
+      id="popover-container"
+      popover
+      placement=${args.placement}
+      margin=${args.margin}>
+      <div
+        style="width: 100%; background-color: var(--uui-color-surface); max-width: 200px; box-shadow: var(--uui-shadow-depth-4); padding: var(--uui-size-space-4); border-radius: var(--uui-border-radius); font-size: 0.9rem;">
+        <h3>Scroll!</h3>
+        Scrolling in any of the 2 boxes should trigger an update
+      </div>
+    </uui-popover-container>
   `,
 };

--- a/packages/uui-popover-container/lib/uui-popover-container.story.ts
+++ b/packages/uui-popover-container/lib/uui-popover-container.story.ts
@@ -158,3 +158,63 @@ export const Tooltip: Story = {
     </uui-popover-container>
   `,
 };
+
+export const InsideScrollContainer: Story = {
+  args: {
+    placement: 'bottom-start',
+    margin: 0,
+  },
+  argTypes: {
+    open: {
+      control: false,
+    },
+    placement: {
+      options: [
+        'auto',
+        'top',
+        'top-start',
+        'top-end',
+        'bottom',
+        'bottom-start',
+        'bottom-end',
+        'right',
+        'right-start',
+        'right-end',
+        'left',
+        'left-start',
+        'left-end',
+      ],
+    },
+  },
+  render: args => html`
+    <div
+      style="width: 300px; height: 300px; outline: 1px solid black; overflow: auto;">
+      <div style="height: 150px"></div>
+      <uui-button
+        id="popover-button"
+        popovertarget="popover-container"
+        look="primary"
+        label="Open popover">
+        Open popover
+      </uui-button>
+      <uui-popover-container
+        id="popover-container"
+        popover
+        placement=${args.placement}
+        margin=${args.margin}>
+        <div
+          style="background-color: var(--uui-color-surface); max-width: 150px; box-shadow: var(--uui-shadow-depth-4); padding: var(--uui-size-space-4); border-radius: var(--uui-border-radius); font-size: 0.9rem;">
+          <h2>Scrolling should trigger an update</h2>
+          <p>
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Quis ex
+            fuga pariatur dolorum, in natus. Ipsa, veritatis minus. Dolore saepe
+            modi libero voluptates provident consequatur ex illo a, eligendi
+            enim?
+          </p>
+        </div>
+      </uui-popover-container>
+      <div style="height: 150px"></div>
+      <div style="height: 150px"></div>
+    </div>
+  `,
+};


### PR DESCRIPTION
Popover container now listens to all parent scroll containers to make sure that a position update is triggered when scrolling.
Before it only listened to the body. Which meant that the popover would not update it's position if inside another scroll container.

Adds story to visualise the fix

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
