### PR TITLE
Ref Element: Change border attribute to standalone

### DIFF
--- a/packages/uui-ref-node-data-type/lib/uui-ref-node-data-type.story.ts
+++ b/packages/uui-ref-node-data-type/lib/uui-ref-node-data-type.story.ts
@@ -81,9 +81,12 @@ CustomIcon.parameters = {
   },
 };
 
-export const Border: Story = () => html`
+export const Standalone: Story = () => html`
   <div style="max-width: 420px;">
-    <uui-ref-node-data-type border name="TextField" alias="Umbraco.TextField">
+    <uui-ref-node-data-type
+      standalone
+      name="TextField"
+      alias="Umbraco.TextField">
       <uui-action-bar slot="actions">
         <uui-button label="Remove">Remove</uui-button>
       </uui-action-bar>
@@ -91,12 +94,12 @@ export const Border: Story = () => html`
   </div>
 `;
 
-Border.parameters = {
+Standalone.parameters = {
   docs: {
     source: {
       code: `
 <uui-ref-node-data-type
-  border
+  standalone
   name="TextField"
   alias="Umbraco.TextField">
   <uui-action-bar slot="actions">

--- a/packages/uui-ref-node-document-type/lib/uui-ref-node-document-type.story.ts
+++ b/packages/uui-ref-node-document-type/lib/uui-ref-node-document-type.story.ts
@@ -81,9 +81,12 @@ CustomIcon.parameters = {
   },
 };
 
-export const Border: Story = () => html`
+export const Standalone: Story = () => html`
   <div style="max-width: 420px;">
-    <uui-ref-node-document-type border name="Product Page" alias="productPage">
+    <uui-ref-node-document-type
+      standalone
+      name="Product Page"
+      alias="productPage">
       <uui-action-bar slot="actions">
         <uui-button label="Remove">Remove</uui-button>
       </uui-action-bar>
@@ -91,12 +94,12 @@ export const Border: Story = () => html`
   </div>
 `;
 
-Border.parameters = {
+Standalone.parameters = {
   docs: {
     source: {
       code: `
 <uui-ref-node-document-type
-  border
+  standalone
   name="Product Page"
   alias="productPage">
   <uui-action-bar slot="actions">

--- a/packages/uui-ref-node-form/lib/uui-ref-node-form.story.ts
+++ b/packages/uui-ref-node-form/lib/uui-ref-node-form.story.ts
@@ -82,10 +82,10 @@ CustomIcon.parameters = {
   },
 };
 
-export const Border: Story = () => html`
+export const Standalone: Story = () => html`
   <div style="max-width: 420px;">
     <uui-ref-node-form
-      border
+      standalone
       name="Newsletter Signup"
       detail="Signup for newsletter">
       <uui-action-bar slot="actions">
@@ -95,12 +95,12 @@ export const Border: Story = () => html`
   </div>
 `;
 
-Border.parameters = {
+Standalone.parameters = {
   docs: {
     source: {
       code: `
 <uui-ref-node-form
-  border
+  standalone
   name="Newsletter Signup"
   detail="Signup for newsletter">
   <uui-action-bar slot="actions">

--- a/packages/uui-ref-node-member/lib/uui-ref-node-member.story.ts
+++ b/packages/uui-ref-node-member/lib/uui-ref-node-member.story.ts
@@ -83,10 +83,10 @@ CustomIcon.parameters = {
   },
 };
 
-export const Border: Story = () => html`
+export const Standalone: Story = () => html`
   <div style="max-width: 420px;">
     <uui-ref-node-member
-      border
+      standalone
       name="Arnold Vitz"
       group-name="Visitor, Registered-Member">
       <uui-action-bar slot="actions">
@@ -96,12 +96,12 @@ export const Border: Story = () => html`
   </div>
 `;
 
-Border.parameters = {
+Standalone.parameters = {
   docs: {
     source: {
       code: `
 <uui-ref-node-member
-  border
+  standalone
   name="Arnold Vitz"
   group-name="Visitor, Registered-Member">
   <uui-action-bar slot="actions">

--- a/packages/uui-ref-node-package/lib/uui-ref-node-package.story.ts
+++ b/packages/uui-ref-node-package/lib/uui-ref-node-package.story.ts
@@ -93,10 +93,10 @@ CustomIcon.parameters = {
   },
 };
 
-export const Border: Story = () => html`
+export const Standalone: Story = () => html`
   <div style="max-width: 420px;">
     <uui-ref-node-package
-      border
+      standalone
       name="Umbraco Starter Kit"
       version="1.1"
       author="Umbraco HQ">
@@ -110,12 +110,12 @@ export const Border: Story = () => html`
   </div>
 `;
 
-Border.parameters = {
+Standalone.parameters = {
   docs: {
     source: {
       code: `
 <uui-ref-node-package
-  border
+  standalone
   name="Umbraco Starter Kit"
   version="1.1"
   author="Umbraco HQ">

--- a/packages/uui-ref-node-user/lib/uui-ref-node-user.story.ts
+++ b/packages/uui-ref-node-user/lib/uui-ref-node-user.story.ts
@@ -81,10 +81,10 @@ CustomIcon.parameters = {
   },
 };
 
-export const Border: Story = () => html`
+export const Standalone: Story = () => html`
   <div style="max-width: 420px;">
     <uui-ref-node-user
-      border
+      standalone
       name="Arnold Edits"
       group-name="Editor, Translator">
       <uui-action-bar slot="actions">
@@ -94,12 +94,12 @@ export const Border: Story = () => html`
   </div>
 `;
 
-Border.parameters = {
+Standalone.parameters = {
   docs: {
     source: {
       code: `
 <uui-ref-node-user
-  border
+  standalone
   name="Arnold Edits"
   group-name="Editor, Translator"
   <uui-action-bar slot="actions">

--- a/packages/uui-ref-node/lib/uui-ref-node.story.ts
+++ b/packages/uui-ref-node/lib/uui-ref-node.story.ts
@@ -85,7 +85,7 @@ CustomIcon.parameters = {
   <uui-action-bar slot="actions">
     <uui-button label="Remove">Remove</uui-button>
   </uui-action-bar>
-</uui-ref-node>s
+</uui-ref-node>
     `,
     },
   },

--- a/packages/uui-ref-node/lib/uui-ref-node.story.ts
+++ b/packages/uui-ref-node/lib/uui-ref-node.story.ts
@@ -85,14 +85,17 @@ CustomIcon.parameters = {
   <uui-action-bar slot="actions">
     <uui-button label="Remove">Remove</uui-button>
   </uui-action-bar>
-</uui-ref-node>
+</uui-ref-node>s
     `,
     },
   },
 };
 
-export const Border: Story = () => html`
-  <uui-ref-node border name="Rabbit Suit Product Page" detail="path/to/nowhere">
+export const Standalone: Story = () => html`
+  <uui-ref-node
+    standalone
+    name="Rabbit Suit Product Page"
+    detail="path/to/nowhere">
     <uui-tag size="s" slot="tag" color="positive">Published</uui-tag>
     <uui-action-bar slot="actions">
       <uui-button type="button" label="Delete"
@@ -102,12 +105,12 @@ export const Border: Story = () => html`
   </uui-ref-node>
 `;
 
-Border.parameters = {
+Standalone.parameters = {
   docs: {
     source: {
       code: `
 <uui-ref-node
-  border
+  standalone
   name="Rabbit Suit Product Page"
   detail="path/to/nowhere">
   <uui-tag size="s" slot="tag" color="positive" >Published</uui-tag>

--- a/packages/uui-ref/lib/uui-ref.element.ts
+++ b/packages/uui-ref/lib/uui-ref.element.ts
@@ -13,6 +13,9 @@ import { UUIRefEvent } from './UUIRefEvent';
  *  @fires {UUISelectableEvent} selected - fires when the ref is selected
  *  @fires {UUISelectableEvent} deselected - fires when the ref is deselected
  *  @description - Base ref component to be extended by specific ref elements. Does not have a tag.
+ *  @attr {boolean} [disabled=false] - Set to true to disable
+ *  @attr {boolean} [error=false] - Set to true to display error state
+ *  @attr {boolean} [standalone=false] - Set to true to make element stand out
  */
 
 @defineElement('uui-ref')
@@ -76,7 +79,7 @@ export class UUIRefElement extends SelectOnlyMixin(
           inset 0 0 2px 0 var(--uui-color-danger);
       }
 
-      :host([border]) {
+      :host([standalone]) {
         border: 1px solid var(--uui-color-border);
       }
 
@@ -179,7 +182,7 @@ export class UUIRefElement extends SelectOnlyMixin(
         opacity: 1;
       }
 
-      :host([border]:not([disabled]):hover) {
+      :host([standalone]:not([disabled]):hover) {
         border-color: var(--uui-color-border-emphasis);
       }
 
@@ -187,7 +190,7 @@ export class UUIRefElement extends SelectOnlyMixin(
         cursor: default;
       }
 
-      :host([border][disabled]) {
+      :host([standalone][disabled]) {
         border-color: var(--uui-color-disabled-standalone);
       }
 


### PR DESCRIPTION
Changes the border attribute on ref to standalone to align with our naming

Also adds missing JSDocs for ref

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
