### PR TITLE
Textarea: Use css var for text

### DIFF
--- a/packages/uui-textarea/lib/uui-textarea.element.ts
+++ b/packages/uui-textarea/lib/uui-textarea.element.ts
@@ -303,6 +303,7 @@ export class UUITextareaElement extends FormControlMixin(LitElement) {
       }
 
       textarea {
+        color: var(--uui-color-text);
         font-family: inherit;
         line-height: var(--uui-size-6);
         box-sizing: border-box;


### PR DESCRIPTION
Changes the the button on ref to use `uui-color-text` css var instead of the default `fieldtext` value

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
