### PR TITLE
fix(uui-tab-group): layout is causing issues due to missing `display: flex`

### DIFF
--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -25,6 +25,8 @@ export class UUITabGroupElement extends LitElement {
   @query('#popover-container')
   private _popoverContainerElement!: UUIPopoverContainerElement;
 
+  @query('#main') private _mainElement!: HTMLElement;
+
   @queryAssignedElements({
     flatten: true,
     selector: 'uui-tab, [uui-tab], [role=tab]',
@@ -61,13 +63,7 @@ export class UUITabGroupElement extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-
-    demandCustomElement(this, 'uui-button');
-    demandCustomElement(this, 'uui-popover-container');
-    demandCustomElement(this, 'uui-symbol-more');
-
-    this.#resizeObserver.observe(this);
-    if (!this.hasAttribute('role')) this.setAttribute('role', 'tablist');
+    this.#initialize();
   }
 
   disconnectedCallback() {
@@ -76,7 +72,20 @@ export class UUITabGroupElement extends LitElement {
     this.#cleanupTabs();
   }
 
+  async #initialize() {
+    demandCustomElement(this, 'uui-button');
+    demandCustomElement(this, 'uui-popover-container');
+    demandCustomElement(this, 'uui-symbol-more');
+
+    if (!this.hasAttribute('role')) this.setAttribute('role', 'tablist');
+
+    await this.updateComplete;
+    this.#resizeObserver.observe(this._mainElement);
+  }
+
   #onResize(entries: ResizeObserverEntry[]) {
+    console.log('resize');
+
     // Check if the gap css custom property has changed.
     const gapCSSVar = Number.parseFloat(
       this.style.getPropertyValue('--uui-tab-group-gap')
@@ -174,9 +183,9 @@ export class UUITabGroupElement extends LitElement {
     }
 
     const tolerance = 2;
-    this.style.maxWidth = childrenWidth - gap + tolerance + 'px';
+    this._mainElement.style.maxWidth = childrenWidth - gap + tolerance + 'px';
 
-    this.#updateCollapsibleTabs(this.offsetWidth);
+    this.#updateCollapsibleTabs(this._mainElement.offsetWidth);
   }
 
   #setTabArray() {
@@ -286,12 +295,15 @@ export class UUITabGroupElement extends LitElement {
   static styles = [
     css`
       :host {
-        width: 100%;
+        /* width: 100%; */
+        display: contents;
       }
 
       #main {
         display: flex;
         justify-content: space-between;
+        overflow: hidden;
+        width: 100%;
       }
 
       #grid {

--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -84,8 +84,6 @@ export class UUITabGroupElement extends LitElement {
   }
 
   #onResize(entries: ResizeObserverEntry[]) {
-    console.log('resize');
-
     // Check if the gap css custom property has changed.
     const gapCSSVar = Number.parseFloat(
       this.style.getPropertyValue('--uui-tab-group-gap')

--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -181,7 +181,7 @@ export class UUITabGroupElement extends LitElement {
     }
 
     const tolerance = 2;
-    this._mainElement.style.maxWidth = childrenWidth - gap + tolerance + 'px';
+    this._mainElement.style.width = childrenWidth - gap + tolerance + 'px';
 
     this.#updateCollapsibleTabs(this._mainElement.offsetWidth);
   }
@@ -293,15 +293,14 @@ export class UUITabGroupElement extends LitElement {
   static styles = [
     css`
       :host {
-        /* width: 100%; */
-        display: contents;
+        min-width: 0;
+        display: flex;
       }
 
       #main {
         display: flex;
         justify-content: space-between;
         overflow: hidden;
-        width: 100%;
       }
 
       #grid {

--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -295,6 +295,7 @@ export class UUITabGroupElement extends LitElement {
       :host {
         min-width: 0;
         display: flex;
+        height: 100%;
       }
 
       #main {

--- a/packages/uui-tabs/lib/uui-tabs.story.ts
+++ b/packages/uui-tabs/lib/uui-tabs.story.ts
@@ -330,13 +330,10 @@ export const CenterAlign: Story = props => html`
   <h3>Tabs implemented into Flex-box scenario</h3>
   <p>Here the tab group is center aligned in a flex-box container.</p>
   <uui-icon-registry-essential>
-    <div style="display: flex;">
+    <div style="display: flex; justify-content: center">
       <uui-tab-group
         dropdown-direction="horizontal"
-        style="
-          margin: auto;
-        --uui-tab-group-gap: 25px;
-        font-size: var(--uui-type-small-size);
+        style="--uui-tab-group-gap: 25px;
         ${props.inlineStyles}">
         <uui-tab label="content">Content</uui-tab>
         <uui-tab active label="packages">Packages</uui-tab>
@@ -369,13 +366,11 @@ export const RightAlign: Story = props => html`
   <h3>Tabs implemented into Flex-box scenario</h3>
   <p>Here the tab group is right aligned in a flex-box container.</p>
   <uui-icon-registry-essential>
-    <div style="display: flex;">
+    <div style="display: flex; justify-content: right">
       <uui-tab-group
         dropdown-direction="horizontal"
         style="
-          margin-left: auto;
         --uui-tab-group-gap: 25px;
-        font-size: var(--uui-type-small-size);
         ${props.inlineStyles}">
         <uui-tab label="content">Content</uui-tab>
         <uui-tab active label="packages">Packages</uui-tab>

--- a/packages/uui-tabs/lib/uui-tabs.story.ts
+++ b/packages/uui-tabs/lib/uui-tabs.story.ts
@@ -291,6 +291,41 @@ Async.parameters = {
   },
 };
 
+export const FlexLayout: Story = props => html`
+  <uui-icon-registry-essential>
+    <div style="display: flex;">
+      <uui-input style="min-width: 100px; width: 100%"></uui-input>
+      <uui-tab-group
+        dropdown-direction="horizontal"
+        style="
+        ${props.inlineStyles}">
+        <uui-tab label="content">Content</uui-tab>
+        <uui-tab active label="packages">Packages</uui-tab>
+        <uui-tab label="media">Media</uui-tab>
+        <uui-tab label="settings">Settings</uui-tab>
+        <uui-tab label="translations">Translations</uui-tab>
+      </uui-tab-group>
+    </div>
+  </uui-icon-registry-essential>
+`;
+FlexLayout.parameters = {
+  docs: {
+    source: {
+      code: `
+      <div style="display: flex">
+        <uui-tab-group style="margin: auto">
+          <uui-tab label="content">Content</uui-tab>
+          <uui-tab active label="packages">Packages</uui-tab>
+          <uui-tab label="media">Media</uui-tab>
+          <uui-tab label="settings">Settings</uui-tab>
+          <uui-tab label="translations">Translations</uui-tab>
+          </uui-tab-group>
+      </div>
+      `,
+    },
+  },
+};
+
 export const CenterAlign: Story = props => html`
   <h3>Tabs implemented into Flex-box scenario</h3>
   <p>Here the tab group is center aligned in a flex-box container.</p>

--- a/packages/uui-tabs/lib/uui-tabs.story.ts
+++ b/packages/uui-tabs/lib/uui-tabs.story.ts
@@ -68,7 +68,7 @@ export const WithBorders: Story = () => html`
     display: flex;
     --uui-tab-divider: var(--uui-color-divider-standalone);
     ">
-    <uui-tab-group style="display: flex;">
+    <uui-tab-group>
       <uui-tab label="content"> Content </uui-tab>
       <uui-tab label="Packages"> Packages </uui-tab>
       <uui-tab label="Media" active> Media </uui-tab>
@@ -87,7 +87,7 @@ export const Navbar: Story = () => html`
     height: 60px;
     font-size: var(--uui-type-default-size);
     ">
-    <uui-tab-group style="display: flex;">
+    <uui-tab-group>
       <uui-tab label="content"> Content </uui-tab>
       <uui-tab label="Packages" active> Packages </uui-tab>
       <uui-tab label="Media"> Media </uui-tab>
@@ -294,7 +294,7 @@ Async.parameters = {
 export const FlexLayout: Story = props => html`
   <uui-icon-registry-essential>
     <div style="display: flex;">
-      <uui-input style="min-width: 100px; width: 100%"></uui-input>
+      <uui-input style="min-width: 200px; flex-grow: 1"></uui-input>
       <uui-tab-group
         dropdown-direction="horizontal"
         style="

--- a/packages/uui-tabs/lib/uui-tabs.test.ts
+++ b/packages/uui-tabs/lib/uui-tabs.test.ts
@@ -3,6 +3,9 @@ import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { UUITabGroupElement } from './uui-tab-group.element';
 import { UUITabElement } from './uui-tab.element';
 
+import '@umbraco-ui/uui-button/lib';
+import '@umbraco-ui/uui-popover-container/lib';
+
 describe('UuiTab', () => {
   let element: UUITabGroupElement;
   let tabs: UUITabElement[];


### PR DESCRIPTION
Fixes layout issues caused by changes made in 1.6

Changed the tab group to use display flex instead of contents as a common use case is to add borders on some or all sides of the tab group. With display contents the tab group would have had to be wrapped in another element with a border on, or we would have to add 5 css vars, one for each side and one for all sides.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
