### PR TITLE
Don't hide placeholder text on focus

### DIFF
--- a/packages/uui-textarea/lib/uui-textarea.element.ts
+++ b/packages/uui-textarea/lib/uui-textarea.element.ts
@@ -332,14 +332,7 @@ export class UUITextareaElement extends FormControlMixin(LitElement) {
           var(--uui-color-border-emphasis)
         );
       }
-
-      textarea::placeholder {
-        transition: opacity 120ms;
-      }
-      :host(:not([readonly])) textarea:focus::placeholder {
-        opacity: 0;
-      }
-
+      
       textarea:focus {
         outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
           var(--uui-color-focus);

--- a/packages/uui-textarea/lib/uui-textarea.element.ts
+++ b/packages/uui-textarea/lib/uui-textarea.element.ts
@@ -332,7 +332,6 @@ export class UUITextareaElement extends FormControlMixin(LitElement) {
           var(--uui-color-border-emphasis)
         );
       }
-      
       textarea:focus {
         outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
           var(--uui-color-focus);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Same as fixed for `<uui-input>` in https://github.com/umbraco/Umbraco.UI/pull/624 but for `<uui-textarea>` as I noticed this in Umbraco 14 beta at description of properties on content type editor.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
