### PR TITLE
fix(uui-css): Lato is loaded twice

### DIFF
--- a/packages/uui-css/lib/custom-properties/fonts.css
+++ b/packages/uui-css/lib/custom-properties/fonts.css
@@ -1,5 +1,3 @@
-@import '../typography/lato.css';
-
 :root {
   --uui-font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }


### PR DESCRIPTION
## Description
Do not import the lato font here as it means you cannot import only the custom properties without getting the font.

Lato is already defined in uui-font.css and you can get all of it by uui-css.css as well.

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
