### PR TITLE
fix(uui-dialog): Remove native dialog background

### DIFF
--- a/packages/uui-modal/lib/uui-modal.element.ts
+++ b/packages/uui-modal/lib/uui-modal.element.ts
@@ -95,6 +95,7 @@ export class UUIModalElement extends LitElement {
         max-width: unset;
         max-height: unset;
         border: none;
+        background: none;
       }
       dialog::backdrop {
         background: none;


### PR DESCRIPTION
The background of the dialog would occasionally appear in the corners of a rounded edge. This update removes the redundant background on the native dialog, as the uui-dialog already includes a background.

Before:
![image](https://github.com/umbraco/Umbraco.UI/assets/26099018/3fe7b89e-44ec-4f4a-b6f3-71ad55ba41fe)

After:
![image](https://github.com/umbraco/Umbraco.UI/assets/26099018/8742e8c2-67a3-4609-80a0-780c1c3e0457)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context
It hurts my eyes

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
