### PR TITLE
Add custom properties to uui-tag

### DIFF
--- a/packages/uui-tag/lib/uui-tag.element.ts
+++ b/packages/uui-tag/lib/uui-tag.element.ts
@@ -45,11 +45,11 @@ export class UUITagElement extends LitElement {
         font-size: var(--uui-tag-font-size, var(--uui-type-small-size));
         font-weight: 700;
         line-height: 1;
-        padding: var(--uui-size-space-1) calc(var(--uui-size-space-1) + 0.5em);
+        padding: var(--uui-tag-padding, var(--uui-size-space-1) calc(var(--uui-size-space-1) + 0.5em));
         border-radius: 100px;
         user-select: none;
-        border-radius: var(--uui-size-4);
-        border: 1px solid transparent;
+        border-radius: var(--uui-tag-border-radius, var(--uui-size-4));
+        border: 1px solid var(--uui-tag-border-color, transparent);
       }
 
       slot {

--- a/packages/uui-tag/lib/uui-tag.element.ts
+++ b/packages/uui-tag/lib/uui-tag.element.ts
@@ -12,6 +12,9 @@ import {
  *  @description Tag component from Umbraco UI components library. Comes in one shape, but different looks and sizes
  *  @slot - slot for tag contents
  *  @cssprop --uui-tag-font-size - overwrite the default font-size for the tag.
+ *  @cssprop --uui-tag-padding - overwrite the default padding size for the tag.
+ *  @cssprop --uui-tag-border-radius - overwrite the default border-radius for the tag.
+ *  @cssprop --uui-tag-border-color - overwrite the default border color for the tag.
  */
 
 @defineElement('uui-tag')


### PR DESCRIPTION
Extending uui-tag with custom properties in order to style it for the new modern umbraco cloud portal design.

## Description

 I've added three properties to modify the padding, border-radius and border color of the uui.tag

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

We want the ability to adapt the uui-tag better to our own needs and styling.

## How to test?

Change properties

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
