### PR TITLE
Umbraco.CMS.Backoffice/issues/1668 - adds aria-label to expand symbol

### DIFF
--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -185,7 +185,7 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
     return html`
       <div id="menu-item" aria-label="menuitem" role="menuitem">
         ${this.hasChildren
-          ? html`<button id="caret-button" @click=${this._onCaretClicked}>
+          ? html`<button id="caret-button" aria-label="show child items" @click=${this._onCaretClicked}>
               <uui-symbol-expand ?open=${this.showChildren}></uui-symbol-expand>
             </button>`
           : ''}


### PR DESCRIPTION
Currently the expand/carat symbol has no `aria-label`. This PR adds a non-localized label to that element to distinguish it from the main menu item's label. 

I'm not clear on how to localize this content in the `Umbraco.UI` app. Ideally, the "show child items" would be translated.  If there are any examples of localization in the library I could take a look at implementing that. 

https://github.com/umbraco/Umbraco.CMS.Backoffice/issues/1668

## Description

Adds `aria-label="show child items"` to the `caret-button` on https://uui.umbraco.com/?path=/docs/uui-menu-item--docs 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [  ] Bug fix (non-breaking change which fixes an issue)
- [ ✅ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

When using a screen reader, carats currently don't describe their role. This fails WCAG 2.0 & 2.1 rule 4.1.2 (provide a name/role/value). 

## How to test?
- Run the app
- Find a content item with a child item
- View in the console app to see "show child items"

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [✅ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ❌ ] I have added tests to cover my changes.
