### PR TITLE
V1/feature/menu items hide actions

### DIFF
--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -497,13 +497,14 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
 
       #actions-container {
         opacity: 0;
-        transition: opacity 120ms;
+        width: 0;
         grid-column-start: 3;
       }
       :host(:not([disabled])) #menu-item:hover #actions-container,
       :host(:not([disabled])) #menu-item:focus #actions-container,
       :host(:not([disabled])) #menu-item:focus-within #actions-container {
         opacity: 1;
+        width: auto;
       }
 
       #loader {

--- a/packages/uui-menu-item/lib/uui-menu-item.story.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.story.ts
@@ -9,6 +9,7 @@ import { UUIMenuItemElement } from './uui-menu-item.element';
 import { UUIMenuItemEvent } from './UUIMenuItemEvent';
 import readme from '../README.md?raw';
 import '@umbraco-ui/uui-symbol-expand/lib';
+import '@umbraco-ui/uui-symbol-more/lib';
 
 export default {
   title: 'Buttons/Menu Item',


### PR DESCRIPTION
Sets the width of the uui-menu-item action slot to 0 when not hovered or focused (previously just opacity)
This gives the text in the menu item more space, which is useful in narrow layouts.

Example of problem: There's a lot of wasted space on the right side of the menu-item
![image](https://github.com/umbraco/Umbraco.UI/assets/26099018/82c1170f-f976-4de7-ab5d-af553ecc7f9d)


Example form Storybook
Before:
![image](https://github.com/umbraco/Umbraco.UI/assets/26099018/99341492-adee-4370-8a8e-35c8f8caaece)

After:
![image](https://github.com/umbraco/Umbraco.UI/assets/26099018/fa250d78-b9a3-4924-9824-535cedc9eaf4)



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
