### PR TITLE
Bugfix: Dont show a link when no href is supplied

### DIFF
--- a/packages/uui-breadcrumbs/lib/uui-breadcrumb-item.element.ts
+++ b/packages/uui-breadcrumbs/lib/uui-breadcrumb-item.element.ts
@@ -20,10 +20,10 @@ export class UUIBreadcrumbItemElement extends LitElement {
   /**
    * Specifies the link href.
    * @type {String}
-   * @default '#'
+   * @default undefined
    */
   @property()
-  href = '#';
+  href?: string;
 
   /**
    * Specifies if the element is the last item in the uui-breadcrumbs. Last item will not render as a link
@@ -35,8 +35,12 @@ export class UUIBreadcrumbItemElement extends LitElement {
   lastItem = false;
 
   renderLinkAndSeparator() {
-    return html`<a id="link" href=${this.href}><slot></slot></a
-      ><span part="separator"></span>`;
+    console.log(this.href);
+    const item = this.href
+      ? html`<a id="link" href=${this.href}><slot></slot></a>`
+      : html`<span id="link"><slot></slot></span>`;
+
+    return html`${item}<span part="separator"></span>`;
   }
 
   renderCurrent() {
@@ -83,10 +87,6 @@ export class UUIBreadcrumbItemElement extends LitElement {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-      }
-
-      #link {
-        cursor: pointer;
       }
     `,
   ];


### PR DESCRIPTION
Makes breadcrumbs render as a span instead of a tag when no href is supplied.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
