### PR TITLE
fix: Hide the native input for boolean elements in firefox

### DIFF
--- a/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
+++ b/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
@@ -193,6 +193,7 @@ export abstract class UUIBooleanInputElement extends UUIFormControlMixin(
       }
 
       label {
+        position: relative;
         cursor: pointer;
         user-select: none;
 
@@ -207,7 +208,7 @@ export abstract class UUIBooleanInputElement extends UUIFormControlMixin(
         position: absolute;
         height: 0px;
         width: 0px;
-        margin-top: -4px;
+        visibility: hidden;
       }
 
       :host([label-position='left']) label {

--- a/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
+++ b/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
@@ -208,7 +208,7 @@ export abstract class UUIBooleanInputElement extends UUIFormControlMixin(
         position: absolute;
         height: 0px;
         width: 0px;
-        visibility: hidden;
+        opacity: 0;
       }
 
       :host([label-position='left']) label {


### PR DESCRIPTION
## Description

In boolean elements, the native input field was never truly hidden in firefox despite height/width set to 0, causing it to appear to look like dots on the screen.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16515

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
