### PR TITLE
Fix wrong close tag in code samples for `uui-color-swatch` element

### DIFF
--- a/packages/uui-color-swatch/lib/uui-color-swatch.story.ts
+++ b/packages/uui-color-swatch/lib/uui-color-swatch.story.ts
@@ -35,7 +35,7 @@ export const Selectable: Story = {
   parameters: {
     docs: {
       source: {
-        code: `<uui-color-swatch selectable></uui-color-slider>`,
+        code: `<uui-color-swatch selectable></uui-color-swatch>`,
       },
     },
   },
@@ -57,7 +57,7 @@ export const Disabled: Story = {
   parameters: {
     docs: {
       source: {
-        code: `<uui-color-swatch disabled></uui-color-slider>`,
+        code: `<uui-color-swatch disabled></uui-color-swatch>`,
       },
     },
   },
@@ -72,7 +72,7 @@ export const DisabledSelected: Story = {
   parameters: {
     docs: {
       source: {
-        code: `<uui-color-swatch disabled selectable selected></uui-color-slider>`,
+        code: `<uui-color-swatch disabled selectable selected></uui-color-swatch>`,
       },
     },
   },
@@ -87,7 +87,7 @@ export const WithLabel: Story = {
   parameters: {
     docs: {
       source: {
-        code: `<uui-color-swatch label="This is the most beautiful color I've ever seen" show-label="true"></uui-color-slider>`,
+        code: `<uui-color-swatch label="This is the most beautiful color I've ever seen" show-label="true"></uui-color-swatch>`,
       },
     },
   },
@@ -101,7 +101,7 @@ export const DifferentColorThanValue: Story = {
   parameters: {
     docs: {
       source: {
-        code: `<uui-color-swatch value="color1" color="green"></uui-color-slider>`,
+        code: `<uui-color-swatch value="color1" color="green"></uui-color-swatch>`,
       },
     },
   },
@@ -114,7 +114,7 @@ export const Transparent: Story = {
   parameters: {
     docs: {
       source: {
-        code: `<uui-color-swatch color="rgba(53, 68, 177, 0.5)"></uui-color-slider>`,
+        code: `<uui-color-swatch color="rgba(53, 68, 177, 0.5)"></uui-color-swatch>`,
       },
     },
   },


### PR DESCRIPTION
## Description

Browsing the docs, I noticed the code samples had mismatching open- and closetags, which was probably a copy & paste error. I don't really know which boxes to tick below; neither have I done any of the required build steps, so leaving this as a Draft PR for now. I can't tell if it's all necessary for something like this that only changes sample code that's not (I guess?) being tested and/or validated.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
