### PR TITLE
Slider UX improvements

### DIFF
--- a/packages/uui-slider/lib/uui-slider.element.ts
+++ b/packages/uui-slider/lib/uui-slider.element.ts
@@ -61,6 +61,8 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
    */
   static readonly formAssociated = true;
 
+  #stepDecimalPlaces = 0;
+
   /**
    * Hides the numbers representing the value of each steps. Dots will still be visible
    * @type {boolean}
@@ -104,7 +106,16 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
    * @default 1
    */
   @property({ type: Number })
-  step = 1;
+  public get step() {
+    return this.#step;
+  }
+
+  public set step(value) {
+    this.#step = value;
+    this.#stepDecimalPlaces = (value.toString().split('.')[1] || []).length;
+  }
+
+  #step = 1;
 
   /**
    * This is a value property of the uui-slider.
@@ -126,11 +137,13 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
 
     let correctedValue = newVal ? parseFloat(newVal as string) : 0;
     correctedValue = Math.min(Math.max(correctedValue, this.min), this.max);
+
     if (this.step > 0) {
       correctedValue = Math.round(correctedValue / this.step) * this.step;
     }
 
-    super.value = correctedValue.toString();
+    super.value = correctedValue.toFixed(this.#stepDecimalPlaces).toString();
+
     this._calculateSliderPosition();
     this.requestUpdate('value', oldVal);
   }

--- a/packages/uui-slider/lib/uui-slider.element.ts
+++ b/packages/uui-slider/lib/uui-slider.element.ts
@@ -386,8 +386,6 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
 
         background-color: var(--uui-color-surface);
         border: 2px solid var(--uui-color-selected);
-
-        transition: 120ms left ease;
       }
       :host([disabled]) #thumb {
         background-color: var(--uui-color-disabled);

--- a/packages/uui-slider/lib/uui-slider.element.ts
+++ b/packages/uui-slider/lib/uui-slider.element.ts
@@ -374,6 +374,9 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
 
       #thumb {
         position: absolute;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         top: 2px;
         bottom: 0;
         left: 0;
@@ -394,9 +397,6 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
 
       #thumb:after {
         content: '';
-        position: absolute;
-        top: 2px;
-        left: 2px;
         height: 9px;
         width: 9px;
         border-radius: 50%;

--- a/packages/uui-slider/lib/uui-slider.element.ts
+++ b/packages/uui-slider/lib/uui-slider.element.ts
@@ -71,6 +71,15 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
   hideStepValues = false;
 
   /**
+   * Hides the value label on the thumb.
+   * @type {boolean}
+   * @attr 'hide-value-label'
+   * @default false
+   */
+  @property({ type: Boolean, attribute: 'hide-value-label' })
+  hideValueLabel = false;
+
+  /**
    * This is a minimum value of the input.
    * @type {number}
    * @attr
@@ -285,7 +294,9 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
 
         <div id="track-inner" aria-hidden="true">
           <div id="thumb" style=${styleMap({ left: this._sliderPosition })}>
-            <div id="thumb-label">${this.value}</div>
+            ${this.hideValueLabel
+              ? null
+              : html`<div id="thumb-label">${this.value}</div>`}
           </div>
         </div>
       </div>

--- a/packages/uui-slider/lib/uui-slider.story.ts
+++ b/packages/uui-slider/lib/uui-slider.story.ts
@@ -14,6 +14,7 @@ export default {
     step: 1,
     label: 'Slider label',
     hideStepValues: false,
+    hideValueLabel: false,
     value: 0,
     disabled: false,
   },
@@ -38,7 +39,8 @@ const Template: Story = props => html`
     max=${props.max}
     ?disabled=${props.disabled}
     .value=${props.value}
-    .hideStepValues=${props.hideStepValues}></uui-slider>
+    .hideStepValues=${props.hideStepValues}
+    .hideValueLabel=${props.hideValueLabel}></uui-slider>
 `;
 
 export const AAAOverview = Template.bind({});


### PR DESCRIPTION
## Description

1. Adds the ability to hide the value label for scenarios where it doesn't make sense (e.g. image cropper zoom).
2. Removes the floating point error and fixes the value's decimal places to be the same as the step attribute.
3. Removes CSS animation from the element to prevent lag.
4. Fixes the positioning of the thumb inner on high DPI displays (at least in Chromium and Firefox, tested on Windows)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?
In storybook: 

- With default properties, set the slider to 97% on a high DPI display. See that the thumb centre is correctly centred.
- Set the min to 0, max to 1, and step to 0.001 (this is the current configuration for the Image Cropper in Umbraco).  As you drag the slider, see that the decimal places displayed are consistent with the step's decimal places (and floating point errors removed)
- Drag the slider quickly, see that lag is gone.

## Screenshots (if appropriate)
Centred thumb, and correct decimals before (top) and after (bottom):
![image](https://github.com/umbraco/Umbraco.UI/assets/7151793/145bc46b-ecaa-44e0-82d2-74ec7fe7033f)
Lag, before(top) and after (bottom):

https://github.com/umbraco/Umbraco.UI/assets/7151793/f5e26d58-3d97-45e2-aab1-3a2afb6f9a0d


## Checklist

- [X] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
