### PR TITLE
fix: prevent overflow when not hovered

### DIFF
--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -508,6 +508,7 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         opacity: 0;
         width: 0;
         grid-column-start: 3;
+        overflow: hidden;
       }
       :host(:not([disabled])) #menu-item:hover #actions-container,
       :host(:not([disabled])) #menu-item:focus #actions-container,


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco.CMS.Backoffice/issues/1912

Fixes an issue where actions would overflow the menu-item, causing layout problems in the containing element.