### PR TITLE
Feat: Readonly state for uui-select

### DIFF
--- a/packages/uui-select/lib/uui-select.element.ts
+++ b/packages/uui-select/lib/uui-select.element.ts
@@ -62,6 +62,15 @@ export class UUISelectElement extends UUIFormControlMixin(LitElement, '') {
   disabled = false;
 
   /**
+   * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
+   * @type {boolean}
+   * @attr
+   * @default false
+   */
+  @property({ type: Boolean, reflect: true })
+  readonly = false;
+
+  /**
    * Set to true if the component should have an error state.Property is reflected to the corresponding attribute.
    * @type {boolean}
    * @attr
@@ -226,7 +235,16 @@ export class UUISelectElement extends UUIFormControlMixin(LitElement, '') {
     `;
   }
 
+  private _getDisplayValue() {
+    return (
+      this.options.find(option => option.value === this.value)?.name ||
+      this.value
+    );
+  }
+
   render() {
+    if (this.readonly) return html`<span>${this._getDisplayValue()}</span>`;
+
     return html` <select
       id="native"
       aria-label=${this.label}

--- a/packages/uui-select/lib/uui-select.story.ts
+++ b/packages/uui-select/lib/uui-select.story.ts
@@ -157,6 +157,27 @@ Disabled.parameters = {
   },
 };
 
+export const Readonly: Story = props =>
+  html`<uui-select
+    .options=${preselectedOptions}
+    label="Label"
+    .placeholder=${props.placeholder}
+    .readonly=${props.readonly}></uui-select>`;
+
+Readonly.args = {
+  readonly: true,
+};
+
+Readonly.parameters = {
+  controls: { include: ['readonly'] },
+  docs: {
+    source: {
+      code: `
+<uui-select readonly></uui-select>`,
+    },
+  },
+};
+
 export const Error: Story = props =>
   html`<uui-select
     .options=${options}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a `readonly` state for the `uui-select` component. It will render the selected value as a text string instead of the select box.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
