### PR TITLE
Feat: Readonly state for uui-slider

### DIFF
--- a/packages/uui-slider/lib/uui-slider.element.ts
+++ b/packages/uui-slider/lib/uui-slider.element.ts
@@ -158,6 +158,15 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
   disabled = false;
 
   /**
+   * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
+   * @type {boolean}
+   * @attr
+   * @default false
+   */
+  @property({ type: Boolean, reflect: true })
+  readonly = false;
+
+  /**
    * Label to be used for aria-label and eventually as visual label
    * @type {string}
    * @attr
@@ -296,7 +305,8 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
         .value="${this.value}"
         aria-label="${this.label}"
         step="${+this.step}"
-        ?disabled=${this.disabled}
+        ?disabled=${this.disabled || this.readonly}
+        ?readonly=${this.readonly}
         @input=${this._onInput}
         @change=${this._onChange} />
       <div id="track" aria-hidden="true">
@@ -362,6 +372,7 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
       .track-step {
         fill: var(--uui-color-border);
       }
+
       input:hover ~ #track svg .track-step {
         fill: var(--uui-color-border-emphasis);
       }
@@ -402,6 +413,7 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
         border-radius: 50%;
         background-color: var(--uui-color-selected);
       }
+
       :host([disabled]) #thumb:after {
         background-color: var(--uui-color-disabled);
       }
@@ -456,6 +468,16 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
       }
       :host(:not([pristine]):invalid) #thumb:after {
         background-color: var(--uui-color-danger);
+      }
+
+      // readonly
+      :host([readonly]) #thumb {
+        background-color: var(--uui-color-disabled);
+        border-color: var(--uui-color-disabled-standalone);
+      }
+
+      :host([readonly]) #thumb-label {
+        opacity: 1;
       }
     `,
   ];

--- a/packages/uui-slider/lib/uui-slider.story.ts
+++ b/packages/uui-slider/lib/uui-slider.story.ts
@@ -17,6 +17,7 @@ export default {
     hideValueLabel: false,
     value: 0,
     disabled: false,
+    readonly: false,
   },
   argTypes: {
     label: {
@@ -38,6 +39,7 @@ const Template: Story = props => html`
     min=${props.min}
     max=${props.max}
     ?disabled=${props.disabled}
+    ?readonly=${props.readonly}
     .value=${props.value}
     .hideStepValues=${props.hideStepValues}
     .hideValueLabel=${props.hideValueLabel}></uui-slider>
@@ -71,4 +73,9 @@ HiddenValues.parameters = {
 export const Disabled = Template.bind({});
 Disabled.args = {
   disabled: true,
+};
+
+export const Readonly = Template.bind({});
+Readonly.args = {
+  readonly: true,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a `readonly` state for the `uui-slider` component. It will ensure that the value is always displayed in the slider and that the handle can't be dragged.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
