### PR TITLE
bug: Prevent UUIToggle from shrinking when the label contains a long string

### DIFF
--- a/packages/uui-toggle/lib/uui-toggle.element.ts
+++ b/packages/uui-toggle/lib/uui-toggle.element.ts
@@ -60,6 +60,8 @@ export class UUIToggleElement extends UUIBooleanInputElement {
         display: flex;
         align-items: center;
 
+        flex-shrink: 0;
+
         width: var(--uui-toggle-switch-width);
         height: var(--uui-toggle-size);
         border-radius: 100px;


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/16697
Prevent UUIToggle from shrinking when the label contains a long string

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
