### PR TITLE
bug(uui-select): Use css vars for background and text color

### DIFF
--- a/packages/uui-select/lib/uui-select.element.ts
+++ b/packages/uui-select/lib/uui-select.element.ts
@@ -23,6 +23,7 @@ declare global {
  * @fires change - when the user changes value
  * @cssprop --uui-select-height - Height of the element
  * @cssprop --uui-select-font-size - Font size of the element
+ * @cssprop --uui-select-text-color - Color of the text
  * @cssprop --uui-select-padding-y - Padding on the y axis
  * @cssprop --uui-select-padding-x - Padding on the x axis
  * @cssprop --uui-select-border-color - Border color
@@ -30,6 +31,7 @@ declare global {
  * @cssprop --uui-select-selected-option-background-color - Background color of the selected option
  * @cssprop --uui-select-selected-option-color - Color of the selected option
  * @cssprop --uui-select-outline-color - Outline color
+ * @cssprop --uui-select-background-color - Background color
  * @cssprop --uui-select-disabled-background-color - Background color when disabled
  * @extends UUIFormControlMixin
  */
@@ -264,13 +266,17 @@ export class UUISelectElement extends UUIFormControlMixin(LitElement, '') {
         height: var(--uui-select-height, var(--uui-size-11));
         padding: var(--uui-select-padding-y, var(--uui-size-1))
           var(--uui-select-padding-x, var(--uui-size-2));
-        color: currentColor;
+        color: var(--uui-select-text-color, var(--uui-color-text));
         box-sizing: border-box;
         border-radius: 0;
         border: 1px solid
           var(--uui-select-border-color, var(--uui-color-border));
         transition: all 150ms ease;
         width: 100%;
+        background-color: var(
+          --uui-select-background-color,
+          var(--uui-color-surface)
+        );
       }
 
       #native:focus {


### PR DESCRIPTION
Add CSS variables to the `uui-select` background and text colors to make it work with theming.
Also adds following overrides:
`--uui-select-background-color`
`--uui-select-text-color`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
