### PR TITLE
docs(uui-card-block-type): add descriptions for slots

### DIFF
--- a/packages/uui-card-block-type/lib/uui-card-block-type.element.ts
+++ b/packages/uui-card-block-type/lib/uui-card-block-type.element.ts
@@ -12,6 +12,9 @@ export type BlockTypeIcon = {
 
 /**
  * @element uui-card-block-type
+ * @slot - Default content.
+ * @slot tag - A slot for a tag
+ * @slot actions - A slot for actions
  */
 @defineElement('uui-card-block-type')
 export class UUICardBlockTypeElement extends UUICardElement {

--- a/packages/uui-card-block-type/lib/uui-card-block-type.element.ts
+++ b/packages/uui-card-block-type/lib/uui-card-block-type.element.ts
@@ -12,9 +12,9 @@ export type BlockTypeIcon = {
 
 /**
  * @element uui-card-block-type
- * @slot - Default content.
- * @slot tag - A slot for a tag
- * @slot actions - A slot for actions
+ * @slot - slot for the default content area
+ * @slot tag - slot for the tag with support for `<uui-tag>` elements
+ * @slot actions - slot for the actions with support for the `<uui-action-bar>` element
  */
 @defineElement('uui-card-block-type')
 export class UUICardBlockTypeElement extends UUICardElement {


### PR DESCRIPTION
## Description

Adds missing documentation for slots on the uui-card-block-type element.