### PR TITLE
fix(uui-form-validation-message): default renderer does not support raw HTML

### DIFF
--- a/packages/uui-form-validation-message/lib/uui-form-validation-message.element.ts
+++ b/packages/uui-form-validation-message/lib/uui-form-validation-message.element.ts
@@ -4,6 +4,7 @@ import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { css, html, LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 /**
  * @element uui-form-validation-message
@@ -92,7 +93,10 @@ export class UUIFormValidationMessageElement extends LitElement {
     return html`
       <slot></slot>
       <div id="messages">
-        ${repeat(this._messages, item => html`<div>${item[1]}</div>`)}
+        ${repeat(
+          this._messages,
+          item => html`<div>${unsafeHTML(item[1])}</div>`,
+        )}
         <slot name="message"></slot>
       </div>
     `;


### PR DESCRIPTION
## Description

Prints the HTML tags inside validation messages.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16504

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
