### PR TITLE
feat: dropzone should support folder upload

### DIFF
--- a/packages/uui-file-dropzone/lib/UUIFileDropzoneEvent.ts
+++ b/packages/uui-file-dropzone/lib/UUIFileDropzoneEvent.ts
@@ -1,8 +1,11 @@
 import { UUIEvent } from '@umbraco-ui/uui-base/lib/events';
-import { UUIFileDropzoneElement } from './uui-file-dropzone.element';
+import {
+  UUIFileDropzoneElement,
+  UUIFileFolder,
+} from './uui-file-dropzone.element';
 
 export class UUIFileDropzoneEvent extends UUIEvent<
-  { files: File[] },
+  { files: File[]; folders: UUIFileFolder[] },
   UUIFileDropzoneElement
 > {
   public static readonly CHANGE: string = 'change';

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
@@ -3,7 +3,8 @@ import { css, html, LitElement } from 'lit';
 import { query, property } from 'lit/decorators.js';
 import { UUIFileDropzoneEvent } from './UUIFileDropzoneEvent';
 import { LabelMixin } from '@umbraco-ui/uui-base/lib/mixins';
-import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
+
+import '@umbraco-ui/uui-symbol-file-dropzone/lib';
 
 export interface UUIFileFolder {
   folderName: string;
@@ -103,11 +104,6 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
     this.addEventListener('dragleave', this._onDragLeave, false);
     this.addEventListener('dragover', this._onDragOver, false);
     this.addEventListener('drop', this._onDrop, false);
-  }
-
-  connectedCallback(): void {
-    super.connectedCallback();
-    demandCustomElement(this, 'uui-symbol-file-dropzone');
   }
 
   private async _getAllEntries(dataTransferItemList: DataTransferItemList) {

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
@@ -164,7 +164,7 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
             folders.push(directory);
           }
         }
-
+        // readEntries only reads up to 100 entries at a time. It is on purpose we call readEntries recursively.
         readEntries(reader);
       });
     };

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
@@ -114,7 +114,7 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
     const files: File[] = [];
 
     for (const entry of queue) {
-      if (!entry || entry.kind !== 'file') continue;
+      if (entry?.kind !== 'file') continue;
 
       if (entry.type) {
         // Entry is a file
@@ -125,14 +125,7 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
         }
       } else if (!this.disallowFolderUpload) {
         // Entry is a directory
-        let dir: FileSystemDirectoryEntry | null = null;
-
-        if ('webkitGetAsEntry' in entry) {
-          dir = entry.webkitGetAsEntry() as FileSystemDirectoryEntry;
-        } else if ('getAsEntry' in entry) {
-          // non-WebKit browsers may rename webkitGetAsEntry to getAsEntry. MDN recommends looking for both.
-          dir = (entry as any).getAsEntry();
-        }
+        const dir = this._getEntry(entry);
 
         if (dir) {
           const structure = await this._mkdir(dir);
@@ -141,6 +134,23 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
       }
     }
     return { files, folders };
+  }
+
+  /**
+   * Get the directory entry from a DataTransferItem.
+   * @remark Supports both WebKit and non-WebKit browsers.
+   */
+  private _getEntry(entry: DataTransferItem): FileSystemDirectoryEntry | null {
+    let dir: FileSystemDirectoryEntry | null = null;
+
+    if ('webkitGetAsEntry' in entry) {
+      dir = entry.webkitGetAsEntry() as FileSystemDirectoryEntry;
+    } else if ('getAsEntry' in entry) {
+      // non-WebKit browsers may rename webkitGetAsEntry to getAsEntry. MDN recommends looking for both.
+      dir = (entry as any).getAsEntry();
+    }
+
+    return dir;
   }
 
   // Make directory structure

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.test.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.test.ts
@@ -1,12 +1,14 @@
 import { html, fixture, expect } from '@open-wc/testing';
 import { UUIFileDropzoneElement } from './uui-file-dropzone.element';
-import '.';
+import { UUIFileDropzoneEvent } from './UUIFileDropzoneEvent';
 
 describe('UUIFileDropzoneElement', () => {
   let element: UUIFileDropzoneElement;
 
   beforeEach(async () => {
-    element = await fixture(html` <uui-file-dropzone></uui-file-dropzone> `);
+    element = await fixture(html`
+      <uui-file-dropzone label="Dropzone"></uui-file-dropzone>
+    `);
   });
 
   it('is defined with its own instance', () => {
@@ -15,5 +17,52 @@ describe('UUIFileDropzoneElement', () => {
 
   it('passes the a11y audit', async () => {
     await expect(element).shadowDom.to.be.accessible();
+  });
+
+  describe('dragover', () => {
+    it('supports dropping a single file', done => {
+      const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
+      const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file1);
+      dataTransfer.items.add(file2);
+
+      element.addEventListener('change', e => {
+        const { files, folders } = (e as UUIFileDropzoneEvent).detail;
+        expect(files.length, 'There should be one file uploaded').to.equal(1);
+        expect(folders.length, 'There should be no folders uploaded').to.equal(
+          0,
+        );
+        done();
+      });
+
+      element.dispatchEvent(new DragEvent('drop', { dataTransfer }));
+    });
+
+    it('can drop multiple files', done => {
+      const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
+      const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file1);
+      dataTransfer.items.add(file2);
+
+      element.multiple = true;
+
+      element.addEventListener('change', e => {
+        const { files, folders } = (e as UUIFileDropzoneEvent).detail;
+        expect(files.length, 'There should be two files uploaded').to.equal(2);
+        expect(folders.length, 'There should be no folders uploaded').to.equal(
+          0,
+        );
+        done();
+      });
+
+      element.dispatchEvent(new DragEvent('drop', { dataTransfer }));
+    });
+
+    it('can drop a folder with multiple files', () => {
+      // TODO: Need to find a way to simulate a folder drop
+      expect(true).to.equal(true);
+    });
   });
 });


### PR DESCRIPTION
## Description

Dropzone now supports folder uploading. Folders inside folders are also allowed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)