### PR TITLE
feat(uui-color-picker): allow the value to be empty

### DIFF
--- a/packages/uui-color-picker/lib/uui-color-picker.element.ts
+++ b/packages/uui-color-picker/lib/uui-color-picker.element.ts
@@ -428,7 +428,7 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
         })}
         aria-disabled=${this.disabled ? 'true' : 'false'}>
         <uui-color-area
-          .value="${this.value ?? ''}"
+          .value="${this.value}"
           .hue="${Math.round(this.hue)}"
           ?disabled=${this.disabled}
           @change=${this.handleGridChange}>

--- a/packages/uui-color-picker/lib/uui-color-picker.element.ts
+++ b/packages/uui-color-picker/lib/uui-color-picker.element.ts
@@ -73,7 +73,7 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
   @state() private hue = 0;
   @state() private saturation = 0;
   @state() private lightness = 0;
-  @state() private alpha = 100;
+  @state() private alpha = 0;
   @state() private _colord: Colord = colord('hsl(0, 0%, 0%)');
 
   /**
@@ -185,8 +185,6 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
 
   connectedCallback(): void {
     super.connectedCallback();
-
-    this.setColor(this.value);
 
     demandCustomElement(this, 'uui-icon');
     demandCustomElement(this, 'uui-icon-registry-essential');

--- a/packages/uui-color-picker/lib/uui-color-picker.element.ts
+++ b/packages/uui-color-picker/lib/uui-color-picker.element.ts
@@ -68,7 +68,8 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
   @query('.color-picker__preview') private _previewButton!: HTMLButtonElement;
   @query('#swatches') private _swatches!: UUIColorSwatchesElement;
 
-  @state() private _value: string = '';
+  private _value: string = '';
+
   @state() private inputValue = '';
   @state() private hue = 0;
   @state() private saturation = 0;
@@ -349,14 +350,15 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
   }
 
   setColor(colorString: string | HslaColor) {
-    if (!colorString) {
+    if (!colorString && colorString !== this.value) {
       this.alpha = 0;
-      if (colorString !== this.value) {
-        this._value = colorString;
-        this.dispatchEvent(
-          new UUIColorPickerChangeEvent(UUIColorPickerChangeEvent.CHANGE),
-        );
-      }
+      this.inputValue = '';
+      this._value = colorString;
+
+      this.dispatchEvent(
+        new UUIColorPickerChangeEvent(UUIColorPickerChangeEvent.CHANGE),
+      );
+
       return true;
     }
 

--- a/packages/uui-color-picker/lib/uui-color-picker.element.ts
+++ b/packages/uui-color-picker/lib/uui-color-picker.element.ts
@@ -81,7 +81,7 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
    * @type {string}
    * @default ''
    **/
-  @property() value = '';
+  @property() value?: string;
 
   /**
    * The format to use for the display value. If opacity is enabled, these will translate to HEXA, RGBA, HSLA, and HSVA
@@ -179,7 +179,7 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
     if (this.value) {
       this.setColor(this.value);
     } else {
-      this.setColor('#000');
+      this.setColor(undefined);
     }
 
     demandCustomElement(this, 'uui-icon');
@@ -297,9 +297,9 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
 
     if (target.value) {
       this.setColor(target.value);
-      target.value = this.value;
+      target.value = this.value ?? '';
     } else {
-      this.setColor('#000');
+      this.setColor(undefined);
     }
 
     event.stopPropagation();
@@ -311,10 +311,10 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
         this.setColor(this.inputValue);
         this._swatches?.resetSelection();
 
-        this.inputValue = this.value;
+        this.inputValue = this.value ?? '';
         setTimeout(() => this._input.select());
       } else {
-        this.setColor('#000');
+        this.setColor(undefined);
       }
     }
   }
@@ -327,8 +327,7 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
     if (target.value) {
       this.setColor(target.value);
     } else {
-      //reset to black
-      this.setColor('#000');
+      this.setColor(undefined);
     }
   }
 
@@ -359,7 +358,17 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
       });
   }
 
-  setColor(colorString: string | HslaColor) {
+  setColor(colorString: string | HslaColor | undefined) {
+    if (!colorString) {
+      // Do not run sync values when undefined. Any good way to indicate our undefined value?
+      this.alpha = 0;
+      this.inputValue = this.getFormattedValue(this.format);
+
+      this.dispatchEvent(
+        new UUIColorPickerChangeEvent(UUIColorPickerChangeEvent.CHANGE),
+      );
+      return true;
+    }
     const colord = new Colord(colorString);
 
     const { h, s, l, a } = colord.toHsl();
@@ -425,7 +434,7 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
         })}
         aria-disabled=${this.disabled ? 'true' : 'false'}>
         <uui-color-area
-          .value="${this.value}"
+          .value="${this.value ?? ''}"
           .hue="${Math.round(this.hue)}"
           ?disabled=${this.disabled}
           @change=${this.handleGridChange}>
@@ -529,7 +538,7 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
   }
 
   private _renderPreviewButton() {
-    return html` <button
+    return html`<button
         type="button"
         part="trigger"
         aria-label="${this.label || 'Open Color picker'}"

--- a/packages/uui-color-picker/lib/uui-color-picker.element.ts
+++ b/packages/uui-color-picker/lib/uui-color-picker.element.ts
@@ -298,20 +298,20 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
 
   handleInputChange(event: CustomEvent) {
     event.stopImmediatePropagation();
+    this._swatches?.resetSelection();
 
     this.inputValue = this._input.value as string;
     this.setColor(this.inputValue);
-
-    this._swatches?.resetSelection();
   }
 
   handleInputKeyDown(event: KeyboardEvent) {
     event.stopImmediatePropagation();
     if (event.key === 'Enter') {
+      this._swatches?.resetSelection();
+
       this.inputValue = this._input.value as string;
       this.setColor(this.inputValue);
 
-      this._swatches?.resetSelection();
       setTimeout(() => this._input.select());
     }
   }

--- a/packages/uui-color-picker/lib/uui-color-picker.element.ts
+++ b/packages/uui-color-picker/lib/uui-color-picker.element.ts
@@ -350,7 +350,9 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
   }
 
   setColor(colorString: string | HslaColor) {
-    if (!colorString && colorString !== this.value) {
+    if (colorString === this.value) return;
+
+    if (!colorString) {
       this.alpha = 0;
       this.inputValue = '';
       this._value = colorString;

--- a/packages/uui-color-picker/lib/uui-color-picker.story.ts
+++ b/packages/uui-color-picker/lib/uui-color-picker.story.ts
@@ -78,9 +78,9 @@ type Story = StoryObj<UUIColorPickerElement>;
 
 export const Overview: Story = {};
 
-export const UndefinedValue: Story = {
+export const EmptyValue: Story = {
   args: {
-    value: undefined,
+    value: '',
   },
   parameters: {
     docs: {

--- a/packages/uui-color-picker/lib/uui-color-picker.story.ts
+++ b/packages/uui-color-picker/lib/uui-color-picker.story.ts
@@ -46,6 +46,7 @@ const meta: Meta<UUIColorPickerElement> = {
     swatches: defaultSwatches,
     format: 'hex',
     size: 'medium',
+    value: '#000000',
   },
   argTypes: {
     format: {
@@ -76,6 +77,19 @@ export default meta;
 type Story = StoryObj<UUIColorPickerElement>;
 
 export const Overview: Story = {};
+
+export const UndefinedValue: Story = {
+  args: {
+    value: undefined,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<uui-color-picker></uui-color-picker>`,
+      },
+    },
+  },
+};
 
 export const Inline: Story = {
   args: {


### PR DESCRIPTION
## Description

Allows the UUI Color picker to have an empty string as value. This shows up as fully transparent.
Deleting a picked color now sets the value to empty string.

Fixed an issue where when typing in a color manually in the input field it would not update the value.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context
We dont want the color picker to automatically pick a color for us. 
