### PR TITLE
Consistent cursor style for checkbox and radiobutton

### DIFF
--- a/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
+++ b/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
@@ -213,8 +213,7 @@ export abstract class UUIBooleanInputElement extends UUIFormControlMixin(
       }
 
       :host([readonly]) label {
-        cursor: text;
-        user-select: auto;
+        cursor: default;
       }
 
       input {
@@ -238,7 +237,8 @@ export abstract class UUIBooleanInputElement extends UUIFormControlMixin(
         flex-direction: column;
       }
 
-      :host([disabled]) .label {
+      :host([disabled]) label {
+        cursor: not-allowed;
         opacity: 0.5;
       }
     `,

--- a/packages/uui-checkbox/lib/uui-checkbox.story.ts
+++ b/packages/uui-checkbox/lib/uui-checkbox.story.ts
@@ -1,6 +1,6 @@
 import '.';
 
-import { Story } from '@storybook/web-components';
+import { StoryFn } from '@storybook/web-components';
 import { html } from 'lit';
 import readme from '../README.md?raw';
 
@@ -34,7 +34,7 @@ export default {
   },
 };
 
-export const AAAOverview: Story = props => html`
+export const AAAOverview: StoryFn = props => html`
   <uui-checkbox
     style="--uui-checkbox-size: ${props['--uui-checkbox-size']}"
     .value=${props.value}
@@ -60,7 +60,7 @@ AAAOverview.argTypes = {
   '--uui-checkbox-size': { control: { type: 'text' } },
 };
 
-export const Error: Story = props => html`<div style="display: flex; gap: 20px;">
+export const Error: StoryFn = props => html`<div style="display: flex; gap: 20px;">
   <uui-checkbox .label=${'Checkbox label'} ?error=${props.error}></uui-checkbox>
   <uui-checkbox
     ?error=${props.error}
@@ -87,7 +87,7 @@ Error.parameters = {
   },
 };
 
-export const WithSlottedLabel: Story = props => html`
+export const WithSlottedLabel: StoryFn = props => html`
   <uui-checkbox
     .label=${'Checkbox label'}
     ?checked=${props.checked}
@@ -104,7 +104,7 @@ WithSlottedLabel.parameters = {
   },
 };
 
-export const LabelPosition: Story = props => html`
+export const LabelPosition: StoryFn = props => html`
   <div
     style="display: grid; grid-template-columns: repeat(4, 128px); align-items: center; justify-items: center">
     <uui-checkbox
@@ -139,7 +139,7 @@ LabelPosition.parameters = {
   },
 };
 
-export const Disabled: Story = props => html`
+export const Disabled: StoryFn = props => html`
   <uui-checkbox
     ?disabled=${props.disabled}
     .label=${'Checkbox label'}></uui-checkbox>
@@ -159,7 +159,7 @@ Disabled.parameters = {
   },
 };
 
-export const Readonly: Story = props => html`
+export const Readonly: StoryFn = props => html`
   <uui-checkbox
     ?readonly=${props.readonly}
     .label=${'Readonly'}

--- a/packages/uui-checkbox/lib/uui-checkbox.story.ts
+++ b/packages/uui-checkbox/lib/uui-checkbox.story.ts
@@ -60,12 +60,11 @@ AAAOverview.argTypes = {
   '--uui-checkbox-size': { control: { type: 'text' } },
 };
 
-export const Error: Story = props => html`
+export const Error: Story = props => html`<div style="display: flex; gap: 20px;">
   <uui-checkbox .label=${'Checkbox label'} ?error=${props.error}></uui-checkbox>
   <uui-checkbox
     ?error=${props.error}
     .label=${'Checkbox label'}
-    style="margin-left: 20px;"
     checked></uui-checkbox>
   <uui-checkbox
     disabled
@@ -75,8 +74,8 @@ export const Error: Story = props => html`
     ?error=${props.error}
     disabled
     .label=${'Checkbox label'}
-    style="margin-left: 20px;"
     checked></uui-checkbox>
+  </div>
 `;
 Error.args = { error: true };
 Error.parameters = {

--- a/packages/uui-checkbox/lib/uui-checkbox.story.ts
+++ b/packages/uui-checkbox/lib/uui-checkbox.story.ts
@@ -60,23 +60,25 @@ AAAOverview.argTypes = {
   '--uui-checkbox-size': { control: { type: 'text' } },
 };
 
-export const Error: StoryFn = props => html`<div style="display: flex; gap: 20px;">
-  <uui-checkbox .label=${'Checkbox label'} ?error=${props.error}></uui-checkbox>
-  <uui-checkbox
-    ?error=${props.error}
-    .label=${'Checkbox label'}
-    checked></uui-checkbox>
-  <uui-checkbox
-    disabled
-    .label=${'Checkbox label'}
-    ?error=${props.error}></uui-checkbox>
-  <uui-checkbox
-    ?error=${props.error}
-    disabled
-    .label=${'Checkbox label'}
-    checked></uui-checkbox>
-  </div>
-`;
+export const Error: StoryFn = props =>
+  html`<div style="display: flex; gap: 20px;">
+    <uui-checkbox
+      .label=${'Checkbox label'}
+      ?error=${props.error}></uui-checkbox>
+    <uui-checkbox
+      ?error=${props.error}
+      .label=${'Checkbox label'}
+      checked></uui-checkbox>
+    <uui-checkbox
+      disabled
+      .label=${'Checkbox label'}
+      ?error=${props.error}></uui-checkbox>
+    <uui-checkbox
+      ?error=${props.error}
+      disabled
+      .label=${'Checkbox label'}
+      checked></uui-checkbox>
+  </div> `;
 Error.args = { error: true };
 Error.parameters = {
   controls: { include: ['error'] },

--- a/packages/uui-checkbox/lib/uui-checkbox.test.ts
+++ b/packages/uui-checkbox/lib/uui-checkbox.test.ts
@@ -8,7 +8,7 @@ import {
 import { UUICheckboxElement } from './uui-checkbox.element';
 import './index';
 
-describe('UuiToggle', () => {
+describe('UUICheckbox', () => {
   let element: UUICheckboxElement;
   let input: HTMLInputElement;
   let iconCheck: HTMLElement;

--- a/packages/uui-radio/lib/uui-radio-group.test.ts
+++ b/packages/uui-radio/lib/uui-radio-group.test.ts
@@ -14,7 +14,7 @@ const preventSubmit = (e: SubmitEvent) => {
   e.preventDefault();
 };
 
-describe('UuiRadio', () => {
+describe('UUIRadio', () => {
   let element: UUIRadioGroupElement;
   let radios: UUIRadioElement[];
   beforeEach(async () => {

--- a/packages/uui-radio/lib/uui-radio.element.ts
+++ b/packages/uui-radio/lib/uui-radio.element.ts
@@ -193,12 +193,17 @@ export class UUIRadioElement extends LitElement {
       }
 
       label {
-        display: block;
+        position: relative;
         box-sizing: border-box;
+        user-select: none;
         display: flex;
         align-items: center;
         cursor: pointer;
         line-height: 18px;
+      }
+
+      :host([readonly]) label {
+        cursor: default;
       }
 
       #input {
@@ -267,7 +272,7 @@ export class UUIRadioElement extends LitElement {
       }
 
       :host([disabled]) label {
-        cursor: default;
+        cursor: not-allowed;
         opacity: 0.5;
       }
       :host([disabled]) .label {

--- a/packages/uui-radio/lib/uui-radio.story.ts
+++ b/packages/uui-radio/lib/uui-radio.story.ts
@@ -1,6 +1,6 @@
 import '.';
 
-import { Story } from '@storybook/web-components';
+import { StoryFn } from '@storybook/web-components';
 import { html } from 'lit';
 import readme from '../README.md?raw';
 
@@ -22,7 +22,7 @@ export default {
   },
 };
 
-export const AAAOverview: Story = props =>
+export const AAAOverview: StoryFn = props =>
   html`<uui-radio
     .value=${props.value}
     .label=${props.label}
@@ -34,7 +34,7 @@ export const AAAOverview: Story = props =>
   >`;
 AAAOverview.storyName = 'Overview';
 
-export const Disabled: Story = props =>
+export const Disabled: StoryFn = props =>
   html` <uui-radio value="1" ?disabled=${props.disabled}>Disabled</uui-radio>`;
 
 Disabled.args = {
@@ -52,7 +52,7 @@ Disabled.parameters = {
   },
 };
 
-export const Readonly: Story = props =>
+export const Readonly: StoryFn = props =>
   html` <uui-radio value="1" ?readonly=${props.readonly}>Readonly</uui-radio>`;
 
 Readonly.args = {
@@ -70,7 +70,7 @@ Readonly.parameters = {
   },
 };
 
-export const Checked: Story = props =>
+export const Checked: StoryFn = props =>
   html` <uui-radio value="1" ?checked=${props.checked}>Checked</uui-radio>`;
 
 Checked.args = {
@@ -88,7 +88,7 @@ Checked.parameters = {
   },
 };
 
-export const RadioGroup: Story = () => html`
+export const RadioGroup: StoryFn = () => html`
   <h5>Group 1</h5>
   <uui-radio-group name="radioGroup">
     <uui-radio value="1">Option 1</uui-radio>
@@ -191,7 +191,7 @@ RadioGroup.parameters = {
   },
 };
 
-export const DisabledGroup: Story = props => html`
+export const DisabledGroup: StoryFn = props => html`
   <uui-radio-group .disabled=${props.disabled}>
     <uui-radio value="1">one</uui-radio>
     <uui-radio value="2" .checked=${props.checked}>two</uui-radio>
@@ -203,7 +203,7 @@ DisabledGroup.args = {
   disabled: true,
 };
 
-export const GroupWithStartValue: Story = props => html`
+export const GroupWithStartValue: StoryFn = props => html`
   <uui-radio-group value=${props.value}>
     <uui-radio value="1">one</uui-radio>
     <uui-radio value="2">two</uui-radio>

--- a/packages/uui-toggle/lib/uui-toggle.story.ts
+++ b/packages/uui-toggle/lib/uui-toggle.story.ts
@@ -1,6 +1,6 @@
 import '.';
 
-import { Story } from '@storybook/web-components';
+import { StoryFn } from '@storybook/web-components';
 import { html } from 'lit';
 import readme from '../README.md?raw';
 
@@ -28,7 +28,7 @@ export default {
   },
 };
 
-export const AAAOverview: Story = props => html`
+export const AAAOverview: StoryFn = props => html`
   <uui-toggle
     style="--uui-toggle-size: ${props[
       '--uui-toggle-size'
@@ -61,7 +61,7 @@ AAAOverview.parameters = {
   },
 };
 
-export const Error: Story = props => html`
+export const Error: StoryFn = props => html`
   <uui-toggle ?error=${props.error} label="Error"></uui-toggle><br />
   <uui-toggle ?error=${props.error} label="Error checked" checked></uui-toggle
   ><br /><uui-toggle
@@ -88,7 +88,7 @@ Error.parameters = {
   },
 };
 
-export const WithSlottedLabel: Story = props => html`
+export const WithSlottedLabel: StoryFn = props => html`
   <uui-toggle label="Toggle label" ?checked=${props.checked} value="toggle"
     >Using <b>Slot</b> for displayed label</uui-toggle
   >
@@ -102,7 +102,7 @@ WithSlottedLabel.parameters = {
   },
 };
 
-export const LabelPosition: Story = props => html`
+export const LabelPosition: StoryFn = props => html`
   <div
     style="display: grid; grid-template-columns: repeat(4, 128px); align-items: center; justify-items: center">
     <uui-toggle
@@ -135,7 +135,7 @@ LabelPosition.parameters = {
   },
 };
 
-export const Disabled: Story = props => html`
+export const Disabled: StoryFn = props => html`
   <uui-toggle ?disabled=${props.disabled} label="Disabled"></uui-toggle>
   <uui-toggle
     ?disabled=${props.disabled}
@@ -153,7 +153,7 @@ Disabled.parameters = {
   },
 };
 
-export const Readonly: Story = props => html`
+export const Readonly: StoryFn = props => html`
   <uui-toggle ?readonly=${props.readonly} label="Readonly" checked></uui-toggle>
 `;
 Readonly.args = { readonly: true };

--- a/packages/uui-toggle/lib/uui-toggle.test.ts
+++ b/packages/uui-toggle/lib/uui-toggle.test.ts
@@ -9,7 +9,7 @@ import { UUIBooleanInputElement } from '@umbraco-ui/uui-boolean-input/lib';
 
 import { UUIToggleElement } from './uui-toggle.element';
 
-describe('UuiToggle', () => {
+describe('UUIToggle', () => {
   let element: UUIToggleElement;
   let input: HTMLInputElement;
   beforeEach(async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR makes some consistency in cursor style of `<uui-checkbox>` and `<uui-radio>`.

- When `readonly` the text isn't selectable as the the other states
- When `disabled` is use `not-allowed` cursor style instead - the style on `<label>` wasn't consistent for checkbox/radiobutton.
- It had redundant `display` CSS property in  `<uui-radio>`
- Simplified checkbox story using `gap: 20px` instead of `margin-left: 20px` on each item.

I also replaced some of the deprecated `Story` with new `StoryFn` and updated the describe name to same format as `UUIInputFileElement`, so instead of `UuiToggle` -> `UUIToggle` (and before checkbox used same name as toggle in tests)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
