### PR TITLE
chore(uui-loader-bar): use the generic `clamp` function from `uui-base`

### DIFF
--- a/packages/uui-loader-bar/lib/uui-loader-bar.element.ts
+++ b/packages/uui-loader-bar/lib/uui-loader-bar.element.ts
@@ -1,9 +1,7 @@
 import { css, html, LitElement } from 'lit';
-import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { property } from 'lit/decorators.js';
-
-const clamp = (num: number, min: number, max: number) =>
-  Math.min(Math.max(num, min), max);
+import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { clamp } from '@umbraco-ui/uui-base/lib/utils';
 
 /**
  *  @element uui-loader-bar


### PR DESCRIPTION
## Description

We now have a generic `clamp` function, so use that instead of defining it locally.

Ref https://github.com/umbraco/Umbraco.CMS.Backoffice/pull/1021#issuecomment-2118387247