### PR TITLE
fix(uui-textarea): add danger border if the element is invalid

### DIFF
--- a/packages/uui-textarea/lib/uui-textarea.element.ts
+++ b/packages/uui-textarea/lib/uui-textarea.element.ts
@@ -276,15 +276,19 @@ export class UUITextareaElement extends UUIFormControlMixin(LitElement, '') {
       :host {
         position: relative;
       }
-      :host([error]) textarea {
-        border: 1px solid var(--uui-color-danger) !important;
-      }
+      :host([error]) textarea,
       :host([error]) textarea[disabled] {
         border: 1px solid var(--uui-color-danger) !important;
+      }
+      :host(:not([pristine]):invalid) textarea,
+      /* polyfill support */
+      :host(:not([pristine])[internals-invalid]) textarea {
+        border-color: var(--uui-color-danger);
       }
       :host([auto-height]) textarea {
         resize: none;
       }
+
       .label {
         display: inline-block;
         margin-bottom: var(--uui-size-1);


### PR DESCRIPTION
## Description

Show a danger border if the element is invalid. This aligns the element with uui-input.

![image](https://github.com/user-attachments/assets/3fbbc45a-9ffb-4349-b55c-732e0c42be20)
