### PR TITLE
docs(uui-table): adjust link to the advanced table example

### DIFF
--- a/packages/uui-table/lib/uui-table.story.ts
+++ b/packages/uui-table/lib/uui-table.story.ts
@@ -225,7 +225,7 @@ Advanced.parameters = {
     source: {
       code: `
 Take a look at the source code for the advanced example:
-https://github.com/umbraco/Umbraco.UI/blob/d26635f0851e32b875406e7f951cdc5660bd8baa/packages/uui-table/lib/uui-table-advanced-example.ts
+https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/packages/uui-table/lib/uui-table-advanced-example.ts
       `,
     },
   },


### PR DESCRIPTION
Updated the link in table-story to the advanced table story so it now redirects correctly

<!--- Provide a general summary of your changes in the Title above -->

## Description

The previous link to the advanced table story redirected to 404, I have updated the link to the correct one.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context



## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
