### PR TITLE
fix(uui-menu-item): the caret button is missing an `aria-label` attribute

### DIFF
--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -111,6 +111,15 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
   @property({ type: String, attribute: 'select-mode', reflect: true })
   public selectMode?: 'highlight' | 'persisting';
 
+  /**
+   * Sets the aria-label for the caret button.
+   * @remark Only used when the menu item has children.
+   * @attr
+   * @default 'Reveal the underlying items'
+   */
+  @property({ type: String, attribute: 'caret-label' })
+  public caretLabel = 'Reveal the underlying items';
+
   @state()
   private iconSlotHasContent = false;
 
@@ -206,8 +215,13 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
     return html`
       <div id="menu-item" aria-label="menuitem" role="menuitem">
         ${this.hasChildren
-          ? html`<button id="caret-button" @click=${this._onCaretClicked}>
-              <uui-symbol-expand ?open=${this.showChildren}></uui-symbol-expand>
+          ? html`<button
+              id="caret-button"
+              aria-label=${this.caretLabel}
+              @click=${this._onCaretClicked}>
+              <uui-symbol-expand
+                aria-hidden="true"
+                ?open=${this.showChildren}></uui-symbol-expand>
             </button>`
           : ''}
         ${this.href ? this._renderLabelAsAnchor() : this._renderLabelAsButton()}

--- a/packages/uui-menu-item/lib/uui-menu-item.story.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.story.ts
@@ -1,5 +1,7 @@
 import '.';
 import '@umbraco-ui/uui-icon-registry-essential/lib';
+import '@umbraco-ui/uui-symbol-expand/lib';
+import '@umbraco-ui/uui-symbol-more/lib';
 
 import { Story } from '@storybook/web-components';
 import { html } from 'lit';
@@ -8,8 +10,6 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { UUIMenuItemElement } from './uui-menu-item.element';
 import { UUIMenuItemEvent } from './UUIMenuItemEvent';
 import readme from '../README.md?raw';
-import '@umbraco-ui/uui-symbol-expand/lib';
-import '@umbraco-ui/uui-symbol-more/lib';
 
 export default {
   title: 'Buttons/Menu Item',
@@ -31,6 +31,7 @@ export default {
     target: undefined,
     rel: undefined,
     selectMode: undefined,
+    caretLabel: 'Expand',
   },
   argTypes: {
     '--uui-menu-item-indent': { control: { type: 'text' } },
@@ -140,10 +141,13 @@ AAAOverview.parameters = {
   },
 };
 
-export const Nested = () => html`
+export const Nested = props => html`
   ${labelNames.map(
     (name: string) =>
-      html` <uui-menu-item label="${name}" has-children>
+      html` <uui-menu-item
+        label="${name}"
+        .caretLabel="${props.caretLabel}"
+        has-children>
         ${renderItems()}
       </uui-menu-item>`,
   )}

--- a/packages/uui-menu-item/lib/uui-menu-item.test.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.test.ts
@@ -28,6 +28,16 @@ describe('UUIMenuItemElement', () => {
     await expect(element).shadowDom.to.be.accessible();
   });
 
+  it('passes the a11y audit with nesting', async () => {
+    element = await fixture(
+      html`<uui-menu-item label="menuitem" has-children>
+        <uui-menu-item label="sub-menuitem"></uui-menu-item>
+        <uui-menu-item label="sub-menuitem"></uui-menu-item>
+      </uui-menu-item>`,
+    );
+    await expect(element).shadowDom.to.be.accessible();
+  });
+
   describe('properties', () => {
     it('has a disabled property', () => {
       expect(element).to.have.property('disabled');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Tested with Storybook and WTR: The accessibility tests were failing because of a missing aria-label.

This is a prerequisite to fix this CMS issue: https://github.com/umbraco/Umbraco-CMS/issues/16690

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?

1. Try and run the Storybook accessibility tests without a label and then with
2. Try and run the unit tests without a label and then with

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
