### PR TITLE
Make toggle fit content

### DIFF
--- a/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
+++ b/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
@@ -209,7 +209,7 @@ export abstract class UUIBooleanInputElement extends UUIFormControlMixin(
   static styles = [
     css`
       :host {
-        display: inline-block;
+        display: inline-flex;
       }
 
       label {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In some parts of the backoffice, when toggle as no label, when placed inside flexbox container or 100% width of `uui-toggle` which stretch label as well, so not only toggle + text in clickable, but also a large part of to whitespace area.

Can be seen a toggle properties in content workspace or in listview bulk actions.

Not sure this is the best option. Alternative `display: inline-flex` on label instead.

When inside flexbox container it could add `margin-right: auto;` to each toggle so it doesn't stretch to size on flexbox container.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?
Can be seen a toggle properties in content workspace or in listview bulk actions.

## Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/c4342125-4851-4e82-89e0-76b2c44dbcc0)

![image](https://github.com/user-attachments/assets/bddee828-2ddf-4f47-8635-2f269fe6a4be)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
