### PR TITLE
V1/bugfix/text color in top layer

### DIFF
--- a/packages/uui-modal/lib/uui-modal.element.ts
+++ b/packages/uui-modal/lib/uui-modal.element.ts
@@ -96,6 +96,7 @@ export class UUIModalElement extends LitElement {
         max-height: unset;
         border: none;
         background: none;
+        color: var(--uui-color-text);
       }
       dialog::backdrop {
         background: none;

--- a/packages/uui-popover-container/lib/uui-popover-container.element.ts
+++ b/packages/uui-popover-container/lib/uui-popover-container.element.ts
@@ -367,6 +367,7 @@ export class UUIPopoverContainerElement extends LitElement {
         background-color: none;
         background: none;
         overflow: visible;
+        color: var(--uui-color-text);
       }
     `,
   ];


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/16247

Makes all modals and popovers (anything that goes into the `#top-layer`) use the correct css var for text.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
