### PR TITLE
fix: Aligned more symbol to center

### DIFF
--- a/packages/uui-symbol-more/lib/uui-symbol-more.element.ts
+++ b/packages/uui-symbol-more/lib/uui-symbol-more.element.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit';
+import { LitElement, svg, css } from 'lit';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 /**
  * @element uui-symbol-more
@@ -6,16 +6,20 @@ import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 @defineElement('uui-symbol-more')
 export class UUISymbolMoreElement extends LitElement {
   render() {
-    return html`···`;
+    return svg`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <circle cx="17" cy="50" r="9"></circle>
+      <circle cx="50" cy="50" r="9"></circle>
+      <circle cx="83" cy="50" r="9"></circle>
+    </svg>`;
   }
 
   static styles = [
     css`
       :host {
         display: inline-block;
-        font-size: 1.48em;
-        line-height: 0.8em;
-        user-select: none;
+        vertical-align: bottom;
+        width: 1.15em;
+        height: 1.15em;
       }
     `,
   ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe the changes in detail -->

This fixes the alignment of the more icon so it's aligned similarly to other icons.

This is the changes applied to the Umbraco backoffice (v14) via devtools:

### Before:
![umb-align](https://github.com/user-attachments/assets/bc2b061c-2b6a-4cd6-89aa-a9110b6b83a0)

### After:
![umb-align-2](https://github.com/user-attachments/assets/791d864a-d0ae-490b-91a6-fb37a7211fe2)

I've tried to match the icon to a pixel-perfect similar svg icon (See screenshots)

This also fixes the small difference in size of the more icon compared to the other icons

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

It hurts my eyes that the three dots are not aligned with the other icons 😅 

## How to test?

## Screenshots (if appropriate)

From storybook (zoomed in a lot):

### Before:
![image](https://github.com/user-attachments/assets/7eeb7994-8a8a-46fe-8355-4dab63b9e9ed)


### After:
![image](https://github.com/user-attachments/assets/64cfb28a-d728-471b-b7e5-f6c13f1e54ac)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
