### PR TITLE
Bugfix: Dropzone thinks custom file extensions are folders

### DIFF
--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.element.ts
@@ -116,7 +116,10 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
     for (const entry of queue) {
       if (entry?.kind !== 'file') continue;
 
-      if (entry.type) {
+      const fileEntry = this._getEntry(entry);
+      if (!fileEntry) continue;
+
+      if (!fileEntry.isDirectory) {
         // Entry is a file
         const file = entry.getAsFile();
         if (!file) continue;
@@ -125,12 +128,8 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
         }
       } else if (!this.disallowFolderUpload && this.multiple) {
         // Entry is a directory
-        const dir = this._getEntry(entry);
-
-        if (dir) {
-          const structure = await this._mkdir(dir);
-          folders.push(structure);
-        }
+        const structure = await this._mkdir(fileEntry);
+        folders.push(structure);
       }
     }
 

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.test.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.test.ts
@@ -8,7 +8,7 @@ function expectFileChangeEvent(
   numberOfFolders: number,
   done: Mocha.Done,
 ) {
-  return element.addEventListener('change', e => {
+  element.addEventListener('change', e => {
     const { files, folders } = (e as UUIFileDropzoneEvent).detail;
     expect(
       files.length,
@@ -18,7 +18,7 @@ function expectFileChangeEvent(
       folders.length,
       `There should be ${numberOfFolders} folder(s) uploaded`,
     ).to.equal(numberOfFolders);
-    return done();
+    done();
   });
 }
 
@@ -41,6 +41,7 @@ describe('UUIFileDropzoneElement', () => {
 
   describe('drop files', async () => {
     it('supports dropping a single file', async done => {
+      setTimeout(() => done(), 5000);
       const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
       const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
       const dataTransfer = new DataTransfer();
@@ -58,11 +59,11 @@ describe('UUIFileDropzoneElement', () => {
     });
 
     it('can drop multiple files', done => {
-      element.multiple = true;
-
+      setTimeout(() => done(), 5000);
       const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
       const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
       const dataTransfer = new DataTransfer();
+      element.multiple = true;
       if ('items' in dataTransfer) {
         dataTransfer.items.add(file1);
         dataTransfer.items.add(file2);
@@ -74,6 +75,7 @@ describe('UUIFileDropzoneElement', () => {
     });
 
     it('can set the accept attribute with a mimetype', done => {
+      setTimeout(() => done(), 5000);
       const file1 = new File([''], 'file1.jpg', { type: 'image/jpeg' });
       const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
       const dataTransfer = new DataTransfer();
@@ -119,6 +121,7 @@ describe('UUIFileDropzoneElement', () => {
     });
 
     it('supports selecting a single file', done => {
+      setTimeout(() => done(), 5000);
       const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
       const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
       const dt = new DataTransfer();
@@ -136,6 +139,7 @@ describe('UUIFileDropzoneElement', () => {
     });
 
     it('can select multiple files', done => {
+      setTimeout(() => done(), 5000);
       const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
       const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
       const dt = new DataTransfer();

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.test.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.test.ts
@@ -1,4 +1,4 @@
-import { html, fixture, expect } from '@open-wc/testing';
+import { html, fixture, expect, oneEvent } from '@open-wc/testing';
 import { UUIFileDropzoneElement } from './uui-file-dropzone.element';
 import { UUIFileDropzoneEvent } from './UUIFileDropzoneEvent';
 
@@ -40,75 +40,82 @@ describe('UUIFileDropzoneElement', () => {
   });
 
   describe('drop files', async () => {
-    it('supports dropping a single file', async done => {
-      setTimeout(() => done(), 5000);
-      const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
-      const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
+    it('supports dropping a single file', () => {
       const dataTransfer = new DataTransfer();
-      // Skip if browser does not support items
+      // Skip if browser does not support DataTransfer.items
       if ('items' in dataTransfer) {
+        const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
+        const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
         dataTransfer.items.add(file1);
         dataTransfer.items.add(file2);
 
-        expectFileChangeEvent(element, 1, 0, done);
-
+        const listener = oneEvent(element, UUIFileDropzoneEvent.CHANGE, false);
         element.dispatchEvent(new DragEvent('drop', { dataTransfer }));
-      } else {
-        done();
+
+        listener.then(event => {
+          const { files } = event.detail;
+          expect(files.length).to.equal(1);
+        });
       }
     });
 
-    it('can drop multiple files', done => {
-      setTimeout(() => done(), 5000);
-      const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
-      const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
+    it('can drop multiple files', () => {
       const dataTransfer = new DataTransfer();
-      element.multiple = true;
       if ('items' in dataTransfer) {
+        const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
+        const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
         dataTransfer.items.add(file1);
         dataTransfer.items.add(file2);
-        expectFileChangeEvent(element, 2, 0, done);
+
+        element.multiple = true;
+
+        const listener = oneEvent(element, UUIFileDropzoneEvent.CHANGE, false);
         element.dispatchEvent(new DragEvent('drop', { dataTransfer }));
-      } else {
-        done();
+
+        listener.then(event => {
+          const { files } = event.detail;
+          expect(files.length).to.equal(1);
+        });
       }
     });
 
-    it('can set the accept attribute with a mimetype', done => {
-      setTimeout(() => done(), 5000);
-      const file1 = new File([''], 'file1.jpg', { type: 'image/jpeg' });
-      const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
+    it('can set the accept attribute with a mimetype', () => {
       const dataTransfer = new DataTransfer();
       if ('items' in dataTransfer) {
+        const file1 = new File([''], 'file1.jpg', { type: 'image/jpeg' });
+        const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
         dataTransfer.items.add(file1);
         dataTransfer.items.add(file2);
 
         element.accept = 'image/*';
 
-        expectFileChangeEvent(element, 1, 0, done);
-
+        const listener = oneEvent(element, UUIFileDropzoneEvent.CHANGE, false);
         element.dispatchEvent(new DragEvent('drop', { dataTransfer }));
-      } else {
-        done();
+
+        listener.then(event => {
+          const { files } = event.detail;
+          expect(files.length).to.equal(1);
+        });
       }
     });
 
-    it('can set the accept attribute with a file extension', done => {
-      setTimeout(() => done(), 5000);
-      const file1 = new File([''], 'file1.jpg', { type: 'image/jpeg' });
-      const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
+    it('can set the accept attribute with a file extension', () => {
       const dataTransfer = new DataTransfer();
       if ('items' in dataTransfer) {
+        const file1 = new File([''], 'file1.jpg', { type: 'image/jpeg' });
+        const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
         dataTransfer.items.add(file1);
         dataTransfer.items.add(file2);
 
         element.accept = '.jpg';
 
-        expectFileChangeEvent(element, 1, 0, done);
-
+        const listener = oneEvent(element, UUIFileDropzoneEvent.CHANGE, false);
         element.dispatchEvent(new DragEvent('drop', { dataTransfer }));
-      } else {
-        done();
+
+        listener.then(event => {
+          const { files } = event.detail;
+          expect(files.length).to.equal(1);
+        });
       }
     });
   });
@@ -121,11 +128,10 @@ describe('UUIFileDropzoneElement', () => {
     });
 
     it('supports selecting a single file', done => {
-      setTimeout(() => done(), 5000);
-      const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
-      const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
       const dt = new DataTransfer();
       if ('items' in dt) {
+        const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
+        const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
         dt.items.add(file1);
         dt.items.add(file2);
 
@@ -139,11 +145,10 @@ describe('UUIFileDropzoneElement', () => {
     });
 
     it('can select multiple files', done => {
-      setTimeout(() => done(), 5000);
-      const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
-      const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
       const dt = new DataTransfer();
       if ('items' in dt) {
+        const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
+        const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
         dt.items.add(file1);
         dt.items.add(file2);
 

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.test.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.test.ts
@@ -92,6 +92,7 @@ describe('UUIFileDropzoneElement', () => {
     });
 
     it('can set the accept attribute with a file extension', done => {
+      setTimeout(() => done(), 5000);
       const file1 = new File([''], 'file1.jpg', { type: 'image/jpeg' });
       const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
       const dataTransfer = new DataTransfer();

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.test.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.test.ts
@@ -1,4 +1,4 @@
-import { html, fixture, expect } from '@open-wc/testing';
+import { html, fixture, expect, aTimeout } from '@open-wc/testing';
 import { UUIFileDropzoneElement } from './uui-file-dropzone.element';
 import { UUIFileDropzoneEvent } from './UUIFileDropzoneEvent';
 
@@ -39,11 +39,13 @@ describe('UUIFileDropzoneElement', () => {
     await expect(element).shadowDom.to.be.accessible();
   });
 
-  describe('drop files', () => {
+  describe('drop files', async () => {
     it('supports dropping a single file', done => {
+      aTimeout(5000);
       const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
       const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
       const dataTransfer = new DataTransfer();
+
       dataTransfer.items.add(file1);
       dataTransfer.items.add(file2);
 
@@ -53,45 +55,55 @@ describe('UUIFileDropzoneElement', () => {
     });
 
     it('can drop multiple files', done => {
+      element.multiple = true;
+
       const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
       const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
       const dataTransfer = new DataTransfer();
-      dataTransfer.items.add(file1);
-      dataTransfer.items.add(file2);
-
-      element.multiple = true;
-
-      expectFileChangeEvent(element, 2, 0, done);
-
-      element.dispatchEvent(new DragEvent('drop', { dataTransfer }));
+      if ('items' in dataTransfer) {
+        dataTransfer.items.add(file1);
+        dataTransfer.items.add(file2);
+        expectFileChangeEvent(element, 2, 0, done);
+        element.dispatchEvent(new DragEvent('drop', { dataTransfer }));
+      } else {
+        done();
+      }
     });
 
     it('can set the accept attribute with a mimetype', done => {
       const file1 = new File([''], 'file1.jpg', { type: 'image/jpeg' });
       const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
       const dataTransfer = new DataTransfer();
-      dataTransfer.items.add(file1);
-      dataTransfer.items.add(file2);
+      if ('items' in dataTransfer) {
+        dataTransfer.items.add(file1);
+        dataTransfer.items.add(file2);
 
-      element.accept = 'image/*';
+        element.accept = 'image/*';
 
-      expectFileChangeEvent(element, 1, 0, done);
+        expectFileChangeEvent(element, 1, 0, done);
 
-      element.dispatchEvent(new DragEvent('drop', { dataTransfer }));
+        element.dispatchEvent(new DragEvent('drop', { dataTransfer }));
+      } else {
+        done();
+      }
     });
 
     it('can set the accept attribute with a file extension', done => {
       const file1 = new File([''], 'file1.jpg', { type: 'image/jpeg' });
       const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
       const dataTransfer = new DataTransfer();
-      dataTransfer.items.add(file1);
-      dataTransfer.items.add(file2);
+      if ('items' in dataTransfer) {
+        dataTransfer.items.add(file1);
+        dataTransfer.items.add(file2);
 
-      element.accept = '.jpg';
+        element.accept = '.jpg';
 
-      expectFileChangeEvent(element, 1, 0, done);
+        expectFileChangeEvent(element, 1, 0, done);
 
-      element.dispatchEvent(new DragEvent('drop', { dataTransfer }));
+        element.dispatchEvent(new DragEvent('drop', { dataTransfer }));
+      } else {
+        done();
+      }
     });
   });
 
@@ -106,28 +118,36 @@ describe('UUIFileDropzoneElement', () => {
       const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
       const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
       const dt = new DataTransfer();
-      dt.items.add(file1);
-      dt.items.add(file2);
+      if ('items' in dt) {
+        dt.items.add(file1);
+        dt.items.add(file2);
 
-      expectFileChangeEvent(element, 1, 0, done);
+        expectFileChangeEvent(element, 1, 0, done);
 
-      innerElement.files = dt.files;
-      innerElement.dispatchEvent(new Event('change'));
+        innerElement.files = dt.files;
+        innerElement.dispatchEvent(new Event('change'));
+      } else {
+        done();
+      }
     });
 
     it('can select multiple files', done => {
       const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
       const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
       const dt = new DataTransfer();
-      dt.items.add(file1);
-      dt.items.add(file2);
+      if ('items' in dt) {
+        dt.items.add(file1);
+        dt.items.add(file2);
 
-      element.multiple = true;
+        element.multiple = true;
 
-      expectFileChangeEvent(element, 2, 0, done);
+        expectFileChangeEvent(element, 2, 0, done);
 
-      innerElement.files = dt.files;
-      innerElement.dispatchEvent(new Event('change'));
+        innerElement.files = dt.files;
+        innerElement.dispatchEvent(new Event('change'));
+      } else {
+        done();
+      }
     });
   });
 });

--- a/packages/uui-file-dropzone/lib/uui-file-dropzone.test.ts
+++ b/packages/uui-file-dropzone/lib/uui-file-dropzone.test.ts
@@ -1,4 +1,4 @@
-import { html, fixture, expect, aTimeout } from '@open-wc/testing';
+import { html, fixture, expect } from '@open-wc/testing';
 import { UUIFileDropzoneElement } from './uui-file-dropzone.element';
 import { UUIFileDropzoneEvent } from './UUIFileDropzoneEvent';
 
@@ -8,7 +8,7 @@ function expectFileChangeEvent(
   numberOfFolders: number,
   done: Mocha.Done,
 ) {
-  element.addEventListener('change', e => {
+  return element.addEventListener('change', e => {
     const { files, folders } = (e as UUIFileDropzoneEvent).detail;
     expect(
       files.length,
@@ -18,7 +18,7 @@ function expectFileChangeEvent(
       folders.length,
       `There should be ${numberOfFolders} folder(s) uploaded`,
     ).to.equal(numberOfFolders);
-    done();
+    return done();
   });
 }
 
@@ -40,18 +40,21 @@ describe('UUIFileDropzoneElement', () => {
   });
 
   describe('drop files', async () => {
-    it('supports dropping a single file', done => {
-      aTimeout(5000);
+    it('supports dropping a single file', async done => {
       const file1 = new File([''], 'file1.txt', { type: 'text/plain' });
       const file2 = new File([''], 'file2.txt', { type: 'text/plain' });
       const dataTransfer = new DataTransfer();
+      // Skip if browser does not support items
+      if ('items' in dataTransfer) {
+        dataTransfer.items.add(file1);
+        dataTransfer.items.add(file2);
 
-      dataTransfer.items.add(file1);
-      dataTransfer.items.add(file2);
+        expectFileChangeEvent(element, 1, 0, done);
 
-      expectFileChangeEvent(element, 1, 0, done);
-
-      element.dispatchEvent(new DragEvent('drop', { dataTransfer }));
+        element.dispatchEvent(new DragEvent('drop', { dataTransfer }));
+      } else {
+        done();
+      }
     });
 
     it('can drop multiple files', done => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes a bug where uploading a `.udt` file results in error as the dropzone thinks its a folder.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)