### PR TITLE
Feat: Readonly state for uui-color-slider

### DIFF
--- a/packages/uui-color-slider/lib/uui-color-slider.element.ts
+++ b/packages/uui-color-slider/lib/uui-color-slider.element.ts
@@ -84,12 +84,22 @@ export class UUIColorSliderElement extends LabelMixin('label', LitElement) {
   @property() value = 0;
 
   /**
-   * Disables the color slider.
+   * Sets the color slider to readonly mode.
+   * @type {boolean}
+   * @attr
+   * @default false
+   */
+  @property({ type: Boolean, reflect: true })
+  readonly = false;
+
+  /**
+   * Sets the color slider to disabled.
    * @type {boolean}
    * @attr
    * @default false
    **/
-  @property({ type: Boolean, reflect: true }) disabled = false;
+  @property({ type: Boolean, reflect: true })
+  disabled = false;
 
   private container!: HTMLElement;
   private handle!: HTMLElement;
@@ -115,7 +125,8 @@ export class UUIColorSliderElement extends LabelMixin('label', LitElement) {
   }
 
   handleDrag(event: PointerEvent) {
-    if (this.disabled || !this.container || !this.handle) return;
+    if (this.disabled || this.readonly || !this.container || !this.handle)
+      return;
 
     const { width, height } = this.container.getBoundingClientRect();
 
@@ -140,7 +151,7 @@ export class UUIColorSliderElement extends LabelMixin('label', LitElement) {
   }
 
   handleClick(event: MouseEvent) {
-    if (this.disabled) return;
+    if (this.disabled || this.readonly) return;
 
     this.value = this.getValueFromMousePosition(event);
     this.syncValues();
@@ -258,7 +269,8 @@ export class UUIColorSliderElement extends LabelMixin('label', LitElement) {
         <span
           id="color-slider__handle"
           style="--current-value: ${this.cssPropCurrentValue}%;"
-          tabindex=${ifDefined(this.disabled ? undefined : '0')}></span>
+          tabindex=${ifDefined(this.disabled ? undefined : '0')}>
+        </span>
       </div>
       ${Math.round(this.value)}`;
   }
@@ -338,6 +350,14 @@ export class UUIColorSliderElement extends LabelMixin('label', LitElement) {
         user-select: none;
         pointer-events: none;
         opacity: 0.55;
+      }
+
+      :host([readonly]) {
+        cursor: default;
+      }
+
+      :host([readonly]) #color-slider {
+        pointer-events: none;
       }
 
       #color-slider__handle {

--- a/packages/uui-color-slider/lib/uui-color-slider.story.ts
+++ b/packages/uui-color-slider/lib/uui-color-slider.story.ts
@@ -53,7 +53,21 @@ export const Disabled: Story = {
   parameters: {
     docs: {
       source: {
-        code: `<uui-color-slider label="Slider label" disabled="true"></uui-color-slider>`,
+        code: `<uui-color-slider label="Slider label" disabled></uui-color-slider>`,
+      },
+    },
+  },
+};
+
+export const Readonly: Story = {
+  args: {
+    readonly: true,
+    value: 50,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<uui-color-slider label="Slider label" readonly></uui-color-slider>`,
       },
     },
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a readonly state for the `uui-color-slider` component. It will ensure that the handle can't be dragged or slider selected via touch/click event.
Fixes https://github.com/umbraco/Umbraco.UI/issues/899

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
