### PR TITLE
Focus handle in slider instead of slider track itself

### DIFF
--- a/packages/uui-slider/lib/uui-slider.element.ts
+++ b/packages/uui-slider/lib/uui-slider.element.ts
@@ -364,7 +364,7 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
         fill: var(--uui-color-border-emphasis);
       }
 
-      input:focus ~ #track svg {
+      input:focus ~ #track #thumb {
         outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
           var(--uui-color-focus);
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes https://github.com/umbraco/Umbraco.UI/issues/878 by focusing slider handle instead of slider track itself (although native slider input does this), which also makes it more consistent with `uui-range-slider` https://uui.umbraco.com/?path=/docs/uui-range-slider--docs

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/219e99bb-f44a-4bec-9368-303fe13e4067)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
