### PR TITLE
Ensure keydown doesn't trigger click event as well in SelectableMixin

### DIFF
--- a/packages/uui-base/lib/mixins/SelectableMixin.ts
+++ b/packages/uui-base/lib/mixins/SelectableMixin.ts
@@ -76,11 +76,22 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
     constructor(...args: any[]) {
       super(...args);
       this.addEventListener('click', this._handleClick);
-      this.addEventListener('keydown', this.handleSelectKeydown);
+      this.addEventListener('keydown', this._handleSelectKeydown);
     }
 
-    private handleSelectKeydown = (e: KeyboardEvent) => {
-      //if (e.composedPath().indexOf(this.selectableTarget) !== -1) {
+    private _handleClick(e: Event) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+
+      if (e.composedPath().indexOf(this.selectableTarget) !== -1) {
+        this._toggleSelect();
+      }
+    }
+
+    private _handleSelectKeydown = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+
       if (this.selectableTarget === this) {
         if (e.key !== ' ' && e.key !== 'Enter') return;
         this._toggleSelect();
@@ -105,14 +116,8 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
       this.selected = false;
     }
 
-    private _handleClick(e: Event) {
-      if (e.composedPath().indexOf(this.selectableTarget) !== -1) {
-        this._toggleSelect();
-      }
-    }
-
     private _toggleSelect() {
-      // Only allow for select-interaction if selectable is true. Deselectable is ignorered in this case, we do not want a DX where only deselection is a possibility..
+      // Only allow for select-interaction if selectable is true. Deselectable is ignorered in this case, we do not want a DX where only deselection is a possibility.
       if (!this.selectable) return;
       if (this.deselectable === false) {
         this._select();

--- a/packages/uui-base/lib/mixins/SelectableMixin.ts
+++ b/packages/uui-base/lib/mixins/SelectableMixin.ts
@@ -80,22 +80,22 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
     }
 
     private _handleClick(e: Event) {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-
       if (e.composedPath().indexOf(this.selectableTarget) !== -1) {
         this._toggleSelect();
       }
+
+      e.preventDefault();
+      e.stopImmediatePropagation();
     }
 
     private _handleSelectKeydown = (e: KeyboardEvent) => {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-
       if (this.selectableTarget === this) {
         if (e.key !== ' ' && e.key !== 'Enter') return;
         this._toggleSelect();
       }
+
+      e.preventDefault();
+      e.stopImmediatePropagation();
     };
 
     private _select() {

--- a/packages/uui-base/lib/mixins/SelectableMixin.ts
+++ b/packages/uui-base/lib/mixins/SelectableMixin.ts
@@ -96,7 +96,7 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
 
       e.preventDefault();
       e.stopImmediatePropagation();
-    };
+    }
 
     private _select() {
       if (!this.selectable) return;


### PR DESCRIPTION
… which trigger select + deselect.

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes https://github.com/umbraco/Umbraco.UI/issues/654

When hitting space key e.g. at `uui-color-swatch` it furthermore triggered click event. So it selected the element, but deselected it immediately after.

I have tested that selection + deselection both work using keydown and click event.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

https://github.com/user-attachments/assets/a31156e0-b2f0-4d12-a3b3-d4a29984fe4f


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
