### PR TITLE
Bugfix: Combobox not working in Safari

### DIFF
--- a/packages/uui-combobox/lib/uui-combobox.element.ts
+++ b/packages/uui-combobox/lib/uui-combobox.element.ts
@@ -407,7 +407,6 @@ export class UUIComboboxElement extends UUIFormControlMixin(LitElement, '') {
         border: 1px solid var(--uui-color-border);
         border-radius: var(--uui-border-radius);
         width: 100%;
-        height: 100%;
         box-sizing: border-box;
         box-shadow: var(--uui-shadow-depth-3);
       }


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco.UI/issues/748
Fixes combobox dropdown having 0 height in safari.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
