### PR TITLE
Bugfix: UUIFormControlMixinClass: Dont call setAttribute in the constructor

### DIFF
--- a/packages/uui-base/lib/mixins/FormControlMixin.ts
+++ b/packages/uui-base/lib/mixins/FormControlMixin.ts
@@ -180,7 +180,9 @@ export const UUIFormControlMixin = <
     public get pristine(): boolean {
       return this._pristine;
     }
-    private _pristine: boolean = true;
+    // Will be set to true instantly to trigger the setAttribute in the setter.
+    // This is to prevent an issue caused by using setAttribute in the constructor.
+    private _pristine: boolean = false;
 
     /**
      * Apply validation rule for requiring a value of this form control.
@@ -221,7 +223,7 @@ export const UUIFormControlMixin = <
     constructor(...args: any[]) {
       super(...args);
       this._internals = this.attachInternals();
-      this.setAttribute('pristine', '');
+      this.pristine = true;
 
       this.addValidator(
         'valueMissing',


### PR DESCRIPTION
Having setAttribute in the constructor is no longer allowed and causes some components in New Backoffice to throw errors and not render.

This fixes it by setting the property instead.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
