### PR TITLE
Feat: Readonly state for uui-color-swatches

### DIFF
--- a/packages/uui-color-swatches/lib/uui-color-swatches.element.ts
+++ b/packages/uui-color-swatches/lib/uui-color-swatches.element.ts
@@ -26,12 +26,21 @@ export class UUIColorSwatchesElement extends LabelMixin('label', LitElement) {
   value = '';
 
   /**
-   * Disables the color swatches.
+   * Sets the swatches to disabled.
    * @type {boolean}
    * @attr
    * @default false
    **/
   @property({ type: Boolean, reflect: true }) disabled = false;
+
+  /**
+   * Sets the swatches to readonly mode.
+   * @type {boolean}
+   * @attr
+   * @default false
+   */
+  @property({ type: Boolean, reflect: true })
+  readonly: boolean = false;
 
   @queryAssignedElements({ selector: 'uui-color-swatch' })
   private readonly _swatches!: Array<UUIColorSwatchElement>;
@@ -84,6 +93,10 @@ export class UUIColorSwatchesElement extends LabelMixin('label', LitElement) {
       } else {
         // For some reason the value it really wants the attribute to be set not the value. If value is set then it is not reflected properly. :cry:
         swatch.setAttribute('selectable', 'selectable');
+      }
+
+      if (this.readonly) {
+        swatch.setAttribute('readonly', '');
       }
 
       if (this.value !== '' && swatch.value === this.value) {

--- a/packages/uui-color-swatches/lib/uui-color-swatches.story.ts
+++ b/packages/uui-color-swatches/lib/uui-color-swatches.story.ts
@@ -60,6 +60,12 @@ export const Disabled: Story = {
   },
 };
 
+export const Readonly: Story = {
+  args: {
+    readonly: true,
+  },
+};
+
 export const ShowLabel: Story = {
   args: {
     showLabel: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe the changes in detail -->
This PR adds a readonly state for the `uui-color-swatches` component. It will ensure that each swatch can't be selected.
Fixes https://github.com/umbraco/Umbraco.UI/issues/901

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
