### PR TITLE
Feat: Readonly state for uui-color-picker

### DIFF
--- a/packages/uui-color-picker/lib/uui-color-picker.element.ts
+++ b/packages/uui-color-picker/lib/uui-color-picker.element.ts
@@ -138,7 +138,7 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
   @property({ type: Boolean, reflect: true }) inline = false;
 
   /**
-   * Disables the color picker.
+   * Sets the color picker to disabled.
    * @attr
    * @type {boolean}
    * @default false
@@ -152,6 +152,14 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
    * @default false
    **/
   @property({ type: Boolean }) opacity = false;
+
+  /**
+   * Sets the color picker to readonly mode.
+   * @type {boolean}
+   * @attr
+   * @default false
+   */
+  @property({ type: Boolean, reflect: true }) readonly = false;
 
   /**
    * By default, the value will be set in lowercase. Set this to true to set it in uppercase instead.
@@ -433,6 +441,7 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
           .value="${this.value}"
           .hue="${Math.round(this.hue)}"
           ?disabled=${this.disabled}
+          ?readonly=${this.readonly}
           @change=${this.handleGridChange}>
         </uui-color-area>
         <div class="color-picker__controls">
@@ -442,6 +451,7 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
               class="hue-slider"
               .value=${Math.round(this.hue)}
               ?disabled=${this.disabled}
+              ?readonly=${this.readonly}
               @change=${this.handleHueChange}>
             </uui-color-slider>
             ${this.opacity
@@ -457,6 +467,7 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
                       this.lightness,
                     )}
                     ?disabled=${this.disabled}
+                    ?readonly=${this.readonly}
                     @change=${this.handleAlphaChange}>
                   </uui-color-slider>
                 `
@@ -486,6 +497,7 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
             spellcheck="false"
             .value=${live(this.inputValue)}
             ?disabled=${this.disabled}
+            ?readonly=${this.readonly}
             @keydown=${this.handleInputKeyDown}
             @change=${this.handleInputChange}>
           </uui-input>
@@ -503,7 +515,7 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
             ${hasEyeDropper
               ? html`<uui-button
                   label="Select a color"
-                  ?disabled=${this.disabled}
+                  ?disabled=${this.disabled || this.readonly}
                   @click=${this.handleEyeDropper}
                   compact>
                   <uui-icon-registry-essential>
@@ -525,6 +537,7 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
       class="color-picker__swatches"
       label="Swatches"
       ?disabled=${this.disabled}
+      ?readonly=${this.readonly}
       @change=${this.handleColorSwatchChange}>
       ${this.swatches.map(
         swatch =>

--- a/packages/uui-color-picker/lib/uui-color-picker.story.ts
+++ b/packages/uui-color-picker/lib/uui-color-picker.story.ts
@@ -57,6 +57,13 @@ export const Disabled: Story = {
   },
 };
 
+export const Formats: Story = {
+  args: {
+    format: 'hex',
+    inline: true,
+  },
+};
+
 export const Inline: Story = {
   args: {
     inline: true,
@@ -70,9 +77,8 @@ export const Opacity: Story = {
   },
 };
 
-export const Formats: Story = {
+export const Readonly: Story = {
   args: {
-    format: 'hex',
-    inline: true,
+    readonly: true,
   },
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a readonly state for the `uui-color-picker` component. It will ensure that each sub component can't be selected.
Fixes https://github.com/umbraco/Umbraco.UI/issues/898

Since `uui-button` (and button element in general) doesn't have a readonly mode, I think it makes most sense to select eyedropper button to disabled - alternative return in event, but may be odd nothing happens clicking the button.
I think it is fine the toggle button is active to switch between color format.

Depends on review of https://github.com/umbraco/Umbraco.UI/pull/932

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
