### PR TITLE
Fix alignment of menu-item parts

### DIFF
--- a/packages/uui-icon/lib/uui-icon.element.ts
+++ b/packages/uui-icon/lib/uui-icon.element.ts
@@ -141,8 +141,8 @@ export class UUIIconElement extends LitElement {
       :host {
         display: inline-block;
         vertical-align: bottom;
-        width: 1.15em;
-        height: 1.15em;
+        width: 1.125em;
+        height: 1.125em;
       }
 
       :host svg,

--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -554,7 +554,6 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
 
       #icon {
         display: inline-flex;
-        font-size: 15.66px;
         margin-right: var(--uui-size-2);
       }
 

--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -519,7 +519,8 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         height: 100%;
         display: flex;
         align-items: center;
-        justify-content: center;
+        justify-content: end;
+        padding-inline-end: 3px;
         color: var(--uui-color-interactive);
       }
 
@@ -553,7 +554,7 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
 
       #icon {
         display: inline-flex;
-        font-size: 16px;
+        font-size: 15.66px;
         margin-right: var(--uui-size-2);
       }
 

--- a/packages/uui-symbol-expand/lib/uui-symbol-expand.element.ts
+++ b/packages/uui-symbol-expand/lib/uui-symbol-expand.element.ts
@@ -35,6 +35,7 @@ export class UUISymbolExpandElement extends LitElement {
       :host {
         display: inline-block;
         width: 12px;
+        height: 12px;
         vertical-align: middle;
       }
 


### PR DESCRIPTION
One of the things that really hurts my eyes when looking at the new backoffice, is that things feel off and misaligned. So I dug a bit in the menu item component and found some improvements.

## Description

I moved the caret for displaying children further to the right, to make it visually connect with the menu item. Previously it looked closer to the browser edge (and also vertically unbalanced) than to the menu item itself.

I also added an aspect-ratio to the caret, to make the browser render a square box for it (instead of 12x17 pixels), which made it connect to the baseline of the label text.

I bumped the font-size of the icon to 15.66px, to make it render a 18x18 icon, instead of 18.39x.18.x39 which caused subpixel issues.

You can see a zoomed in before and after here: (after is the left one, note the improved symmetry in the icon rendering, and the flushing of baselines on the caret and label)

![image](https://github.com/user-attachments/assets/cd5e08dc-8c23-47db-9fc2-00a996528865)

## Motivation and context

It makes the menu item look less half baked.

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
