### PR TITLE
Fix disabled and readonly checkbox/radiobutton stories

### DIFF
--- a/packages/uui-checkbox/lib/uui-checkbox.story.ts
+++ b/packages/uui-checkbox/lib/uui-checkbox.story.ts
@@ -39,9 +39,23 @@ export const Disabled: Story = {
   },
 };
 
+export const DisabledChecked: Story = {
+  args: {
+    disabled: true,
+    checked: true,
+  },
+};
+
 export const Readonly: Story = {
   args: {
     readonly: true,
+  },
+};
+
+export const ReadonlyChecked: Story = {
+  args: {
+    readonly: true,
+    checked: true,
   },
 };
 

--- a/packages/uui-checkbox/lib/uui-checkbox.story.ts
+++ b/packages/uui-checkbox/lib/uui-checkbox.story.ts
@@ -35,7 +35,7 @@ export const Error: Story = {
 
 export const Disabled: Story = {
   args: {
-    disabled: false,
+    disabled: true,
   },
 };
 

--- a/packages/uui-checkbox/lib/uui-checkbox.story.ts
+++ b/packages/uui-checkbox/lib/uui-checkbox.story.ts
@@ -41,7 +41,7 @@ export const Disabled: Story = {
 
 export const Readonly: Story = {
   args: {
-    readonly: false,
+    readonly: true,
   },
 };
 

--- a/packages/uui-radio/lib/uui-radio.story.ts
+++ b/packages/uui-radio/lib/uui-radio.story.ts
@@ -30,9 +30,23 @@ export const Disabled: Story = {
   },
 };
 
+export const DisabledChecked: Story = {
+  args: {
+    disabled: true,
+    checked: true,
+  },
+};
+
 export const Readonly: Story = {
   args: {
     readonly: true,
+  },
+};
+
+export const ReadonlyChecked: Story = {
+  args: {
+    readonly: true,
+    checked: true,
   },
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe the changes in detail -->
Fixes some incorrect args in checkbox and radiobutton stories. I also added stories for `disabled` and `readonly` with checked state.
I think in disabled and checked state isn't very clear it is selected (e.g. in TipTap configuration, perhaps use the purple fill and when not disabled - but dimmed?

Current: 
![image](https://github.com/user-attachments/assets/a5730521-0b97-4778-81a9-bcbb6359aae7)

Suggestion:
![image](https://github.com/user-attachments/assets/549cc171-0fd2-42ec-b7e7-b2a916493425)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
