### PR TITLE
Autofix: Action container is not visible in uui-ref-node when focusing on child buttons

### DIFF
--- a/packages/uui-ref-node/lib/uui-ref-node.element.ts
+++ b/packages/uui-ref-node/lib/uui-ref-node.element.ts
@@ -147,8 +147,10 @@ export class UUIRefNodeElement extends UUIRefElement {
 
       <slot></slot>
       <slot name="tag"></slot>
+       <div id="actions-wrapper">
+         <slot name="actions" id="actions-container"></slot>
+       </div>
       <slot name="actions" id="actions-container"></slot>
-    `;
   }
 
   #renderSomething() {
@@ -226,6 +228,17 @@ export class UUIRefNodeElement extends UUIRefElement {
         color: var(--uui-color-disabled-contrast);
       }
     `,
+     css`
+       #actions-wrapper {
+         opacity: 0;
+         transition: opacity 120ms ease-in-out;
+       }
+       :host(:hover) #actions-wrapper,
+       :host(:focus-within) #actions-wrapper {
+         opacity: 1;
+       }
+     `,
+     css`
   ];
 }
 


### PR DESCRIPTION
Updated the UUIRefNodeElement to make the action button visible when focused using keyboard navigation. Added CSS styles to show the actions container on focus and hover. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    