### PR TITLE
Make actions container visible on focus-within

### DIFF
--- a/packages/uui-ref/lib/uui-ref.element.ts
+++ b/packages/uui-ref/lib/uui-ref.element.ts
@@ -190,7 +190,8 @@ export class UUIRefElement extends SelectOnlyMixin(
         opacity: 0;
         transition: opacity 120ms;
       }
-      :host(:hover) #actions-container {
+      :host(:hover) #actions-container,
+      :host(:focus-within) #actions-container {
         opacity: 1;
       }
 


### PR DESCRIPTION
Make actions container visible on focus-within

## Description

The change in the PR makes the `#actions-container` element visible when focusing on an element within. Addresses the following issues

- https://github.com/umbraco/Umbraco.UI/issues/947
- https://github.com/umbraco/Umbraco-CMS/issues/17451

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

Improves accessibility

## How to test?

Navigate to the Node element and use the `Tab` key to make the hidden actions visible on focus.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
