### PR TITLE
Fix: Input: set to flex grow

### DIFF
--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -360,6 +360,7 @@ export class UUIInputElement extends UUIFormControlMixin(
         flex-direction: column;
         align-items: stretch;
         justify-content: center;
+        flex-grow: 1;
       }
 
       #auto {


### PR DESCRIPTION
Make the control part of the uui-input flex-grow.

This will fix case where the input is set to min-width and the content of the input is not that wide, leaving some space that cannot be interacted with. — this change makes the input-element fill all the way, but still leaving room for event append or prepend slotted items.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
