### PR TITLE
Fix: Make slider handle decimal values

### DIFF
--- a/packages/uui-range-slider/lib/uui-range-slider.element.ts
+++ b/packages/uui-range-slider/lib/uui-range-slider.element.ts
@@ -16,6 +16,14 @@ const TRACK_HEIGHT = 3;
 const TRACK_PADDING = 12;
 const STEP_MIN_WIDTH = 24;
 
+const CountDecimalPlaces = (num: number) => {
+  const decimalIndex = num.toString().indexOf('.');
+  return decimalIndex >= 0 ? num.toString().length - decimalIndex - 1 : 0;
+};
+
+const RoundToDecimalPlaces = (target: number, decimalPlaces: number) =>
+  Number(target.toFixed(decimalPlaces));
+
 // TODO: ability to focus on the range, to enable keyboard interaction to move the range.
 // TODO: Ability to click outside a range, to move the range if the maxGap has been reached.
 // TODO: .
@@ -624,8 +632,22 @@ export class UUIRangeSliderElement extends UUIFormControlMixin(LitElement, '') {
 
   private _renderThumbValues() {
     return html`<div class="thumb-values">
-      <span><span>${this._lowInputValue}</span></span>
-      <span><span>${this._highInputValue}</span></span>
+      <span
+        ><span
+          >${RoundToDecimalPlaces(
+            this._lowInputValue,
+            CountDecimalPlaces(this._step),
+          )}</span
+        ></span
+      >
+      <span
+        ><span
+          >${RoundToDecimalPlaces(
+            this._highInputValue,
+            CountDecimalPlaces(this._step),
+          )}</span
+        ></span
+      >
     </div>`;
   }
 
@@ -656,7 +678,12 @@ export class UUIRangeSliderElement extends UUIFormControlMixin(LitElement, '') {
     let index = 0;
     const stepValues = new Array(stepAmount + 1)
       .fill(this._step)
-      .map(step => this._min + step * index++);
+      .map(step =>
+        RoundToDecimalPlaces(
+          this._min + step * index++,
+          CountDecimalPlaces(this._step),
+        ),
+      );
 
     return html`<div class="step-values">
       ${stepValues.map(value => html`<span><span>${value}</span></span>`)}

--- a/packages/uui-range-slider/lib/uui-range-slider.element.ts
+++ b/packages/uui-range-slider/lib/uui-range-slider.element.ts
@@ -21,9 +21,6 @@ const CountDecimalPlaces = (num: number) => {
   return decimalIndex >= 0 ? num.toString().length - decimalIndex - 1 : 0;
 };
 
-const RoundToDecimalPlaces = (target: number, decimalPlaces: number) =>
-  Number(target.toFixed(decimalPlaces));
-
 // TODO: ability to focus on the range, to enable keyboard interaction to move the range.
 // TODO: Ability to click outside a range, to move the range if the maxGap has been reached.
 // TODO: .
@@ -634,18 +631,12 @@ export class UUIRangeSliderElement extends UUIFormControlMixin(LitElement, '') {
     return html`<div class="thumb-values">
       <span
         ><span
-          >${RoundToDecimalPlaces(
-            this._lowInputValue,
-            CountDecimalPlaces(this._step),
-          )}</span
+          >${this._lowInputValue.toFixed(CountDecimalPlaces(this._step))}</span
         ></span
       >
       <span
         ><span
-          >${RoundToDecimalPlaces(
-            this._highInputValue,
-            CountDecimalPlaces(this._step),
-          )}</span
+          >${this._highInputValue.toFixed(CountDecimalPlaces(this._step))}</span
         ></span
       >
     </div>`;
@@ -679,10 +670,7 @@ export class UUIRangeSliderElement extends UUIFormControlMixin(LitElement, '') {
     const stepValues = new Array(stepAmount + 1)
       .fill(this._step)
       .map(step =>
-        RoundToDecimalPlaces(
-          this._min + step * index++,
-          CountDecimalPlaces(this._step),
-        ),
+        (this._min + step * index++).toFixed(CountDecimalPlaces(this._step)),
       );
 
     return html`<div class="step-values">

--- a/packages/uui-slider/lib/uui-slider.element.ts
+++ b/packages/uui-slider/lib/uui-slider.element.ts
@@ -267,7 +267,7 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
     this.dispatchEvent(new UUISliderEvent(UUISliderEvent.CHANGE));
   }
 
-  RenderTrackSteps() {
+  renderTrackSteps() {
     return svg`
   ${this._steps.map(el => {
     if (this._stepWidth >= STEP_MIN_WIDTH) {
@@ -281,7 +281,7 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
 `;
   }
 
-  RenderStepValues() {
+  renderStepValues() {
     if (this.hideStepValues) return nothing;
 
     return html`<div id="step-values">
@@ -315,7 +315,7 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
       <div id="track" aria-hidden="true">
         <svg height="100%" width="100%">
           <rect x="9" y="9" height="3" rx="2" />
-          ${this.RenderTrackSteps()}
+          ${this.renderTrackSteps()}
         </svg>
 
         <div id="track-inner" aria-hidden="true">
@@ -326,7 +326,7 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
           </div>
         </div>
       </div>
-      ${this.RenderStepValues()}
+      ${this.renderStepValues()}
     `;
   }
 

--- a/packages/uui-slider/lib/uui-slider.element.ts
+++ b/packages/uui-slider/lib/uui-slider.element.ts
@@ -35,9 +35,7 @@ const RenderStepValues = (
       el =>
         html` <span
           ><span>
-            ${steps.length <= 20 && stepWidth >= STEP_MIN_WIDTH
-              ? el.toFixed(0)
-              : nothing}
+            ${steps.length <= 20 && stepWidth >= STEP_MIN_WIDTH ? el : nothing}
           </span></span
         >`,
     )}
@@ -45,7 +43,14 @@ const RenderStepValues = (
 };
 
 const GenerateStepArray = (start: number, stop: number, step: number) =>
-  Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + i * step);
+  Array.from({ length: (stop - start) / step + 1 }, (_, i) =>
+    Number((start + i * step).toFixed(CountDecimalPlaces(step))),
+  );
+
+const CountDecimalPlaces = (num: number) => {
+  const decimalIndex = num.toString().indexOf('.');
+  return decimalIndex >= 0 ? num.toString().length - decimalIndex - 1 : 0;
+};
 
 /**
  * @element uui-slider

--- a/packages/uui-slider/lib/uui-slider.element.ts
+++ b/packages/uui-slider/lib/uui-slider.element.ts
@@ -11,41 +11,8 @@ import { UUISliderEvent } from './UUISliderEvent';
 const TRACK_PADDING = 12;
 const STEP_MIN_WIDTH = 24;
 
-const RenderTrackSteps = (steps: number[], stepWidth: number) => {
-  return svg`
-  ${steps.map(el => {
-    if (stepWidth >= STEP_MIN_WIDTH) {
-      const x = Math.round(TRACK_PADDING + stepWidth * steps.indexOf(el));
-      return svg`<circle class="track-step" cx="${x}" cy="50%" r="4.5" />`;
-    }
-    return svg``;
-  })}
-`;
-};
-
-const RenderStepValues = (
-  steps: number[],
-  stepWidth: number,
-  hide: boolean,
-) => {
-  if (hide) return nothing;
-
-  return html`<div id="step-values">
-    ${steps.map(
-      el =>
-        html` <span
-          ><span>
-            ${steps.length <= 20 && stepWidth >= STEP_MIN_WIDTH ? el : nothing}
-          </span></span
-        >`,
-    )}
-  </div>`;
-};
-
 const GenerateStepArray = (start: number, stop: number, step: number) =>
-  Array.from({ length: (stop - start) / step + 1 }, (_, i) =>
-    Number((start + i * step).toFixed(CountDecimalPlaces(step))),
-  );
+  Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + i * step);
 
 const CountDecimalPlaces = (num: number) => {
   const decimalIndex = num.toString().indexOf('.');
@@ -300,6 +267,37 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
     this.dispatchEvent(new UUISliderEvent(UUISliderEvent.CHANGE));
   }
 
+  RenderTrackSteps() {
+    return svg`
+  ${this._steps.map(el => {
+    if (this._stepWidth >= STEP_MIN_WIDTH) {
+      const x = Math.round(
+        TRACK_PADDING + this._stepWidth * this._steps.indexOf(el),
+      );
+      return svg`<circle class="track-step" cx="${x}" cy="50%" r="4.5" />`;
+    }
+    return svg``;
+  })}
+`;
+  }
+
+  RenderStepValues() {
+    if (this.hideStepValues) return nothing;
+
+    return html`<div id="step-values">
+      ${this._steps.map(
+        el =>
+          html` <span
+            ><span>
+              ${this._steps.length <= 20 && this._stepWidth >= STEP_MIN_WIDTH
+                ? el.toFixed(CountDecimalPlaces(this.step))
+                : nothing}
+            </span></span
+          >`,
+      )}
+    </div>`;
+  }
+
   render() {
     return html`
       <input
@@ -317,7 +315,7 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
       <div id="track" aria-hidden="true">
         <svg height="100%" width="100%">
           <rect x="9" y="9" height="3" rx="2" />
-          ${RenderTrackSteps(this._steps, this._stepWidth)}
+          ${this.RenderTrackSteps()}
         </svg>
 
         <div id="track-inner" aria-hidden="true">
@@ -328,7 +326,7 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
           </div>
         </div>
       </div>
-      ${RenderStepValues(this._steps, this._stepWidth, this.hideStepValues)}
+      ${this.RenderStepValues()}
     `;
   }
 

--- a/packages/uui-slider/lib/uui-slider.story.ts
+++ b/packages/uui-slider/lib/uui-slider.story.ts
@@ -56,3 +56,12 @@ export const Readonly: Story = {
     readonly: true,
   },
 };
+
+export const DecimalValue: Story = {
+  args: {
+    min: 0,
+    max: 1,
+    step: 0.1,
+    value: 0.5,
+  },
+};


### PR DESCRIPTION
## Description

I'm a backend dev, likely, this solution is likely not optimal, feel free to make whatever change you see fit 😄 

As reported over on the CMS tracker the sliders didn't handle decimal values https://github.com/umbraco/Umbraco-CMS/issues/17546 

This PR fixes this.

The fix is to "count" the amount of decimals in the step. I.E `0.1` has 1 decimal, `0.15` has 2, and then round the value to this amount of digits. 

For the normal slider I round the numbers when they're generated, this is because in the render methods the step size is not available. 

For the range slider the rounding happens in the render methods because the step size is available there. 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

It doesn't work, see the linked issue

## How to test?

I've added 2 stories to test, if you add these before this change you see weird behaviour.

## Screenshots (if appropriate)

See issue