### PR TITLE
Fix: do not select when opening href on selectable elements

### DIFF
--- a/packages/uui-base/lib/mixins/SelectableMixin.ts
+++ b/packages/uui-base/lib/mixins/SelectableMixin.ts
@@ -112,7 +112,11 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
     }
 
     private _handleClick(e: Event) {
-      if (e.composedPath().indexOf(this.selectableTarget) !== -1) {
+      const composePath = e.composedPath();
+      if (
+        (this._selectable || (this.deselectable && this.selected)) &&
+        composePath.indexOf(this.selectableTarget) === 0
+      ) {
         this._toggleSelect();
       }
     }

--- a/packages/uui-base/lib/mixins/SelectableMixin.ts
+++ b/packages/uui-base/lib/mixins/SelectableMixin.ts
@@ -79,7 +79,7 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
       this.addEventListener('keydown', this.#onKeydown);
     }
 
-    #onKeydown = (e: KeyboardEvent) => {
+    readonly #onKeydown = (e: KeyboardEvent) => {
       const composePath = e.composedPath();
       if (
         (this._selectable || (this.deselectable && this.selected)) &&
@@ -93,7 +93,7 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
       }
     };
 
-    #onClick = (e: Event) => {
+    readonly #onClick = (e: Event) => {
       const composePath = e.composedPath();
       if (
         (this._selectable || (this.deselectable && this.selected)) &&

--- a/packages/uui-card-media/lib/uui-card-media.test.ts
+++ b/packages/uui-card-media/lib/uui-card-media.test.ts
@@ -99,6 +99,22 @@ describe('UUICardMediaElement', () => {
         expect(event.type).to.equal(UUISelectableEvent.SELECTED);
         expect(element.selected).to.be.true;
       });
+      it('do react to a click event on performed in this way', async () => {
+        element.selectable = true;
+        await elementUpdated(element);
+        element.click();
+        await Promise.resolve();
+        expect(element.selected).to.be.true;
+      });
+      it('do not react to a click event on other parts', async () => {
+        element.selectable = true;
+        await elementUpdated(element);
+        element
+          .shadowRoot!.querySelector<HTMLAnchorElement>('#open-part')!
+          .click();
+        await Promise.resolve();
+        expect(element.selected).to.be.false;
+      });
       it('can be selected with keyboard', async () => {
         element.selectable = true;
         await elementUpdated(element);

--- a/packages/uui-card-media/lib/uui-card-media.test.ts
+++ b/packages/uui-card-media/lib/uui-card-media.test.ts
@@ -109,6 +109,19 @@ describe('UUICardMediaElement', () => {
       it('do not react to a click event on other parts', async () => {
         element.selectable = true;
         await elementUpdated(element);
+        const listener = oneEvent(element, UUICardEvent.OPEN);
+        element
+          .shadowRoot!.querySelector<HTMLAnchorElement>('#open-part')!
+          .click();
+        const event = await listener;
+        expect(event).to.exist;
+        expect(event.type).to.equal(UUICardEvent.OPEN);
+        expect(element.selected).to.be.false;
+      });
+      it('do not react to a click event on other parts as href', async () => {
+        element.selectable = true;
+        element.href = '#hello';
+        await elementUpdated(element);
         element
           .shadowRoot!.querySelector<HTMLAnchorElement>('#open-part')!
           .click();


### PR DESCRIPTION
A fix to avoid selection happening when clicking or keyboard interacting with sub element of a selectable element.