### PR TITLE
Fix: double declare uui-h styles to bring back previous specificity

### DIFF
--- a/packages/uui-css/lib/uui-text.css
+++ b/packages/uui-css/lib/uui-text.css
@@ -18,7 +18,7 @@
 }
 
 .uui-text h1,
-.uui-h1 {
+.uui-h1.uui-h1 {
   font-size: var(--uui-type-h1-size);
   line-height: var(--uui-size-layout-4);
   font-weight: 300;
@@ -38,7 +38,7 @@
 }
 
 .uui-text h2,
-.uui-h2 {
+.uui-h2.uui-h2 {
   font-size: var(--uui-type-h2-size);
   line-height: var(--uui-size-layout-3);
   font-weight: 300;
@@ -58,7 +58,7 @@
 }
 
 .uui-text h3,
-.uui-h3 {
+.uui-h3.uui-h3 {
   font-size: var(--uui-type-h3-size);
   line-height: var(--uui-size-large);
   font-weight: 300;
@@ -74,7 +74,7 @@
 }
 
 .uui-text h4,
-.uui-h4 {
+.uui-h4.uui-h4 {
   font-size: var(--uui-type-h4-size);
   line-height: 21px;
   font-weight: 400;
@@ -90,7 +90,7 @@
 }
 
 .uui-text h5,
-.uui-h5 {
+.uui-h5.uui-h5 {
   font-size: var(--uui-type-h5-size);
   line-height: inherit;
   font-weight: 700;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

After we allowed `.uui-h*` classes to be used outside a `.uui-text` container it got a lower specifity. I have fixed this so it is still possible to use the styles like previously.

How to test:
* Make sure the `.uui-h*` styles work outside a `.uui-text` container.
* Make sure you can override a `h1`, `h2`, `h3` style inside a `.uui-text` container with a `.uui-h*` class.
* Example `<div class="uui-text"><h1 class="uui-h3">This should have h3 styling</h1></div>`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
