### PR TITLE
bug(uui-symbol-expand): remove height of the svg

### DIFF
--- a/packages/uui-symbol-expand/lib/uui-symbol-expand.element.ts
+++ b/packages/uui-symbol-expand/lib/uui-symbol-expand.element.ts
@@ -35,7 +35,6 @@ export class UUISymbolExpandElement extends LitElement {
       :host {
         display: inline-block;
         width: 12px;
-        height: 12px;
         vertical-align: middle;
       }
 

--- a/packages/uui-symbol-expand/lib/uui-symbol-expand.story.ts
+++ b/packages/uui-symbol-expand/lib/uui-symbol-expand.story.ts
@@ -3,8 +3,10 @@ import readme from '../README.md?raw';
 import { html } from 'lit';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { spread } from '../../../storyhelpers';
+import { UUISymbolExpandElement } from './uui-symbol-expand.element.js';
+import '@umbraco-ui/uui-button/lib';
 
-const meta: Meta = {
+const meta: Meta<UUISymbolExpandElement> = {
   id: 'uui-symbol-expand',
   component: 'uui-symbol-expand',
   title: 'Symbols/Expand',
@@ -25,3 +27,15 @@ export default meta;
 type Story = StoryObj;
 
 export const Default: Story = {};
+
+export const Open: Story = {
+  args: { open: true },
+};
+
+export const WithButton: Story = {
+  render: args =>
+    html`<uui-button look="primary">
+      Toggle
+      <uui-symbol-expand ${spread(args)}></uui-symbol-expand>
+    </uui-button>`,
+};


### PR DESCRIPTION
## Description

This reverts part of PR #935 where the caret icon had a `height` CSS property. This is reverted to align the symbol better with buttons and menu items. The inherent problems in the Backoffice will be fixed there instead.

 See before and after:

**Before**
![Screenshot 2024-11-25 at 10 45 50](https://github.com/user-attachments/assets/66e8e93c-24c5-4c02-9130-f0c6f16abac7)

**After**
![Screenshot 2024-11-25 at 10 46 03](https://github.com/user-attachments/assets/c8b1b15b-462e-47e8-a872-ae7579229260)

**Before**
![Screenshot 2024-11-25 at 10 51 03](https://github.com/user-attachments/assets/3063f2f4-20e8-4298-bee7-9748ddede7fd)

**After**
![Screenshot 2024-11-25 at 10 51 11](https://github.com/user-attachments/assets/17b00828-86ff-4b7a-8ccb-5deafd63611e)

