### PR TITLE
fix: bump media card action and tag slot z-index

### DIFF
--- a/packages/uui-card-media/lib/uui-card-media.element.ts
+++ b/packages/uui-card-media/lib/uui-card-media.element.ts
@@ -139,6 +139,7 @@ export class UUICardMediaElement extends UUICardElement {
         right: var(--uui-size-4);
         display: flex;
         justify-content: right;
+        z-index: 2;
       }
 
       slot[name='actions'] {
@@ -147,7 +148,7 @@ export class UUICardMediaElement extends UUICardElement {
         right: var(--uui-size-4);
         display: flex;
         justify-content: right;
-
+        z-index: 2;
         opacity: 0;
         transition: opacity 120ms;
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Problem: It is no longer possible to use the media card actions when a media item has an href:

This PR bumps the z-index for the action and tag slots

# What to test
* make sure that you can click the actions when a card has en href

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
