### PR TITLE
Fix: allow current element to be the selectable target by default

### DIFF
--- a/packages/uui-base/lib/mixins/SelectableMixin.ts
+++ b/packages/uui-base/lib/mixins/SelectableMixin.ts
@@ -95,6 +95,10 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
 
     readonly #onClick = (e: Event) => {
       const composePath = e.composedPath();
+      const target = composePath[0] as HTMLElement;
+
+      if (target.tagName === 'A') return;
+
       const isSelectable =
         this._selectable || (this.deselectable && this.selected);
 

--- a/packages/uui-base/lib/mixins/SelectableMixin.ts
+++ b/packages/uui-base/lib/mixins/SelectableMixin.ts
@@ -95,6 +95,15 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
 
     readonly #onClick = (e: Event) => {
       const composePath = e.composedPath();
+
+      if (
+        (this._selectable || (this.deselectable && this.selected)) &&
+        this.selectableTarget === this
+      ) {
+        this.#toggleSelect();
+        return;
+      }
+
       if (
         (this._selectable || (this.deselectable && this.selected)) &&
         composePath.indexOf(this.selectableTarget) === 0

--- a/packages/uui-base/lib/mixins/SelectableMixin.ts
+++ b/packages/uui-base/lib/mixins/SelectableMixin.ts
@@ -95,9 +95,13 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
 
     readonly #onClick = (e: Event) => {
       const composePath = e.composedPath();
-      const target = composePath[0] as HTMLElement;
+      const isAnchorTag = composePath.some(el => {
+        const element = el as HTMLElement;
+        return element.tagName === 'A';
+      });
 
-      if (target.tagName === 'A') return;
+      // never select when clicking on a link
+      if (isAnchorTag) return;
 
       const isSelectable =
         this._selectable || (this.deselectable && this.selected);

--- a/packages/uui-base/lib/mixins/SelectableMixin.ts
+++ b/packages/uui-base/lib/mixins/SelectableMixin.ts
@@ -95,19 +95,15 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
 
     readonly #onClick = (e: Event) => {
       const composePath = e.composedPath();
+      const isSelectable =
+        this._selectable || (this.deselectable && this.selected);
 
-      if (
-        (this._selectable || (this.deselectable && this.selected)) &&
-        this.selectableTarget === this
-      ) {
+      if (isSelectable && this.selectableTarget === this) {
         this.#toggleSelect();
         return;
       }
 
-      if (
-        (this._selectable || (this.deselectable && this.selected)) &&
-        composePath.indexOf(this.selectableTarget) === 0
-      ) {
+      if (isSelectable && composePath.indexOf(this.selectableTarget) === 0) {
         this.#toggleSelect();
       }
     };

--- a/packages/uui-base/lib/mixins/SelectableMixin.ts
+++ b/packages/uui-base/lib/mixins/SelectableMixin.ts
@@ -95,13 +95,13 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
 
     readonly #onClick = (e: Event) => {
       const composePath = e.composedPath();
-      const isAnchorTag = composePath.some(el => {
+      const isActionTag = composePath.some(el => {
         const element = el as HTMLElement;
-        return element.tagName === 'A';
+        return element.tagName === 'A' || element.tagName === 'BUTTON';
       });
 
-      // never select when clicking on a link
-      if (isAnchorTag) return;
+      // never select when clicking on a link or button
+      if (isActionTag) return;
 
       const isSelectable =
         this._selectable || (this.deselectable && this.selected);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We currently have an issue where selection does not work if a selectableTarget is not set to something different than the element itself.

This PR allows the element itself (`this`) to be selectable if a specific `selectableTarget` is not specified.

## Elements using the SelectableMixin:
* uui-card
* uui-color-swatch
* uui-combobox-list-option
* uui-menu-item
* uui-ref
* uui-table-row

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)