### PR TITLE
Fix reference to TouchEvent which is not defined in Firefox

### DIFF
--- a/packages/uui-base/lib/utils/drag.ts
+++ b/packages/uui-base/lib/utils/drag.ts
@@ -22,10 +22,14 @@ export const drag = (
     const offsetY = dims.top + defaultView.scrollY;
 
     let pointerEvent: PointerEvent | Touch;
-    if (event instanceof TouchEvent) {
+    // TouchEvent is not available in Firefox
+    if ('TouchEvent' in window && event instanceof TouchEvent) {
       pointerEvent = event.touches[0];
-    } else {
+    } else if ( event instanceof PointerEvent ) {
       pointerEvent = event;
+    }
+    else {
+      return;
     }
 
     const x = pointerEvent.pageX - offsetX;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes issue #1000 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

drag does not work on Firefox

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
