### PR TITLE
Fix vertical alignment uui-symbol-expand.element.ts

### DIFF
--- a/packages/uui-symbol-expand/lib/uui-symbol-expand.element.ts
+++ b/packages/uui-symbol-expand/lib/uui-symbol-expand.element.ts
@@ -33,7 +33,7 @@ export class UUISymbolExpandElement extends LitElement {
   static styles = [
     css`
       :host {
-        display: inline-block;
+        display: inline-flex;
         width: 12px;
         vertical-align: middle;
       }


### PR DESCRIPTION
Changed display property from inline-block to inline-flex

## Description

Fixed vertical alignment by changing css display property from inline-block to inline-flex

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

It solves vertical alignment of carrot icon against menu item in umbraco backoffice tree menu

## How to test?

After:
![after](https://github.com/user-attachments/assets/900ffc33-aec7-425c-ad78-e87de0120cad)
Before:
![before](https://github.com/user-attachments/assets/517b5c02-5f29-4a62-b190-f13a30a5b221)

## Checklist

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
