### PR TITLE
Readonly of select

### DIFF
--- a/packages/uui-select/lib/uui-select.element.ts
+++ b/packages/uui-select/lib/uui-select.element.ts
@@ -28,11 +28,13 @@ declare global {
  * @cssprop --uui-select-padding-x - Padding on the x axis
  * @cssprop --uui-select-border-color - Border color
  * @cssprop --uui-select-border-color-hover - Border color on hover
+ * @cssprop --uui-select-border-color-readonly - Border color when readonly
  * @cssprop --uui-select-selected-option-background-color - Background color of the selected option
  * @cssprop --uui-select-selected-option-color - Color of the selected option
  * @cssprop --uui-select-outline-color - Outline color
  * @cssprop --uui-select-background-color - Background color
- * @cssprop --uui-select-disabled-background-color - Background color when disabled
+ * @cssprop --uui-select-background-color-disabled - Background color when disabled
+ * @cssprop --uui-select-background-color-readonly - Background color when readonly
  * @extends UUIFormControlMixin
  */
 // TODO: Consider if this should use child items instead of an array.
@@ -237,21 +239,13 @@ export class UUISelectElement extends UUIFormControlMixin(LitElement, '') {
     `;
   }
 
-  private _getDisplayValue() {
-    return (
-      this.options.find(option => option.value === this.value)?.name ||
-      this.value
-    );
-  }
-
   render() {
-    if (this.readonly) return html`<span>${this._getDisplayValue()}</span>`;
-
     return html` <select
       id="native"
       aria-label=${this.label}
       @change=${this.setValue}
       ?disabled=${this.disabled}
+      aria-readonly=${this.readonly ? 'true' : 'false'}
       .name=${this.name}
       .value=${this.value as string}>
       <option disabled selected value="" hidden>${this.placeholder}</option>
@@ -305,8 +299,24 @@ export class UUISelectElement extends UUIFormControlMixin(LitElement, '') {
       #native[disabled] {
         cursor: not-allowed;
         background-color: var(
-          --uui-select-disabled-background-color,
+          --uui-select-background-color-disabled,
           var(--uui-color-disabled)
+        );
+        border-color: var(
+          --uui-select-border-color-disabled,
+          var(--uui-color-disabled)
+        );
+      }
+
+      #native[aria-readonly='true'] {
+        pointer-events: none;
+        background-color: var(
+          --uui-select-background-color-readonly,
+          var(--uui-color-disabled)
+        );
+        border-color: var(
+          --uui-select-border-color-readonly,
+          var(--uui-color-disabled-standalone)
         );
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently the `readonly` of `uui-select` just render as label, which I don't think it the right approach although browser only support `readonly` on native input and not select. I have seems suggestions that browsers should support this.
However there's an `aria-readonly` attribute we can use instead.
https://helloanselm.com/writings/til-css-readonly-is-not-for-select-fields

Generally speaking I think think `readonly` state should still render the editor, not disable it (meaning it can still be focused and text selected, but not change input/editor value).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
