### PR TITLE
Resolve Issue #1023 - SVG Icons zero size on Safari

### DIFF
--- a/packages/uui-icon/lib/uui-icon.element.ts
+++ b/packages/uui-icon/lib/uui-icon.element.ts
@@ -149,6 +149,7 @@ export class UUIIconElement extends LitElement {
       :host svg,
       ::slotted(svg) {
         color: var(--uui-icon-color, currentColor);
+        width: 100%;
       }
 
       :host-context(div[slot='prepend']) {

--- a/packages/uui-icon/lib/uui-icon.test.ts
+++ b/packages/uui-icon/lib/uui-icon.test.ts
@@ -224,5 +224,13 @@ describe('UUIIconElement', () => {
     it('Child uui-icon passes the a11y audit', async () => {
       await expect(testElement.iconElement).shadowDom.to.be.accessible();
     });
+
+    it('svg has a size of 18px for both width and height', () => {
+      const svgElement =
+        testElement.iconElement.shadowRoot!.querySelector('svg')!;
+      const computedStyle = getComputedStyle(svgElement);
+      expect(computedStyle.width).to.equal('18px');
+      expect(computedStyle.height).to.equal('18px');
+    });
   });
 });


### PR DESCRIPTION
## Description

In https://github.com/umbraco/Umbraco.UI/pull/972 the UUIIconElement was changed to display: inline-flex.

This unfortunately triggered odd behaviour in Safari with how it handles SVGs in flexbox container - see https://stackoverflow.com/questions/66532071/flex-svg-behaving-strange-in-ios-safari-14-0-3

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

Icons vanish in Safari

## How to test?

Open the storybook and go to symbols / icon in Safari. The love heart icon is not visible because the computed size is 0.

<img width="1451" alt="image" src="https://github.com/user-attachments/assets/78a7872d-2503-443d-9c98-68cc567702c4" />

## Screenshots (if appropriate)

Test added to show problem in webkit:

<img width="1057" alt="image" src="https://github.com/user-attachments/assets/39475800-23b4-40ea-9c5e-3b307f0551b8" />

Width 100% added to SVG

Tests pass and icon is visible:

<img width="1041" alt="image" src="https://github.com/user-attachments/assets/cd1e1916-401b-48bf-95fb-ce6a66b8bf1a" />

<img width="824" alt="image" src="https://github.com/user-attachments/assets/61fbed1f-3c7b-4887-a144-ac5b3d5a3315" />


## Checklist

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request. (n/a)
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
