### PR TITLE
fix: accessibility problem with more button on tablist

### DIFF
--- a/packages/uui-base/lib/utils/drag.ts
+++ b/packages/uui-base/lib/utils/drag.ts
@@ -25,10 +25,9 @@ export const drag = (
     // TouchEvent is not available in Firefox
     if ('TouchEvent' in window && event instanceof TouchEvent) {
       pointerEvent = event.touches[0];
-    } else if ( event instanceof PointerEvent ) {
+    } else if (event instanceof PointerEvent) {
       pointerEvent = event;
-    }
-    else {
+    } else {
       return;
     }
 

--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -77,8 +77,6 @@ export class UUITabGroupElement extends LitElement {
     demandCustomElement(this, 'uui-popover-container');
     demandCustomElement(this, 'uui-symbol-more');
 
-    if (!this.hasAttribute('role')) this.setAttribute('role', 'tablist');
-
     await this.updateComplete;
     this.#resizeObserver.observe(this._mainElement);
   }
@@ -268,7 +266,7 @@ export class UUITabGroupElement extends LitElement {
   render() {
     return html`
       <div id="main">
-        <div id="grid">
+        <div id="grid" role="tablist">
           <slot @slotchange=${this.#onSlotChange}></slot>
         </div>
         <uui-button
@@ -284,7 +282,7 @@ export class UUITabGroupElement extends LitElement {
         id="popover-container"
         popover
         placement="bottom-end">
-        <div id="hidden-tabs-container">
+        <div id="hidden-tabs-container" role="tablist">
           ${repeat(this.#hiddenTabElements, el => html`${el}`)}
         </div>
       </uui-popover-container>

--- a/packages/uui-tabs/lib/uui-tabs.test.ts
+++ b/packages/uui-tabs/lib/uui-tabs.test.ts
@@ -17,6 +17,21 @@ describe('UuiTab', () => {
         <uui-tab label="Content">Content</uui-tab>
         <uui-tab label="Packages">Packages</uui-tab>
         <uui-tab label="Media" active>Media</uui-tab>
+        <uui-tab label="Content1">Content to force a more button</uui-tab>
+        <uui-tab label="Content2">Content to force a more button</uui-tab>
+        <uui-tab label="Content3">Content to force a more button</uui-tab>
+        <uui-tab label="Content4">Content to force a more button</uui-tab>
+        <uui-tab label="Content5">Content to force a more button</uui-tab>
+        <uui-tab label="Content6">Content to force a more button</uui-tab>
+        <uui-tab label="Content7">Content to force a more button</uui-tab>
+        <uui-tab label="Content8">Content to force a more button</uui-tab>
+        <uui-tab label="Content9">Content to force a more button</uui-tab>
+        <uui-tab label="Content10">Content to force a more button</uui-tab>
+        <uui-tab label="Content11">Content to force a more button</uui-tab>
+        <uui-tab label="Content12">Content to force a more button</uui-tab>
+        <uui-tab label="Content13">Content to force a more button</uui-tab>
+        <uui-tab label="Content14">Content to force a more button</uui-tab>
+        <uui-tab label="Content15">Content to force a more button</uui-tab>
       </uui-tab-group>
     `);
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/umbraco/Umbraco.UI/issues/987

When the tab list does not fit into view, the more button was causing an accessibility violation error.

This has been corrected by moving the tablist role to the grid and the popover tablist.

Note this still does not make this component fully accessible, but it does remove the accessibility violation errors. There is another issue (issues/700) that I will address after this fix is applied.

Rather than having the role of tablist on the root of the component, it has been placed on the parts of the dom which directly house the tabs. This has meant requiring two tablists - one for the normal list, and one for the "more" list.

It should be noted that a [previous pull request](https://github.com/umbraco/Umbraco.UI/pull/996) was attempted to keep a single tablist. This could not be achieved with the more button pattern which works well for the Workspace Views Tabs Navigation. This pull request supersedes that one.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

Removes an accessibility violation

## How to test?

Navigate to the tabs component in the Umbraco.UI story book. Click on the accessibility tab. If the browser is wide enough you will see 0 violations.

Reduce the browser size so that the more button appears and refresh the page. You will see 1 violation before the fix is applied because an element of role tablist is not allowed children other than of role tab, and now there is a button in there for the popup.

After the fix the violations will be 0.

## Screenshots (if appropriate)

Tests updated to show accessibility fail (before fix):

<img width="628" alt="image" src="https://github.com/user-attachments/assets/d0b9e042-80a3-432a-a694-75f292019c98" />

Accessibility checker in story book (after fix):

<img width="673" alt="image" src="https://github.com/user-attachments/assets/d23f8632-c1b6-46ee-91b6-257842218ed8" />

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
