### PR TITLE
Make disabled menu item button more clear

### DIFF
--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -311,10 +311,6 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
 
       /** Disabled */
       :host([disabled]) #menu-item {
-        color: var(
-          --uui-menu-item-color-disabled,
-          var(--uui-color-disabled-contrast)
-        );
         background-color: var(
           --uui-menu-item-background-color-disabled,
           var(--uui-color-disabled)
@@ -467,6 +463,7 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
 
       :host([disabled]) #label-button {
         cursor: default;
+        opacity: 0.4;
       }
 
       button {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes issue #18545.
I added opacity to the buttons marked as disabled, removed the color of the disabled menu-item to avoid overwriting.
<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)
Before:
<img width="224" alt="image" src="https://github.com/user-attachments/assets/80d3f5ff-c061-4bf9-bc9b-6b463ea6766f" />

After Fixed:
<img width="252" alt="image" src="https://github.com/user-attachments/assets/4b75bd20-9f27-48ad-ba4d-dd06d83f19bb" />

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
