### PR TITLE
Fix: Remove extra margin on ref-node

### DIFF
--- a/packages/uui-ref-node/lib/uui-ref-node.element.ts
+++ b/packages/uui-ref-node/lib/uui-ref-node.element.ts
@@ -184,7 +184,7 @@ export class UUIRefNodeElement extends UUIRefElement {
         align-items: center;
         justify-content: center;
         line-height: 1.2em;
-        padding: calc(var(--uui-size-3));
+        padding: calc(var(--uui-size-2));
       }
 
       #open-part {
@@ -219,6 +219,11 @@ export class UUIRefNodeElement extends UUIRefElement {
       :host([selectable]) #open-part {
         flex-grow: 0;
         padding: 0;
+        margin: calc(var(--uui-size-2));
+
+        #content {
+          padding: 0;
+        }
       }
 
       :host(:not([disabled])) #open-part:hover #icon {

--- a/packages/uui-ref-node/lib/uui-ref-node.element.ts
+++ b/packages/uui-ref-node/lib/uui-ref-node.element.ts
@@ -219,7 +219,6 @@ export class UUIRefNodeElement extends UUIRefElement {
       :host([selectable]) #open-part {
         flex-grow: 0;
         padding: 0;
-        margin: calc(var(--uui-size-2));
       }
 
       :host(:not([disabled])) #open-part:hover #icon {


### PR DESCRIPTION
## Description

When adjusting the margin for ref items without an open part, I didn't notice that we had this extra margin when selected. This margin can be removed now because it results in a "double" margin.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)


