### PR TITLE
vertical center align icon when used in text

### DIFF
--- a/packages/uui-icon/lib/uui-icon.element.ts
+++ b/packages/uui-icon/lib/uui-icon.element.ts
@@ -139,6 +139,7 @@ export class UUIIconElement extends LitElement {
   static styles = [
     css`
       :host {
+        vertical-align: text-bottom;
         display: inline-flex;
         align-items: center;
         justify-content: center;


### PR DESCRIPTION
Center aligns icon in textual context.

So icons align alright like here:
![image](https://github.com/user-attachments/assets/b2e33a8c-a9fd-46f5-82c2-0885bbcf8006)
