### PR TITLE
Fix bug long media name hides the thumbnail

### DIFF
--- a/packages/uui-card-media/lib/uui-card-media.element.ts
+++ b/packages/uui-card-media/lib/uui-card-media.element.ts
@@ -106,7 +106,7 @@ export class UUICardMediaElement extends UUICardElement {
         <!--
         TODO: Implement info box when pop-out is ready
         -->
-        <span id="name">${this.name}</span>
+        <span id="name" title="${this.name}">${this.name}</span>
         <small id="detail">${this.detail}<slot name="detail"></slot></small>
       </div>
     `;
@@ -189,6 +189,12 @@ export class UUICardMediaElement extends UUICardElement {
       }
       #open-part:hover #name {
         text-decoration: underline;
+        display: -webkit-box;
+        -webkit-line-clamp: 1;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        overflow-wrap: anywhere;
       }
 
       :host([image]:not([image=''])) #open-part {

--- a/packages/uui-card-media/lib/uui-card-media.element.ts
+++ b/packages/uui-card-media/lib/uui-card-media.element.ts
@@ -189,6 +189,9 @@ export class UUICardMediaElement extends UUICardElement {
       }
       #open-part:hover #name {
         text-decoration: underline;
+      }
+
+      #open-part #name {
         display: -webkit-box;
         -webkit-line-clamp: 1;
         -webkit-box-orient: vertical;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes issue https://github.com/umbraco/Umbraco.UI/issues/865
The media card name will display with an ellipsis at the end if the name is too long. Hover to the name to see the full text.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?
Before:
<img alt="image" src="https://github.com/user-attachments/assets/939825b1-bdc9-4515-8e57-9744696ce2b7" />

After fix:
![image](https://github.com/user-attachments/assets/3507aaf7-6872-49d6-85cc-874a3ae7d976)

