### PR TITLE
fixes the color-picker-handles placement, after selecting a preset value

### DIFF
--- a/packages/uui-color-area/lib/uui-color-area.element.ts
+++ b/packages/uui-color-area/lib/uui-color-area.element.ts
@@ -115,7 +115,7 @@ export class UUIColorAreaElement extends LitElement {
       const parsed = colord(newVal);
 
       if (parsed.isValid()) {
-        const { h, l, a } = parsed.toHsl();
+        const { h, s, l, a } = parsed.toHsl();
 
         // Update hue from parsed color, but when color is black, value from hue slider may be different from zero.
         if (h !== 0) {
@@ -123,6 +123,7 @@ export class UUIColorAreaElement extends LitElement {
         }
 
         this.lightness = l;
+        this.saturation = s;
         this.brightness = this.getBrightness(l);
         this.alpha = a * 100;
       }
@@ -210,9 +211,8 @@ export class UUIColorAreaElement extends LitElement {
       l: this.lightness,
       a: this.alpha / 100,
     });
-
+    console.log(this.saturation);
     this._value = color.toRgbString();
-
     this.dispatchEvent(new UUIColorAreaEvent(UUIColorAreaEvent.CHANGE));
   }
 
@@ -226,10 +226,13 @@ export class UUIColorAreaElement extends LitElement {
     const color = colord(
       `hsla(${hue}, ${saturation}%, ${lightness}%, ${alpha / 100})`,
     );
+
+    console.log(`hsla(${hue}, ${saturation}%, ${lightness}%, ${alpha / 100})`);
+
     if (!color.isValid()) {
       return '';
     }
-
+    console.log(color.toHex());
     return color.toHex();
   }
 

--- a/packages/uui-color-area/lib/uui-color-area.element.ts
+++ b/packages/uui-color-area/lib/uui-color-area.element.ts
@@ -211,7 +211,7 @@ export class UUIColorAreaElement extends LitElement {
       l: this.lightness,
       a: this.alpha / 100,
     });
-    console.log(this.saturation);
+
     this._value = color.toRgbString();
     this.dispatchEvent(new UUIColorAreaEvent(UUIColorAreaEvent.CHANGE));
   }
@@ -227,12 +227,10 @@ export class UUIColorAreaElement extends LitElement {
       `hsla(${hue}, ${saturation}%, ${lightness}%, ${alpha / 100})`,
     );
 
-    console.log(`hsla(${hue}, ${saturation}%, ${lightness}%, ${alpha / 100})`);
-
     if (!color.isValid()) {
       return '';
     }
-    console.log(color.toHex());
+
     return color.toHex();
   }
 


### PR DESCRIPTION
fixes the color-picker-handles placement, after selecting a preset value

## Description

Due to missing saturation, the placement of the color-picker-handle would also default to 0 or to the last x axel position.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

Cleaning up the UI

## How to test?

Open a color-picker and select any of the prevalues, and see that color-picker move 

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
