### PR TITLE
fix: 'uui-ref' spacing is different when readonly is enabled

### DIFF
--- a/packages/uui-ref-node/lib/uui-ref-node.element.ts
+++ b/packages/uui-ref-node/lib/uui-ref-node.element.ts
@@ -181,6 +181,7 @@ export class UUIRefNodeElement extends UUIRefElement {
 
       #content {
         display: flex;
+        flex-grow: 1;
         align-items: center;
         justify-content: center;
         line-height: 1.2em;


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco.UI/issues/983