### PR TITLE
UUI-Label: always red asterix

### DIFF
--- a/packages/uui-label/lib/uui-label.element.ts
+++ b/packages/uui-label/lib/uui-label.element.ts
@@ -80,7 +80,7 @@ export class UUILabelElement extends LitElement {
       }
       #required {
         display: inline;
-        color: var(--uui-color-invalid);
+        color: var(--uui-color-danger);
         font-weight: 900;
       }
     `,


### PR DESCRIPTION
We changed this recent to follow along with the invalid color, but it is not ideal for the asterix to follow this, so reverting this part.