### PR TITLE
Fix selection on click in color area

### DIFF
--- a/packages/uui-base/lib/utils/drag.ts
+++ b/packages/uui-base/lib/utils/drag.ts
@@ -25,7 +25,9 @@ export const drag = (
     // TouchEvent is not available in Firefox
     if ('TouchEvent' in window && event instanceof TouchEvent) {
       pointerEvent = event.touches[0];
-    } else if (event instanceof PointerEvent) {
+    } else if (event instanceof MouseEvent) {
+      // Some browsers seems to return PointerEvent instead of MouseEvent for click event.
+      // We can use MouseEvent as PointerEvent inherits from MouseEvent.
       pointerEvent = event;
     } else {
       return;

--- a/packages/uui-base/lib/utils/drag.ts
+++ b/packages/uui-base/lib/utils/drag.ts
@@ -26,7 +26,7 @@ export const drag = (
     if ('TouchEvent' in window && event instanceof TouchEvent) {
       pointerEvent = event.touches[0];
     } else if (event instanceof MouseEvent) {
-      // Some browsers seems to return PointerEvent instead of MouseEvent for click event.
+      // Some browsers seem to return PointerEvent instead of MouseEvent for click event.
       // We can use MouseEvent as PointerEvent inherits from MouseEvent.
       pointerEvent = event;
     } else {

--- a/packages/uui-base/lib/utils/drag.ts
+++ b/packages/uui-base/lib/utils/drag.ts
@@ -28,6 +28,8 @@ export const drag = (
     } else if (event instanceof MouseEvent) {
       // Some browsers seem to return PointerEvent instead of MouseEvent for click event.
       // We can use MouseEvent as PointerEvent inherits from MouseEvent.
+      // Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1675847
+      // Safari: https://bugs.webkit.org/show_bug.cgi?id=218665
       pointerEvent = event;
     } else {
       return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes regression made in PR https://github.com/umbraco/Umbraco.UI/pull/1001 and metioned here: https://github.com/umbraco/Umbraco.UI/pull/1001#issuecomment-2816816476

Noticed in Chrome Version 135.0.7049.96 / Win 10 Pro.

In Chrome the click event returns `MouseEvent`, so it went to `else` statement and stopped executing the `onMove()` event.

It may be a bug that Firefox return `PointerEvent` as click is a `MouseEvent`:
https://stackoverflow.com/a/76900433

I can reproduce to issue in Firefox as well, so it may only be an issue click returning `PointerEvent` in older versions of Firefox and Safari as these has been resolved:
https://bugzilla.mozilla.org/show_bug.cgi?id=1675847
https://bugs.webkit.org/show_bug.cgi?id=218665

However it is safe casting to `MouseEvent` as `PointerEvent` inherits from this:
https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
