### PR TITLE
uui-input-lock: Only focus input when unlocked

### DIFF
--- a/packages/uui-input-lock/lib/uui-input-lock.element.ts
+++ b/packages/uui-input-lock/lib/uui-input-lock.element.ts
@@ -22,12 +22,12 @@ export class UUIInputLockElement extends UUIInputElement {
    * @default true
    */
   @property({ type: Boolean, reflect: true })
-  public get locked(): boolean {
-    return this.#locked;
-  }
   public set locked(lock: boolean) {
     this.#locked = lock;
     this.tabIndex = lock ? -1 : 0;
+  }
+  public get locked(): boolean {
+    return this.#locked;
   }
   #locked: boolean = true;
 

--- a/packages/uui-input-lock/lib/uui-input-lock.element.ts
+++ b/packages/uui-input-lock/lib/uui-input-lock.element.ts
@@ -67,7 +67,7 @@ export class UUIInputLockElement extends UUIInputElement {
     this.pristine = false;
     this.dispatchEvent(new UUIInputLockEvent(UUIInputLockEvent.LOCK_CHANGE));
     if (!this.locked) {
-      this.shadowRoot?.querySelector('input')?.focus();
+      this._input?.focus();
     }
   }
 

--- a/packages/uui-input-lock/lib/uui-input-lock.element.ts
+++ b/packages/uui-input-lock/lib/uui-input-lock.element.ts
@@ -22,11 +22,37 @@ export class UUIInputLockElement extends UUIInputElement {
    * @default true
    */
   @property({ type: Boolean, reflect: true })
-  public locked: boolean = true;
+  public get locked(): boolean {
+    return this.#locked;
+  }
+  public set locked(lock: boolean) {
+    this.#locked = lock;
+    this.tabIndex = lock ? -1 : 0;
+  }
+  #locked: boolean = true;
+
+  /**
+   * Define the label for the unlock button.
+   * @type {string}
+   * @attr
+   * @default true
+   */
+  @property({ type: String, reflect: false, attribute: 'unlock-label' })
+  public unlockLabel: string = 'Unlock input';
+
+  /**
+   * Define the label for the lock button.
+   * @type {string}
+   * @attr
+   * @default true
+   */
+  @property({ type: String, reflect: false, attribute: 'lock-label' })
+  public lockLabel: string = 'Lock input';
 
   constructor() {
     super();
     this.readonly = true;
+    this.tabIndex = -1;
   }
 
   connectedCallback(): void {
@@ -40,6 +66,9 @@ export class UUIInputLockElement extends UUIInputElement {
     this.readonly = this.locked = !this.locked;
     this.pristine = false;
     this.dispatchEvent(new UUIInputLockEvent(UUIInputLockEvent.LOCK_CHANGE));
+    if (!this.locked) {
+      this.shadowRoot?.querySelector('input')?.focus();
+    }
   }
 
   renderIcon() {
@@ -56,7 +85,7 @@ export class UUIInputLockElement extends UUIInputElement {
       @click=${this._onLockToggle}
       compact
       id="lock"
-      label="${this.locked ? 'Unlock input' : 'Lock input'}">
+      label="${this.locked ? this.unlockLabel : this.lockLabel}">
       ${this.renderIcon()}
     </uui-button>`;
   }

--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -214,6 +214,14 @@ export class UUIInputElement extends UUIFormControlMixin(
   @property({ type: String })
   pattern?: string;
 
+  /**
+   * Set the input tabindex, set this to `-1` to avoid tabbing into the input.
+   * @type {number}
+   * @attr
+   */
+  @property({ type: Number, reflect: false, attribute: 'tabindex' })
+  tabIndex: number = 0;
+
   @query('#input')
   _input!: HTMLInputElement;
 
@@ -349,6 +357,7 @@ export class UUIInputElement extends UUIFormControlMixin(
       ?autofocus=${this.autofocus}
       ?required=${this.required}
       ?readonly=${this.readonly}
+      tabindex=${ifDefined(this.tabIndex)}
       @input=${this.onInput}
       @change=${this.onChange} />`;
   }


### PR DESCRIPTION
Implements the tabIndex for input and makes use of that for the uui-input-lock, so the user does not focus on the input when it is locked.

As well when unlocking we now focus the input and implemented options to define the label for lock-button and unluck-button