### PR TITLE
Fix: `uui-card-media`: flex-direction of "content"

### DIFF
--- a/packages/uui-card-media/lib/uui-card-media.element.ts
+++ b/packages/uui-card-media/lib/uui-card-media.element.ts
@@ -209,7 +209,7 @@ export class UUICardMediaElement extends UUICardElement {
         position: relative;
         display: flex;
         width: 100%;
-        align-items: center;
+        flex-direction: column;
         font-family: inherit;
         box-sizing: border-box;
         text-align: left;

--- a/packages/uui-card-media/lib/uui-card-media.story.ts
+++ b/packages/uui-card-media/lib/uui-card-media.story.ts
@@ -41,6 +41,12 @@ type Story = StoryObj;
 
 export const Default: Story = {};
 
+export const WithDetail: Story = {
+  args: {
+    detail: 'The detail',
+  },
+};
+
 export const Folder: Story = {
   args: {
     fileExt: '',


### PR DESCRIPTION
## Description

In the `<uui-card-media>` component, sets `#content` to use `flex-direction: column`, so that the `detail` will display below the `name`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

