### PR TITLE
feat(uui-input): Adds `<datalist>` options support

### DIFF
--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -34,6 +34,11 @@ export type InputMode =
   | 'email'
   | 'url';
 
+export type InputDataListOption = {
+  name?: string;
+  value: string;
+};
+
 /**
  * Custom element wrapping the native input element.This is a formAssociated element, meaning it can participate in a native HTMLForm. A name:value pair will be submitted.
  * @element uui-input
@@ -163,6 +168,16 @@ export class UUIInputElement extends UUIFormControlMixin(
    */
   @property()
   placeholder = '';
+
+  /**
+   * An array of options to be rendered by the input's datalist. The option interface has 2 properties:
+   * `interface Option {
+    name: string;
+    value: string;
+  }`
+   */
+  @property({ type: Array, attribute: false })
+  options: Array<InputDataListOption> = [];
 
   /**
    * Defines the input autocomplete.
@@ -324,11 +339,26 @@ export class UUIInputElement extends UUIFormControlMixin(
     return html`<slot name="append"></slot>`;
   }
 
+  protected renderDataList() {
+    if (!this.options?.length) return;
+    return html`
+      <datalist id="options">
+        ${this.options.map(
+          option => html`
+            <option value=${option.value}>
+              ${option.name ?? option.value}
+            </option>
+          `,
+        )}
+      </datalist>
+    `;
+  }
+
   render() {
     return html`
       ${this.renderPrepend()}
       ${this.autoWidth ? this.renderInputWithAutoWidth() : this.renderInput()}
-      ${this.renderAppend()}
+      ${this.renderAppend()} ${this.renderDataList()}
     `;
   }
 
@@ -351,6 +381,7 @@ export class UUIInputElement extends UUIFormControlMixin(
       spellcheck=${this.spellcheck}
       autocomplete=${ifDefined(this.autocomplete as any)}
       placeholder=${ifDefined(this.placeholder)}
+      list=${ifDefined(this.options?.length ? 'options' : undefined)}
       aria-label=${ifDefined(this.label)}
       inputmode=${ifDefined(this.inputMode)}
       ?disabled=${this.disabled}
@@ -363,7 +394,7 @@ export class UUIInputElement extends UUIFormControlMixin(
   }
 
   private renderAutoWidthBackground() {
-    return html` <div id="auto" aria-hidden="true">${this.renderText()}</div>`;
+    return html`<div id="auto" aria-hidden="true">${this.renderText()}</div>`;
   }
 
   private renderText() {

--- a/packages/uui-input/lib/uui-input.story.ts
+++ b/packages/uui-input/lib/uui-input.story.ts
@@ -222,4 +222,25 @@ export const DataList: Story = {
       { name: 'Strawberry', value: 'red' },
     ],
   },
+  parameters: {
+    docs: {
+      source: {
+        format: false,
+        language: 'jsx',
+        code: `
+// this is an example of array you need to pass to the input component
+const options: Array<Option> = [
+  { name: 'Carrot', value: 'orange' },
+  { name: 'Cucumber', value: 'green' },
+  { name: 'Aubergine', value: 'purple' },
+  { name: 'Blueberry', value: 'Blue' },
+  { name: 'Banana', value: 'yellow' },
+  { name: 'Strawberry', value: 'red' },
+];
+
+<uui-input .options=\${options}></uui-input>
+`,
+      },
+    },
+  },
 };

--- a/packages/uui-input/lib/uui-input.story.ts
+++ b/packages/uui-input/lib/uui-input.story.ts
@@ -209,3 +209,17 @@ export const AutoWidth: Story = {
     placeholder: 'Start typing...',
   },
 };
+
+export const DataList: Story = {
+  args: {
+    autocomplete: 'off',
+    options: [
+      { name: 'Carrot', value: 'orange' },
+      { name: 'Cucumber', value: 'green' },
+      { name: 'Aubergine', value: 'purple' },
+      { name: 'Blueberry', value: 'Blue' },
+      { name: 'Banana', value: 'yellow' },
+      { name: 'Strawberry', value: 'red' },
+    ],
+  },
+};


### PR DESCRIPTION
## Description

Implements #999.

Adds `<datalist>` options support to `<uui-input>`.

Adds an `options` property to `<uui-input>`, accepting an array of `{ name, value }` objects, (similar to `<uui-select options>`). This will result in a `<datalist>` element being rendered within the Shadow DOM, so that the `input` can be associated with it via the `list` attribute.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## How to test?

```jsx
// this is an example of array you need to pass to the input component
const options: Array<Option> = [
  { name: 'Carrot', value: 'orange' },
  { name: 'Cucumber', value: 'green' },
  { name: 'Aubergine', value: 'purple' },
  { name: 'Blueberry', value: 'Blue' },
  { name: 'Banana', value: 'yellow' },
  { name: 'Strawberry', value: 'red' },
];

<uui-input .options=${options}></uui-input>
```