### PR TITLE
use firstUpdated for label feedback

### DIFF
--- a/packages/uui-base/lib/mixins/LabelMixin.ts
+++ b/packages/uui-base/lib/mixins/LabelMixin.ts
@@ -37,8 +37,8 @@ export const LabelMixin = <T extends Constructor<LitElement>>(
     @property({ type: String })
     public label!: string;
 
-    connectedCallback() {
-      super.connectedCallback();
+    firstUpdated(_changedProperties: Map<string | number | symbol, unknown>) {
+      super.firstUpdated(_changedProperties);
       if (!this.label) {
         console.warn(this.tagName + ' needs a `label`', this);
       }

--- a/packages/uui-base/lib/mixins/LabelMixin.ts
+++ b/packages/uui-base/lib/mixins/LabelMixin.ts
@@ -37,8 +37,7 @@ export const LabelMixin = <T extends Constructor<LitElement>>(
     @property({ type: String })
     public label!: string;
 
-    firstUpdated(_changedProperties: Map<string | number | symbol, unknown>) {
-      super.firstUpdated(_changedProperties);
+    firstUpdated() {
       if (!this.label) {
         console.warn(this.tagName + ' needs a `label`', this);
       }


### PR DESCRIPTION
I have seen a few issues where we get this warning despite a label being set. A bit like if this was executed just before it got set, so this should be better.