### PR TITLE
fix: Set height for input prepend/append slots

### DIFF
--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -508,6 +508,7 @@ export class UUIInputElement extends UUIFormControlMixin(
         display: flex;
         align-items: center;
         line-height: 1;
+        height: 100%;
       }
 
       ::slotted(uui-input),

--- a/packages/uui-input/lib/uui-input.story.ts
+++ b/packages/uui-input/lib/uui-input.story.ts
@@ -179,6 +179,14 @@ export const MultipleInputs: Story = {
   },
 };
 
+export const InputAlignment: Story = {
+  render: args =>
+    html`<uui-input ${spread(args)}>${renderSlots(args)}</uui-input>–<uui-input
+        ${spread(args)}
+        >${renderSlots(args)}</uui-input
+      >`,
+};
+
 export const AutoWidth: Story = {
   render: args =>
     html`<uui-input ${spread(args)}></uui-input>


### PR DESCRIPTION
Fixes issue in Backoffice, with prepended items not getting full height.