### PR TITLE
Fix line-height uui-button.element.ts

### DIFF
--- a/packages/uui-button/lib/uui-button.element.ts
+++ b/packages/uui-button/lib/uui-button.element.ts
@@ -292,7 +292,7 @@ export class UUIButtonElement extends UUIFormControlMixin(
       }
 
       .label {
-        line-height: normal; /** needed to reset 'a > span' */
+        line-height: 1; /** needed to reset 'a > span' */
         transition: opacity 120ms;
         display: flex;
         gap: var(--uui-size-1);


### PR DESCRIPTION
Using line-height: 1; insted of line-height: normal; in .label css class style fixes vertical alignment ensuring the line height to exactly 1 times the font size. Ensures consistent spacing across different fonts and browsers.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Screenshots

**After**
![Snimka zaslona 2025-05-28 152915](https://github.com/user-attachments/assets/20faaf61-a51d-404c-8be1-8b9c3b678555)

**Before**
![Snimka zaslona 2025-05-28 152900](https://github.com/user-attachments/assets/17744f1b-310a-4f37-882d-644c4c46b833)

**After**
![Snimka zaslona 2025-05-28 153030](https://github.com/user-attachments/assets/7bcfd292-0296-4d5f-9061-c9022bcd1aab)

**Before**
![Snimka zaslona 2025-05-28 153016](https://github.com/user-attachments/assets/cb16820e-c1b9-4de3-9081-b221b60ba5dd)

**After**
![Snimka zaslona 2025-05-28 153159](https://github.com/user-attachments/assets/eededd52-ae53-4c0d-82f1-131b7f6bb8e5)

**Before**
![Snimka zaslona 2025-05-28 153143](https://github.com/user-attachments/assets/d54825bb-93fa-455d-b84e-209eff266346)

## Checklist

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
