### PR TITLE
Fix vertical alignment of input text for uui-input.element.ts

### DIFF
--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -478,8 +478,7 @@ export class UUIInputElement extends UUIFormControlMixin(
 
       input {
         font-family: inherit;
-        padding: 1px var(--uui-size-space-3) var(--uui-size-1)
-          var(--uui-size-space-3);
+        padding: 1px var(--uui-size-space-3);
         font-size: inherit;
         color: inherit;
         border-radius: var(--uui-border-radius);


### PR DESCRIPTION
Fix vertical alignment of input text caused by padding inconsistency.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Screenshots

The green color indicates the padding size

**Before**
![Snimka zaslona 2025-06-12 114140](https://github.com/user-attachments/assets/b884fccc-502b-4e4e-9fc1-5666f04f1262)
![Snimka zaslona 2025-06-12 114151](https://github.com/user-attachments/assets/a4246311-3bf9-4cfc-8112-9ab509ad018a)

**After**
![Snimka zaslona 2025-06-12 114237](https://github.com/user-attachments/assets/4d88098c-18c3-499c-92f8-7065699bfe05)
![Snimka zaslona 2025-06-12 114246](https://github.com/user-attachments/assets/04492923-51e9-4b57-91c9-608d960980d6)

**Before**
![Snimka zaslona 2025-06-12 114331](https://github.com/user-attachments/assets/e8ade6cb-9247-45a4-b260-8c95e68d81fe)

**After**
![Snimka zaslona 2025-06-12 114401](https://github.com/user-attachments/assets/37076540-3f08-4edb-9435-f0e937ce8b44)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
