### PR TITLE
Add support type attr. on button

### DIFF
--- a/packages/uui-button/lib/uui-button.element.ts
+++ b/packages/uui-button/lib/uui-button.element.ts
@@ -251,6 +251,7 @@ export class UUIButtonElement extends UUIFormControlMixin(
       : html`
           <button
             id="button"
+            type=${this.type}
             ?disabled=${this.disabled}
             aria-label=${ifDefined(this.label)}>
             ${this.renderState()} ${this.renderLabel()}


### PR DESCRIPTION
Bug fix for - https://github.com/umbraco/Umbraco.UI/issues/1054

## Description
Add the attr to the HTML Button and consume the type prop value for it.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context
Stop weired behavior where all form are kind of submitted even tho it is just a button

## How to test?
Storybook, try to set it to submit and i devtool see the button type become "SUBMIT"

## Checklist
- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
