### PR TITLE
Fix stuck while loop where the checked element never got updated

### DIFF
--- a/packages/uui-popover-container/lib/uui-popover-container.element.ts
+++ b/packages/uui-popover-container/lib/uui-popover-container.element.ts
@@ -359,6 +359,7 @@ export class UUIPopoverContainerElement extends LitElement {
       style = getComputedStyle(el);
 
       if (excludeStaticParent && style.position === 'static') {
+        el = this.#getAncestorElement(el);
         continue;
       }
       if (
@@ -370,14 +371,18 @@ export class UUIPopoverContainerElement extends LitElement {
         return;
       }
 
-      if (el.parentElement) {
-        el = el.parentElement;
-      } else {
-        // If we had no parentElement, then check for shadow roots:
-        el = (el.getRootNode() as any)?.host;
-      }
+      el = this.#getAncestorElement(el);
     }
     this.#scrollParents.push(document.body);
+  }
+
+  #getAncestorElement(el: HTMLElement | null): HTMLElement | null {
+    if (el?.parentElement) {
+      return el.parentElement;
+    } else {
+      // If we had no parentElement, then check for shadow roots:
+      return (el?.getRootNode() as any)?.host;
+    }
   }
 
   render() {


### PR DESCRIPTION
The TipTap Table Popover no longer opens after changes to the popover container. It gets stuck in the while loop because the checked element has static positioning. The element in the loop is never updated, so it keeps checking the same element repeatedly.