### PR TITLE
fix(uui-color-slider): sets `max = 360` for `hue` type

### DIFF
--- a/packages/uui-color-slider/lib/uui-color-slider.element.ts
+++ b/packages/uui-color-slider/lib/uui-color-slider.element.ts
@@ -107,7 +107,7 @@ export class UUIColorSliderElement extends LabelMixin('label', LitElement) {
   willUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.has('type')) {
       if (this.type === 'hue') {
-        this.max = this.max ?? 360;
+        this.max = 360;
       } else if (this.type === 'saturation') {
         this.max = this.max ?? 100;
       } else if (this.type === 'lightness') {


### PR DESCRIPTION
## Description

Extends the range of the hue slider in the UUI Color Picker component.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/19620.

PR #1076 added nullable fallbacks for the `max` value for the different types, ([ref](https://github.com/umbraco/Umbraco.UI/pull/1076/files#diff-81edfa8ef6b008f409cc5bfe231d075cbacc730c7a0e8804febc8774ddf4be84R110)). Which for the `hue` type doesn't account for the initial `max` value of `100`, meaning it wouldn't fallback to `360` by default.

The previous implementation fixed the `max` value to `360`, so I've reverted the code to this.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?

Open a Color Picker component, in the hue slider, extend to over a value of `100`, so that you can scroll through the spectrum of colours (from red to red).

