### PR TITLE
feat(uui-color-slider): adds `hideValueLabel` option

### DIFF
--- a/packages/uui-color-picker/lib/uui-color-picker.element.ts
+++ b/packages/uui-color-picker/lib/uui-color-picker.element.ts
@@ -446,6 +446,7 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
         <div class="color-picker__controls">
           <div class="color-picker__sliders">
             <uui-color-slider
+              hide-value-label
               label="hue"
               class="hue-slider"
               .value=${Math.round(this.hue)}

--- a/packages/uui-color-slider/lib/uui-color-slider.element.ts
+++ b/packages/uui-color-slider/lib/uui-color-slider.element.ts
@@ -101,6 +101,15 @@ export class UUIColorSliderElement extends LabelMixin('label', LitElement) {
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
+  /**
+   * Hides the value label under the slider.
+   * @type {boolean}
+   * @attr 'hide-value-label'
+   * @default false
+   */
+  @property({ type: Boolean, attribute: 'hide-value-label' })
+  hideValueLabel = false;
+
   private container!: HTMLElement;
   private handle!: HTMLElement;
 
@@ -290,7 +299,7 @@ export class UUIColorSliderElement extends LabelMixin('label', LitElement) {
           tabindex=${ifDefined(this.disabled ? undefined : '0')}>
         </span>
       </div>
-      ${Math.round(this.value)}`;
+      ${this.hideValueLabel ? null : Math.round(this.value)}`;
   }
 
   static styles = [

--- a/packages/uui-color-slider/lib/uui-color-slider.element.ts
+++ b/packages/uui-color-slider/lib/uui-color-slider.element.ts
@@ -107,7 +107,7 @@ export class UUIColorSliderElement extends LabelMixin('label', LitElement) {
    * @attr 'hide-value-label'
    * @default false
    */
-  @property({ type: Boolean, attribute: 'hide-value-label' })
+  @property({ type: Boolean, attribute: 'hide-value-label', reflect: true })
   hideValueLabel = false;
 
   private container!: HTMLElement;

--- a/packages/uui-color-slider/lib/uui-color-slider.story.ts
+++ b/packages/uui-color-slider/lib/uui-color-slider.story.ts
@@ -231,3 +231,9 @@ export const Advanced: Story = {
     </div>`;
   },
 };
+
+export const HideValueLabel: Story = {
+  args: {
+    hideValueLabel: true,
+  },
+};


### PR DESCRIPTION
## Description

Adds a `hide-value-label` option to the UUI Color Slider component.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Motivation and context

The reason for this is when used in the UUI Color Picker inline/popover component, the Hue slider has a numeric value beneath it, ranging from 0 to 360. This value holds little relevance to the UX or the specified colour value. By hiding the value label, the UI is also tightened up a little.

## How to test?

Open the Color Picker component, notice that the numerical value below the Hue slider is not visible.