### PR TITLE
fix(uui-combobox): Remove bottom gap

### DIFF
--- a/packages/uui-combobox/lib/uui-combobox.element.ts
+++ b/packages/uui-combobox/lib/uui-combobox.element.ts
@@ -330,7 +330,7 @@ export class UUIComboboxElement extends UUIFormControlMixin(LitElement, '') {
   };
 
   #renderInput = () => {
-    return html` <uui-input
+    return html`<uui-input
       slot="trigger"
       id="combobox-input"
       label="combobox-input"
@@ -383,7 +383,7 @@ export class UUIComboboxElement extends UUIFormControlMixin(LitElement, '') {
 
   render() {
     if (this._isPhone && this.open) {
-      return html` <div id="phone-wrapper">
+      return html`<div id="phone-wrapper">
         <uui-button label="close" look="primary" @click=${this.#onClose}>
           ${this.closeLabel}
         </uui-button>
@@ -405,7 +405,7 @@ export class UUIComboboxElement extends UUIFormControlMixin(LitElement, '') {
   static styles = [
     css`
       :host {
-        display: inline-block;
+        display: inline-flex;
       }
 
       #combobox-input {


### PR DESCRIPTION
## Description

When inspecting the `uui-combobox` element, there is some form of whitespace/padding/gap at the bottom of the component.

<img width="493" height="343" alt="Screenshot 2025-08-05 132603" src="https://github.com/user-attachments/assets/85bebd3b-df2e-46d2-b6d4-b23cf8c4dd1e" />

Inspecting the element and shadow DOM, I haven't been able to locate the cause of the gap.

I did find that changing the `display` from `inline-block` to `inline-flex` appears to resolve the gap issue.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and context

In Umbraco CMS, there are features that need to flexbox align components next to the combobox, but the additional gapping at the bottom causes them to appear misaligned (by a few pixels).

<img width="572" height="90" alt="Screenshot 2025-08-05 134344" src="https://github.com/user-attachments/assets/15032a91-1955-4dd1-bfce-5bfa62644517" />

## How to test?

Using the browser's devtools, inspect the combobox element, notice if the bottom gap has gone.
