### PR TITLE
Bugfix/uui ref items slot

### DIFF
--- a/packages/uui-ref/lib/uui-ref.element.ts
+++ b/packages/uui-ref/lib/uui-ref.element.ts
@@ -197,16 +197,20 @@ export class UUIRefElement extends SelectOnlyMixin(
       }
 
       slot[name='actions']::slotted(*:first-child) {
-        display: flex;
-        align-items: center;
         --uui-button-height: calc(var(--uui-size-2) * 4);
         margin-right: var(--uui-size-2);
+      }
+      slot[name='actions'] {
+        display: flex;
+        align-items: center;
       }
       #tag-container::slotted(*:first-child) {
         margin: calc(var(--uui-size-2));
       }
       #actions-container::slotted(*:first-child) {
         margin: calc(var(--uui-size-2));
+      }
+      #actions-container {
         opacity: 0;
         transition: opacity 120ms;
       }
@@ -228,7 +232,7 @@ export class UUIRefElement extends SelectOnlyMixin(
         border-color: var(--uui-color-disabled-standalone);
       }
 
-      slot[name='tag']::slotted(*:first-child) {
+      slot[name='tag'] {
         display: flex;
         justify-content: flex-end;
         align-items: center;

--- a/packages/uui-ref/lib/uui-ref.element.ts
+++ b/packages/uui-ref/lib/uui-ref.element.ts
@@ -196,16 +196,16 @@ export class UUIRefElement extends SelectOnlyMixin(
         border-radius: var(--uui-border-radius);
       }
 
-      slot[name='actions'] {
+      slot[name='actions']::slotted(*:first-child) {
         display: flex;
         align-items: center;
         --uui-button-height: calc(var(--uui-size-2) * 4);
         margin-right: var(--uui-size-2);
       }
-      #tag-container {
+      #tag-container::slotted(*:first-child) {
         margin: calc(var(--uui-size-2));
       }
-      #actions-container {
+      #actions-container::slotted(*:first-child) {
         margin: calc(var(--uui-size-2));
         opacity: 0;
         transition: opacity 120ms;
@@ -228,7 +228,7 @@ export class UUIRefElement extends SelectOnlyMixin(
         border-color: var(--uui-color-disabled-standalone);
       }
 
-      slot[name='tag'] {
+      slot[name='tag']::slotted(*:first-child) {
         display: flex;
         justify-content: flex-end;
         align-items: center;

--- a/packages/uui-ref/lib/uui-ref.element.ts
+++ b/packages/uui-ref/lib/uui-ref.element.ts
@@ -196,8 +196,11 @@ export class UUIRefElement extends SelectOnlyMixin(
         border-radius: var(--uui-border-radius);
       }
 
-      slot[name='actions']::slotted(*:first-child) {
+      slot[name='actions']::slotted(*) {
         --uui-button-height: calc(var(--uui-size-2) * 4);
+      }
+
+      slot[name='actions']::slotted(*:first-child) {
         margin-right: var(--uui-size-2);
       }
       slot[name='actions'] {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixed the issue https://github.com/umbraco/Umbraco-CMS/issues/19936, where the tags and actions slots were taking up space even when empty. The fix removes the margin from the `<slot>` itself and instead applies it only to the first and last child elements within the slot using`:: slotted()` selectors.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)
_Before fix_: empty slots occupy space

https://github.com/user-attachments/assets/b0fde5d2-b207-4517-8178-fc7383a5ae8d


_After fix_: empty slots collapse, spacing only applied to child elements

https://github.com/user-attachments/assets/6a866774-5de0-4b54-b0e6-90c2920f61d3


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
