### PR TITLE
feature-upgrade/button - Focus state color can be controled

### DIFF
--- a/packages/uui-button/lib/uui-button.element.ts
+++ b/packages/uui-button/lib/uui-button.element.ts
@@ -50,6 +50,7 @@ export type UUIButtonType = 'submit' | 'button' | 'reset';
  *  @cssprop --uui-button-contrast-disabled - overwrite the text color for disabled state
  *  @cssprop --uui-button-content-align - Overwrite justify-content alignment. Possible values: 'left', 'right', 'center'.
  *  @cssprop --uui-button-transition - Add transition to the button. Default is none.
+ *  @cssprop --uui-focus-outline-color - overwrite the focus outline color
  */
 @defineElement('uui-button')
 export class UUIButtonElement extends UUIFormControlMixin(
@@ -358,7 +359,7 @@ export class UUIButtonElement extends UUIFormControlMixin(
       }
 
       #button:focus-visible {
-        outline: 2px solid var(--color-emphasis);
+        outline: 2px solid var(--uui-focus-outline-color, var(--color-emphasis));
       }
 
       button[disabled]:active,

--- a/packages/uui-button/lib/uui-button.story.ts
+++ b/packages/uui-button/lib/uui-button.story.ts
@@ -46,6 +46,7 @@ const meta: Meta = {
       options: ['left', 'center', 'right'],
     },
     '--uui-button-transition': { control: { type: 'text' } },
+    '--uui-focus-outline-color': { control: { type: 'color' } },
   },
   render: args => {
     return html`<uui-button ${spread(args)}>${renderSlots(args)}</uui-button>`;


### PR DESCRIPTION
Added a focus color property to control the focus state color for further use and more customizability

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This helps fix an accessibility issue in the backoffice 

When tabbing through the buttons below the focus state that is coming up does not appear due to the color being the same as the background
<img width="1636" height="83" alt="image" src="https://github.com/user-attachments/assets/54961f5e-b3d5-4daa-b142-ae71e28b2bf4" />

## How to test?

Run the project and go to the button section and change the new property `--uui-focus-outline-color`
<img width="1062" height="172" alt="image" src="https://github.com/user-attachments/assets/9bf56932-50b4-4cd4-9685-4a6b2689fc9d" />

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
