### PR TITLE
Adjust indent to compensate border

### DIFF
--- a/packages/uui-toggle/lib/uui-toggle.element.ts
+++ b/packages/uui-toggle/lib/uui-toggle.element.ts
@@ -121,13 +121,13 @@ export class UUIToggleElement extends UUIBooleanInputElement {
 
       #icon-checked {
         margin-left: -0.5em;
-        left: calc(var(--uui-toggle-size) * 0.5);
+        left: calc((var(--uui-toggle-size) + 1px) * 0.5);
         color: var(--uui-color-interactive);
       }
 
       #icon-unchecked {
         margin-right: -0.5em;
-        right: calc(var(--uui-toggle-size) * 0.5);
+        right: calc((var(--uui-toggle-size)) + 1px) * 0.5);
         color: var(--uui-color-interactive);
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This add slightly more indent of toggle icons.
Currently it just use `--uui-toggle-size` which is 18px by default, but also have 1px border so a total width of 20px.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
