### PR TITLE
Item-Ref: Less daunting error visuals

### DIFF
--- a/packages/uui-ref/lib/uui-ref.element.ts
+++ b/packages/uui-ref/lib/uui-ref.element.ts
@@ -86,10 +86,7 @@ export class UUIRefElement extends SelectOnlyMixin(
       }
 
       :host([error]) {
-        border: 2px solid var(--uui-color-invalid);
-        box-shadow:
-          0 0 4px 0 var(--uui-color-invalid),
-          inset 0 0 2px 0 var(--uui-color-invalid);
+        border: 1px solid var(--uui-color-invalid);
       }
 
       :host([standalone]) {


### PR DESCRIPTION
With this chang,e it will look like this:
<img width="1727" height="281" alt="image" src="https://github.com/user-attachments/assets/c0044db1-ba39-4529-a35b-4bf8d04a2e79" />

Coming from this:
<img width="1751" height="306" alt="image" src="https://github.com/user-attachments/assets/a8eba132-841a-439b-835f-ec968eafa076" />
