### PR TITLE
uui-menu-item: custom expand symbol render method

### DIFF
--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -254,7 +254,8 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
     }
 
     return html`<uui-symbol-expand
-      .direction=${this.showChildren ? 'up' : 'down'}></uui-symbol-expand>`;
+      aria-hidden="true"
+      ?open=${this.showChildren}></uui-symbol-expand>`;
   }
 
   static styles = [

--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -126,7 +126,7 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
    * Overwrite the expand symbol rendering, this replaces the Expand Symbol from UI Library.
    */
   @property({ attribute: false })
-  public renderExpandSymbol?: () => Element | TemplateResult<1>;
+  public renderExpandSymbol?: () => Element | TemplateResult<1> | undefined;
 
   @state()
   private iconSlotHasContent = false;
@@ -229,11 +229,7 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
               id="caret-button"
               aria-label=${this.caretLabel}
               @click=${this._onCaretClicked}>
-              ${this.renderExpandSymbol
-                ? this.renderExpandSymbol()
-                : html` <uui-symbol-expand
-                    aria-hidden="true"
-                    ?open=${this.showChildren}></uui-symbol-expand>`}
+              ${this.#renderExpandSymbol()}
             </button>`
           : ''}
         ${this.href && this.selectOnly !== true && this.selectable !== true
@@ -247,6 +243,18 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
       </div>
       ${this.showChildren ? html`<slot></slot>` : ''}
     `;
+  }
+
+  #renderExpandSymbol() {
+    if (this.renderExpandSymbol) {
+      const result = this.renderExpandSymbol();
+      if (result) {
+        return result;
+      }
+    }
+
+    return html`<uui-symbol-expand
+      .direction=${this.showChildren ? 'up' : 'down'}></uui-symbol-expand>`;
   }
 
   static styles = [

--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -6,7 +6,7 @@ import {
 } from '@umbraco-ui/uui-base/lib/mixins';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { demandCustomElement } from '@umbraco-ui/uui-base/lib/utils';
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, TemplateResult } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -122,6 +122,12 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
   @property({ type: String, attribute: 'caret-label' })
   public caretLabel = 'Reveal the underlying items';
 
+  /**
+   * Overwrite the expand symbol rendering, this replaces the Expand Symbol from UI Library.
+   */
+  @property({ attribute: false })
+  public renderExpandSymbol?: () => Element | TemplateResult<1>;
+
   @state()
   private iconSlotHasContent = false;
 
@@ -222,9 +228,11 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
               id="caret-button"
               aria-label=${this.caretLabel}
               @click=${this._onCaretClicked}>
-              <uui-symbol-expand
-                aria-hidden="true"
-                ?open=${this.showChildren}></uui-symbol-expand>
+              ${this.renderExpandSymbol
+                ? this.renderExpandSymbol()
+                : html` <uui-symbol-expand
+                    aria-hidden="true"
+                    ?open=${this.showChildren}></uui-symbol-expand>`}
             </button>`
           : ''}
         ${this.href && this.selectOnly !== true && this.selectable !== true

--- a/packages/uui-menu-item/lib/uui-menu-item.story.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.story.ts
@@ -145,7 +145,12 @@ export const CustomExpandSymbol: Story = {
     docs: {
       source: {
         code: html`
-          <uui-menu-item label="Menu Item 1" has-children>
+          <uui-menu-item
+            label="Menu Item 1"
+            has-children
+            .renderExpandSymbol=${() => {
+              return html`<uui-icon name="favorite"></uui-icon>`;
+            }}>
             <uui-menu-item label="Nested Menu Item 1"></uui-menu-item>
             <uui-menu-item label="Nested Menu Item 2"></uui-menu-item>
           </uui-menu-item>

--- a/packages/uui-menu-item/lib/uui-menu-item.story.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.story.ts
@@ -126,6 +126,35 @@ export const Nested: Story = {
   },
 };
 
+export const CustomExpandSymbol: Story = {
+  render: args => html`
+    ${labelNames.map(
+      (name: string) =>
+        html` <uui-menu-item
+          label="${name}"
+          .caretLabel="${args.caretLabel}"
+          .renderExpandSymbol=${() => {
+            return html`<uui-icon name="favorite"></uui-icon>`;
+          }}
+          has-children>
+          ${renderItems()}
+        </uui-menu-item>`,
+    )}
+  `,
+  parameters: {
+    docs: {
+      source: {
+        code: html`
+          <uui-menu-item label="Menu Item 1" has-children>
+            <uui-menu-item label="Nested Menu Item 1"></uui-menu-item>
+            <uui-menu-item label="Nested Menu Item 2"></uui-menu-item>
+          </uui-menu-item>
+        `.strings,
+      },
+    },
+  },
+};
+
 export const Active: Story = {
   render: () => {
     const [activeIndex, setActiveIndex] = useState<number>(1);


### PR DESCRIPTION
Adds ability to bring a custom render/template for the Expand-button insides/symbol — We need this in the CMS for the Collections-shortcut.

<img width="271" height="214" alt="image" src="https://github.com/user-attachments/assets/e1459dc7-c46e-4cb1-bc1e-65eb6558384a" />
