### PR TITLE
fix: Hide value label for opacity slider as well in color picker

### DIFF
--- a/packages/uui-color-picker/lib/uui-color-picker.element.ts
+++ b/packages/uui-color-picker/lib/uui-color-picker.element.ts
@@ -651,11 +651,8 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
 
       .color-picker__transparent-bg {
         border: 1px solid var(--uui-color-border);
-        background-image: linear-gradient(
-            45deg,
-            var(--uui-palette-grey) 25%,
-            transparent 25%
-          ),
+        background-image:
+          linear-gradient(45deg, var(--uui-palette-grey) 25%, transparent 25%),
           linear-gradient(45deg, transparent 75%, var(--uui-palette-grey) 75%),
           linear-gradient(45deg, transparent 75%, var(--uui-palette-grey) 75%),
           linear-gradient(45deg, var(--uui-palette-grey) 25%, transparent 25%);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe the changes in detail -->
https://github.com/umbraco/Umbraco.UI/pull/1150 added a feature to hide value label for `uui-color-slider` and set this for hue slider, but not opacity slider.

I think it's a bit inconsistent it is show for opacity slider, but not hue slider:
https://uui.umbraco.com/?path=/story/uui-color-picker--opacity

and like this in CMS:

<img width="635" height="543" alt="image" src="https://github.com/user-attachments/assets/aa76a9e7-f452-404a-a4ec-3535d99991fa" />

Ideally I think we should have a proper [Tooltip](https://github.com/umbraco/Umbraco.UI/discussions/1082) component (not same as popover which may contain interactive elements) and possible it can be used for both `uui-range-slider` and `uui-color-slider`.

At the moment the specific opacity level can be seen in RGB(A) mode as well HEX(A) - although easiest in RGB(A) mode:

<img width="566" height="508" alt="image" src="https://github.com/user-attachments/assets/2f63c70d-0f45-455c-803c-1cb324c39da1" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

<img width="717" height="749" alt="image" src="https://github.com/user-attachments/assets/3635ff62-db6c-43f8-8f32-c10e914e346d" />

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
