### PR TITLE
uui-loader-bar: Make loader-bar on uui-menu-item fade in

### DIFF
--- a/packages/uui-menu-item/lib/uui-menu-item.element.ts
+++ b/packages/uui-menu-item/lib/uui-menu-item.element.ts
@@ -237,9 +237,9 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
           : this._renderLabelAsButton()}
 
         <slot id="actions-container" name="actions"></slot>
-        <uui-loader-bar
-          id="loader"
-          class=${this.loading ? 'visible' : ''}></uui-loader-bar>
+        ${this.loading
+          ? html`<uui-loader-bar id="loader"></uui-loader-bar>`
+          : ''}
       </div>
       ${this.showChildren ? html`<slot></slot>` : ''}
     `;
@@ -618,14 +618,15 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         margin-right: var(--uui-size-base-unit);
       }
 
-      #loader {
-        opacity: 0;
-        transition: opacity 120ms ease-in 60ms;
-        pointer-events: none;
+      @keyframes fadeIn {
+        100% {
+          opacity: 1;
+        }
       }
 
-      #loader.visible {
-        opacity: 1;
+      uui-loader-bar {
+        opacity: 0;
+        animation: fadeIn 120ms ease-in 60ms forwards;
       }
     `,
   ];


### PR DESCRIPTION
## Description
This PR improves the user experience of the loader bar inside the UUI Menu Item by preventing a visual “flash” that occurs during short loading operations.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots (if appropriate)
Before fixing:
![OldLoadingNew](https://github.com/user-attachments/assets/e7c54d8e-7064-41bf-b97a-d4486d5994bb)
Afterf fix:
![NewLoadingNew](https://github.com/user-attachments/assets/05637be3-bdd1-4990-9724-7adb365f0ca2)
