### PR TITLE
uui-card: tooltip issue for uui card when selectOnly

### DIFF
--- a/packages/uui-card-block-type/lib/uui-card-block-type.element.ts
+++ b/packages/uui-card-block-type/lib/uui-card-block-type.element.ts
@@ -47,6 +47,7 @@ export class UUICardBlockTypeElement extends UUICardElement {
     return html`
       ${this.#renderMedia()}
       ${this.href ? this.#renderLink() : this.#renderButton()}
+      <div id="name-wrapper" title="${this.name}"></div>
       <!-- Select border must be right after #open-part -->
       <div id="select-border"></div>
       ${this.selectable ? this.renderCheckbox() : nothing}
@@ -105,6 +106,13 @@ export class UUICardBlockTypeElement extends UUICardElement {
     css`
       :host {
         background-color: var(--uui-color-surface-alt);
+      }
+
+      #name-wrapper {
+        position: absolute;
+        inset: 0;
+        pointer-events: auto;
+        z-index: 0;
       }
 
       slot[name='tag'] {

--- a/packages/uui-card-content-node/lib/uui-card-content-node.element.ts
+++ b/packages/uui-card-content-node/lib/uui-card-content-node.element.ts
@@ -116,6 +116,7 @@ export class UUICardContentNodeElement extends UUICardElement {
   public render() {
     return html`
       ${this.href ? this.#renderLink() : this.#renderButton()}
+      <div id="name-wrapper" title="${this.name}"></div>
       <!-- Select border must be right after #open-part -->
       <div id="select-border"></div>
       ${this.selectable ? this.renderCheckbox() : nothing}
@@ -131,6 +132,13 @@ export class UUICardContentNodeElement extends UUICardElement {
         min-width: 250px;
         flex-direction: column;
         justify-content: space-between;
+      }
+
+      #name-wrapper {
+        position: absolute;
+        inset: 0;
+        pointer-events: auto;
+        z-index: 0;
       }
 
       slot[name='tag'] {

--- a/packages/uui-card-media/lib/uui-card-media.element.ts
+++ b/packages/uui-card-media/lib/uui-card-media.element.ts
@@ -113,6 +113,7 @@ export class UUICardMediaElement extends UUICardElement {
   public render() {
     return html` ${this.renderMedia()}
       <slot @slotchange=${this.queryPreviews}></slot>
+      <div id="name-wrapper" title="${this.name}"></div>
       ${this.href ? this.#renderLink() : this.#renderButton()}
       <!-- Select border must be right after .open-part -->
       <div id="select-border"></div>
@@ -196,6 +197,13 @@ export class UUICardMediaElement extends UUICardElement {
         overflow: hidden;
         text-overflow: ellipsis;
         overflow-wrap: anywhere;
+      }
+
+      #name-wrapper {
+        position: absolute;
+        inset: 0;
+        pointer-events: auto;
+        z-index: 0;
       }
 
       :host([image]:not([image=''])) #open-part {

--- a/packages/uui-card-user/lib/uui-card-user.element.ts
+++ b/packages/uui-card-user/lib/uui-card-user.element.ts
@@ -89,6 +89,7 @@ export class UUICardUserElement extends UUICardElement {
   public render() {
     return html`
       ${this.href ? this.#renderLink() : this.#renderButton()}
+      <div id="name-wrapper" title="${this.name}"></div>
       <!-- Select border must be right after #open-part -->
       <div id="select-border"></div>
       ${this.selectable ? this.renderCheckbox() : nothing}
@@ -102,6 +103,13 @@ export class UUICardUserElement extends UUICardElement {
     css`
       :host {
         min-width: 250px;
+      }
+
+      #name-wrapper {
+        position: absolute;
+        inset: 0;
+        pointer-events: auto;
+        z-index: 0;
       }
 
       slot:not([name])::slotted(*) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes for the issue https://github.com/umbraco/Umbraco.UI/issues/1233

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and context

Because when in `selectOnly `state, the card is disabled, the tooltip cannot display the full name.
I added a div tag for a tooltip to display its name for:
- uui-card-media
- uui-card-block-type
- uui-card-user
- uui-card-content-node

## How to test?

## Screenshots (if appropriate)

