### PR TITLE
chore: add context7 configuration for Umbraco.UI

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/umbraco/umbraco.ui",
+  "public_key": "pk_GTIgsrGAQiHNxCirZBDIM"
+}


### PR DESCRIPTION
### Description

Context7 is a documentation service for AI coding tools. LLM's have cutoff dates for their knowledge that are usually at least 6 months in the past. Context7 fills in these gaps by allowing vendors to supply the most up to date documentation. Context7 is consumed by the user as an MCP server. 

By default context7 indexes the most popular repos on the web and automatically generates this documentation. Sometimes this is outdated and needs updating, the first step to that is to prove ownership of the repo. 
The file in this PR does that. 

Adds the `context7.json` file to claim this repository for the [Context7](https://context7.com) documentation service.

**What this does:**
- Adds a `context7.json` configuration file containing:
  - URL pointing to the Umbraco UI Context7 page
  - Public key for verification


