### PR TITLE
Input: make autoWidth become smaller than browser default width

### DIFF
--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -341,6 +341,7 @@ export class UUIInputElement extends UUIFormControlMixin(
   renderInput() {
     return html`<input
       id="input"
+      size=${ifDefined(this.autoWidth ? '1' : undefined)}
       .type=${this.type}
       .value=${this.value as string}
       .name=${this.name}

--- a/packages/uui-input/lib/uui-input.story.ts
+++ b/packages/uui-input/lib/uui-input.story.ts
@@ -221,19 +221,13 @@ export const AutoWidth: Story = {
           ?auto-width=${args.autoWidth}></uui-input>
       </uui-input>
 
-      <uui-input-lock
-        placeholder="Pure input iwth lock for test"
-        auto-width
-        style="max-width:240px;"></uui-input-lock>
+      <uui-input-lock placeholder="" auto-width></uui-input-lock>
 
       <uui-input
         ${spread(args)}
-        style="max-width:400px"
-        placeholder="max-width 400px">
-        <uui-input-lock
-          slot="append"
-          placeholder="Append auto-width false"
-          ?auto-width=${args.autoWidth}></uui-input-lock>
+        style="width:320px"
+        placeholder="Enter alias...">
+        <uui-input-lock slot="append" auto-width></uui-input-lock>
       </uui-input>
 
       <uui-input


### PR DESCRIPTION
Enables a input with autoWidth to become smaller than the default width of the browser.
<img width="390" height="109" alt="image" src="https://github.com/user-attachments/assets/b433ffe8-de16-4409-9093-dc353e0bfd01" />

and here a screencapture of the effect it will have in Backoffice:
<img width="666" height="438" alt="image" src="https://github.com/user-attachments/assets/cafa4fc4-abf5-42c1-8897-f96331f47cea" />

Making the alias-input, smaller until it has content that fills it up:
![Uploading image.png…]()
