### PR TITLE
input: add text overflow

### DIFF
--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -491,6 +491,7 @@ export class UUIInputElement extends UUIFormControlMixin(
         height: inherit;
         text-align: inherit;
         outline: none;
+        text-overflow: ellipsis;
       }
 
       input[type='password']::-ms-reveal {


### PR DESCRIPTION
Make elipsis appear when there is text overflow, but only when not in focus:
<img width="455" height="145" alt="image" src="https://github.com/user-attachments/assets/b4ffc7ab-48d2-4c69-bbb0-2669f24d4cc3" />
