### PR TITLE
fix(base): prefix class declarations with UUI to satisfy eslint rule

### DIFF
--- a/packages/uui-base/lib/events/UUISelectableEvent.ts
+++ b/packages/uui-base/lib/events/UUISelectableEvent.ts
@@ -1,7 +1,10 @@
-import { SelectableMixinInterface } from '../mixins';
+import { UUISelectableMixinInterface } from '../mixins';
 import { UUIEvent } from './UUIEvent';
 
-export class UUISelectableEvent extends UUIEvent<{}, SelectableMixinInterface> {
+export class UUISelectableEvent extends UUIEvent<
+  {},
+  UUISelectableMixinInterface
+> {
   public static readonly SELECTED = 'selected';
   public static readonly DESELECTED = 'deselected';
 

--- a/packages/uui-base/lib/mixins/ActiveMixin.ts
+++ b/packages/uui-base/lib/mixins/ActiveMixin.ts
@@ -3,7 +3,7 @@ import { property } from 'lit/decorators.js';
 
 type Constructor<T = {}> = new (...args: any[]) => T;
 
-export declare class ActiveMixinInterface {
+export declare class UUIActiveMixinInterface {
   /**
    * Set this boolean to true for then the related composition is sorted.
    * @type {boolean}
@@ -22,7 +22,7 @@ export declare class ActiveMixinInterface {
 export const ActiveMixin = <T extends Constructor<LitElement>>(
   superClass: T,
 ) => {
-  class ActiveMixinClass extends superClass {
+  class UUIActiveMixinClass extends superClass {
     /**
      * Set this boolean to true for then the related composition is sorted.
      * @type {boolean}
@@ -32,5 +32,6 @@ export const ActiveMixin = <T extends Constructor<LitElement>>(
     public active = false;
   }
 
-  return ActiveMixinClass as unknown as Constructor<ActiveMixinInterface> & T;
+  return UUIActiveMixinClass as unknown as Constructor<UUIActiveMixinInterface> &
+    T;
 };

--- a/packages/uui-base/lib/mixins/LabelMixin.ts
+++ b/packages/uui-base/lib/mixins/LabelMixin.ts
@@ -3,7 +3,7 @@ import { property, state } from 'lit/decorators.js';
 
 type Constructor<T = {}> = new (...args: any[]) => T;
 
-export declare class LabelMixinInterface {
+export declare class UUILabelMixinInterface {
   /**
    * Label to be used for aria-label and potentially as visual label for some components
    * @type {string}
@@ -28,7 +28,7 @@ export const LabelMixin = <T extends Constructor<LitElement>>(
   /**
    * Label mixin class containing the label functionality.
    */
-  class LabelMixinClass extends superClass {
+  class UUILabelMixinClass extends superClass {
     /**
      * Label to be used for aria-label and potentially as visual label for some components
      * @type {string}
@@ -71,5 +71,6 @@ export const LabelMixin = <T extends Constructor<LitElement>>(
       `;
     }
   }
-  return LabelMixinClass as unknown as Constructor<LabelMixinInterface> & T;
+  return UUILabelMixinClass as unknown as Constructor<UUILabelMixinInterface> &
+    T;
 };

--- a/packages/uui-base/lib/mixins/PopoverTargetMixin.ts
+++ b/packages/uui-base/lib/mixins/PopoverTargetMixin.ts
@@ -4,7 +4,7 @@ import { findAncestorByAttributeValue } from '../utils';
 
 type Constructor<T = {}> = new (...args: any[]) => T;
 
-export declare class PopoverTargetMixinInterface {
+export declare class UUIPopoverTargetMixinInterface {
   /**
    * Set a popovertarget.
    * @type {string}
@@ -31,7 +31,7 @@ export const PopoverTargetMixin = <T extends Constructor<LitElement>>(
   /**
    * Popover target mixin class containing the popover target functionality.
    */
-  class PopoverTargetMixinClass extends superClass {
+  class UUIPopoverTargetMixinClass extends superClass {
     /**
      * Set a popovertarget.
      * @type {string}
@@ -74,6 +74,6 @@ export const PopoverTargetMixin = <T extends Constructor<LitElement>>(
       });
     };
   }
-  return PopoverTargetMixinClass as unknown as Constructor<PopoverTargetMixinInterface> &
+  return UUIPopoverTargetMixinClass as unknown as Constructor<UUIPopoverTargetMixinInterface> &
     T;
 };

--- a/packages/uui-base/lib/mixins/SelectOnlyMixin.ts
+++ b/packages/uui-base/lib/mixins/SelectOnlyMixin.ts
@@ -1,9 +1,9 @@
 import { property } from 'lit/decorators.js';
-import { SelectableMixinInterface } from './SelectableMixin';
+import { UUISelectableMixinInterface } from './SelectableMixin';
 
 type Constructor<T = {}> = new (...args: any[]) => T;
 
-export declare class SelectOnlyMixinInterface extends SelectableMixinInterface {
+export declare class UUISelectOnlyMixinInterface extends UUISelectableMixinInterface {
   selectOnly: boolean;
 }
 
@@ -15,11 +15,11 @@ export declare class SelectOnlyMixinInterface extends SelectableMixinInterface {
  * @mixin
  */
 export const SelectOnlyMixin = <
-  T extends Constructor<SelectableMixinInterface>,
+  T extends Constructor<UUISelectableMixinInterface>,
 >(
   superClass: T,
 ) => {
-  class SelectOnlyMixinClass extends superClass {
+  class UUISelectOnlyMixinClass extends superClass {
     private _selectOnly = false;
 
     /**
@@ -38,5 +38,5 @@ export const SelectOnlyMixin = <
     }
   }
   // prettier-ignore
-  return (SelectOnlyMixinClass as unknown) as Constructor<SelectOnlyMixinInterface> & T;
+  return (UUISelectOnlyMixinClass as unknown) as Constructor<UUISelectOnlyMixinInterface> & T;
 };

--- a/packages/uui-base/lib/mixins/SelectableMixin.ts
+++ b/packages/uui-base/lib/mixins/SelectableMixin.ts
@@ -5,7 +5,7 @@ import { UUISelectableEvent } from '../events/UUISelectableEvent';
 
 type Constructor<T = {}> = new (...args: any[]) => T;
 
-export declare class SelectableMixinInterface extends LitElement {
+export declare class UUISelectableMixinInterface extends LitElement {
   /**
    * Enable the ability to select this element.
    * @attr
@@ -39,7 +39,7 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
    * @fires {UUISelectableEvent} selected - fires when the media card is selected
    * @fires {UUISelectableEvent} deselected - fires when the media card is deselected
    */
-  class SelectableMixinClass extends superClass {
+  class UUISelectableMixinClass extends superClass {
     private _selectable = false;
     /**
      * Enable the ability to select this element.
@@ -179,5 +179,5 @@ export const SelectableMixin = <T extends Constructor<LitElement>>(
     }
   }
   // prettier-ignore
-  return (SelectableMixinClass as unknown) as Constructor<SelectableMixinInterface> & T;
+  return (UUISelectableMixinClass as unknown) as Constructor<UUISelectableMixinInterface> & T;
 };

--- a/packages/uui-base/lib/utils/Timer.ts
+++ b/packages/uui-base/lib/utils/Timer.ts
@@ -1,4 +1,4 @@
-export class Timer {
+export class UUITimer {
   private _timerId: number | null = null;
   private _startTime!: number;
   private _duration!: number;

--- a/packages/uui-modal/lib/modal-example.element.ts
+++ b/packages/uui-modal/lib/modal-example.element.ts
@@ -6,7 +6,7 @@ import { UUIModalElement } from './uui-modal.element';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 
 @defineElement('modal-example')
-export class ModalExampleElement extends LitElement {
+export class UUIModalExampleElement extends LitElement {
   @state()
   private _modals: TemplateResult<1>[] = [];
 
@@ -108,6 +108,6 @@ export class ModalExampleElement extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'modal-example': ModalExampleElement;
+    'modal-example': UUIModalExampleElement;
   }
 }

--- a/packages/uui-toast-notification/lib/uui-toast-notification.element.ts
+++ b/packages/uui-toast-notification/lib/uui-toast-notification.element.ts
@@ -1,5 +1,5 @@
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
-import { demandCustomElement, Timer } from '@umbraco-ui/uui-base/lib/utils';
+import { demandCustomElement, UUITimer } from '@umbraco-ui/uui-base/lib/utils';
 import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
 import { iconRemove } from '@umbraco-ui/uui-icon-registry-essential/lib/svgs';
 import { css, html, LitElement } from 'lit';
@@ -43,7 +43,7 @@ export class UUIToastNotificationElement extends LitElement {
     this._autoClose = value;
     if (value !== null) {
       if (this._timer === null) {
-        this._timer = new Timer(this._onOpenTimerComplete, value);
+        this._timer = new UUITimer(this._onOpenTimerComplete, value);
       } else {
         this._timer.setDuration(value);
       }
@@ -91,7 +91,7 @@ export class UUIToastNotificationElement extends LitElement {
 
   @query('#toast')
   private _toastEl!: HTMLElement;
-  private _timer: Timer | null = null;
+  private _timer: UUITimer | null = null;
   private _pauseTimer: boolean = false;
 
   protected isOpen = false;


### PR DESCRIPTION
## Summary
- Renamed all class declarations missing the `UUI` prefix to comply with the `local-rules/uui-class-prefix` eslint rule
- Updated mixin interface types (`ActiveMixinInterface` -> `UUIActiveMixinInterface`, etc.), internal mixin classes, `Timer` -> `UUITimer`, and `ModalExampleElement` -> `UUIModalExampleElement`
- Updated all cross-file references (imports, type annotations, generics) accordingly

## Affected files
- `packages/uui-base/lib/mixins/ActiveMixin.ts`
- `packages/uui-base/lib/mixins/LabelMixin.ts`
- `packages/uui-base/lib/mixins/PopoverTargetMixin.ts`
- `packages/uui-base/lib/mixins/SelectableMixin.ts`
- `packages/uui-base/lib/mixins/SelectOnlyMixin.ts`
- `packages/uui-base/lib/events/UUISelectableEvent.ts`
- `packages/uui-base/lib/utils/Timer.ts`
- `packages/uui-toast-notification/lib/uui-toast-notification.element.ts`
- `packages/uui-modal/lib/modal-example.element.ts`

## Test plan
- [x] `npm run lint` passes (no more `uui-class-prefix` warnings on affected files)
- [x] `npm run build` succeeds (85/85 packages)
- [x] `npm run test` — 821 passed, 2 pre-existing failures unrelated to this change (uui-input email/url validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)