### PR TITLE
build(deps-dev): update @testing-library/dom to v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@storybook/addon-docs": "^10.2.8",
         "@storybook/addon-links": "^10.2.8",
         "@storybook/web-components-vite": "^10.2.8",
-        "@testing-library/dom": "7.21.4",
+        "@testing-library/dom": "10.4.1",
         "@types/chai": "5.2.3",
         "@types/mocha": "10.0.10",
         "@types/react": "18.3.1",
@@ -268,17 +268,6 @@
       "version": "7.28.4",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.28.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-js-pure": "^3.43.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1462,41 +1451,6 @@
       "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/@jest/types": {
-      "version": "25.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^1.1.1",
-        "@types/yargs": "^15.0.0",
-        "chalk": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8.3"
-      }
-    },
-    "node_modules/@jest/types/node_modules/@types/istanbul-reports": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*",
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@jest/types/node_modules/chalk": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -3315,18 +3269,23 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "7.21.4",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.10.3",
-        "@types/aria-query": "^4.2.0",
-        "aria-query": "^4.2.2",
-        "dom-accessibility-api": "^0.4.6",
-        "pretty-format": "^25.5.0"
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@testing-library/jest-dom": {
@@ -3418,7 +3377,9 @@
       }
     },
     "node_modules/@types/aria-query": {
-      "version": "4.2.2",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3809,19 +3770,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/yargs": {
-      "version": "15.0.20",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -5649,15 +5597,13 @@
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
-      "version": "4.2.2",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime": "^7.10.2",
-        "@babel/runtime-corejs3": "^7.10.2"
-      },
-      "engines": {
-        "node": ">=6.0"
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/array-back": {
@@ -6971,16 +6917,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/core-js-pure": {
-      "version": "3.46.0",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "dev": true,
@@ -7617,7 +7553,9 @@
       }
     },
     "node_modules/dom-accessibility-api": {
-      "version": "0.4.7",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -10961,6 +10899,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/make-dir": {
@@ -14459,17 +14407,31 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "25.5.0",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^25.5.0",
-        "ansi-regex": "^5.0.0",
-        "ansi-styles": "^4.0.0",
-        "react-is": "^16.12.0"
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
       },
       "engines": {
-        "node": ">= 8.3"
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/pretty-hrtime": {
@@ -14782,7 +14744,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "16.13.1",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@storybook/addon-docs": "^10.2.8",
     "@storybook/addon-links": "^10.2.8",
     "@storybook/web-components-vite": "^10.2.8",
-    "@testing-library/dom": "7.21.4",
+    "@testing-library/dom": "10.4.1",
     "@types/chai": "5.2.3",
     "@types/mocha": "10.0.10",
     "@types/react": "18.3.1",


### PR DESCRIPTION
## Summary
- Update `@testing-library/dom` from **7.21.4** to **10.4.1** (latest stable)
- No source code changes required — this dependency has no direct imports in the codebase; it is consumed transitively by `@testing-library/user-event` (via Storybook)
- All 823 component tests pass with zero failures

## Breaking changes reviewed (v7 → v10)
- **v8**: Removed deprecated `waitForDOMChange` and `waitForElement`; `waitFor` timeout uses same clock as interval; `prettyDOM` ignores script/style/comment nodes by default — **not used directly**
- **v9**: `ByRole` only accepts `string`; removed `exact`/`trim`/`collapseWhitespace`/`normalizer` options from `ByRole` — **not used directly**
- **v10**: Minimum Node.js 18 (repo requires >=24.13); updated `aria-query` to 5.3.0 — **compatible**

## Test plan
- [x] `npm run test` — all 823 tests pass, 0 failures
- [x] Verified `@testing-library/user-event@14.6.1` peer dependency (`>=7.21.4`) is satisfied
- [x] Confirmed no direct imports of `@testing-library/dom` exist in source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)