### PR TITLE
fix(card): await nested element renders in card tests to prevent Webkit CI timeouts

### DIFF
--- a/packages/uui-card-block-type/lib/uui-card-block-type.test.ts
+++ b/packages/uui-card-block-type/lib/uui-card-block-type.test.ts
@@ -21,7 +21,9 @@ describe('UUICardBlockTypeElement', () => {
     `);
   });
 
-  it('passes the a11y audit', async () => {
+  // Increase timeout for a11y audit which can be slow on WebKit CI
+  it('passes the a11y audit', async function () {
+    this.timeout(4000);
     await expect(element).shadowDom.to.be.accessible();
   });
 

--- a/packages/uui-card-media/lib/uui-card-media.test.ts
+++ b/packages/uui-card-media/lib/uui-card-media.test.ts
@@ -18,6 +18,10 @@ describe('UUICardMediaElement', () => {
     element = await fixture(html`
       <uui-card-media name="Media item"></uui-card-media>
     `);
+
+    // Wait for nested uui-symbol-folder to fully render (avoids WebKit timeout on slow CI)
+    const symbol = element.shadowRoot!.querySelector('uui-symbol-folder');
+    if (symbol) await symbol.updateComplete;
   });
 
   it('is defined with its own instance', () => {

--- a/packages/uui-card-user/lib/uui-card-user.test.ts
+++ b/packages/uui-card-user/lib/uui-card-user.test.ts
@@ -20,6 +20,10 @@ describe('UUICardUserElement', () => {
     element = await fixture(html`
       <uui-card-user name="John Rabbit"></uui-card-user>
     `);
+
+    // Wait for nested uui-avatar to fully render (avoids WebKit timeout on slow CI)
+    const avatar = element.shadowRoot!.querySelector('uui-avatar');
+    if (avatar) await avatar.updateComplete;
   });
 
   it('passes the a11y audit', async () => {


### PR DESCRIPTION
## Summary
- In `uui-card-media` and `uui-card-user` tests, await the `updateComplete` promise of nested custom elements (`uui-symbol-folder`, `uui-avatar`) in `beforeEach` after `fixture()` creation. This matches the existing fix in `uui-card-content-node` that awaits `uui-icon`.
- For `uui-card-block-type` (which does not render nested custom elements), increase the a11y audit test timeout from 2s to 4s to accommodate slow WebKit CI runners.

## Root cause
The `fixture()` helper only awaits the host element's `updateComplete`, not nested custom elements rendered in its shadow DOM. On slow WebKit CI, nested elements like `<uui-symbol-folder>` and `<uui-avatar>` may not finish their initial render in time, causing the subsequent a11y audit or DOM queries to exceed the default 2000ms Mocha timeout.

## Test plan
- [x] `npm run test:coverage-for uui-card-block-type` -- all 16 tests pass
- [x] `npm run test:coverage-for uui-card-media` -- all 19 tests pass
- [x] `npm run test:coverage-for uui-card-user` -- all 15 tests pass
- [x] `npm run test:coverage-for uui-card-content-node` -- all 16 tests pass (unchanged, verified still passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)