### PR TITLE
feat(base)!: remove element-internals-polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "@web/test-runner-playwright": "0.11.1",
         "autoprefixer": "10.4.21",
         "chromatic": "15.1.0",
-        "element-internals-polyfill": "3.0.2",
         "esbuild": "0.27.2",
         "eslint": "10.0.0",
         "eslint-config-prettier": "10.1.8",
@@ -6810,11 +6809,6 @@
       "version": "1.5.255",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/element-internals-polyfill": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "@web/test-runner-playwright": "0.11.1",
     "autoprefixer": "10.4.21",
     "chromatic": "15.1.0",
-    "element-internals-polyfill": "3.0.2",
     "esbuild": "0.27.2",
     "eslint": "10.0.0",
     "eslint-config-prettier": "10.1.8",

--- a/packages/uui-base/lib/mixins/FormControlMixin.ts
+++ b/packages/uui-base/lib/mixins/FormControlMixin.ts
@@ -146,12 +146,7 @@ export const UUIFormControlMixin = <
     set value(newValue: ValueType | DefaultValueType) {
       const oldValue = this.#value;
       this.#value = newValue;
-      if (
-        'ElementInternals' in window &&
-        'setFormValue' in window.ElementInternals.prototype
-      ) {
-        this._internals.setFormValue((this.#value as any) ?? null);
-      }
+      this._internals.setFormValue((this.#value as any) ?? null);
       this.requestUpdate('value', oldValue);
     }
 

--- a/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
+++ b/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
@@ -28,15 +28,9 @@ export abstract class UUIBooleanInputElement extends UUIFormControlMixin(
   set value(newVal: string) {
     const oldValue = super.value;
     this._value = newVal;
-    if (
-      'ElementInternals' in window &&
-      //@ts-ignore
-      'setFormValue' in window.ElementInternals.prototype
-    ) {
-      this._internals.setFormValue(
-        this._checked && this.name !== '' ? this._value : null,
-      );
-    }
+    this._internals.setFormValue(
+      this._checked && this.name !== '' ? this._value : null,
+    );
 
     this.requestUpdate('value', oldValue);
   }

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -42,9 +42,6 @@ export default {
       </head>
       <body>
         <script type="module" src="${testFramework}"></script>
-        <script type="module">
-          import 'element-internals-polyfill';
-        </script>
       </body>
     </html>`,
 };


### PR DESCRIPTION
## Summary

- Removes the `element-internals-polyfill` devDependency from root package.json
- Removes the polyfill import from the test runner HTML template (web-test-runner.config.mjs)
- Removes runtime guards (`'ElementInternals' in window && 'setFormValue' in ...`) in FormControlMixin and uui-boolean-input that checked for polyfill presence before calling `setFormValue`

ElementInternals is now supported in all modern browsers (Chrome 77+, Firefox 98+, Safari 16.4+), making the polyfill unnecessary.

## BREAKING CHANGE

The `element-internals-polyfill` is no longer bundled or guarded for. Consumers targeting browsers without native ElementInternals support must provide their own polyfill.

## Test plan

- [ ] `npm run test` passes — form controls (input, checkbox, toggle, select, slider, range-slider, textarea, radio) still work correctly
- [ ] `npm run build` succeeds
- [ ] Verify form submission and validation still work in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)