### PR TITLE
fix(base): remove @ts-ignore for Popover API

### DIFF
--- a/packages/uui-base/lib/mixins/PopoverTargetMixin.ts
+++ b/packages/uui-base/lib/mixins/PopoverTargetMixin.ts
@@ -59,10 +59,8 @@ export const PopoverTargetMixin = <T extends Constructor<LitElement>>(
       if (!popoverContainerElement) return;
 
       if (this.#popoverIsOpen) {
-        // @ts-ignore - This is part of the new popover API, but typescript doesn't recognize it yet.
         popoverContainerElement.hidePopover();
       } else {
-        // @ts-ignore - This is part of the new popover API, but typescript doesn't recognize it yet.
         popoverContainerElement.showPopover();
       }
     };

--- a/packages/uui-popover-container/lib/uui-popover-container.element.ts
+++ b/packages/uui-popover-container/lib/uui-popover-container.element.ts
@@ -286,7 +286,6 @@ export class UUIPopoverContainerElement extends LitElement {
       left > screenWidth;
 
     if (isCompletelyOutsideScreen) {
-      // @ts-ignore - This is part of the new popover API, but typescript doesn't recognize it yet.
       this.hidePopover();
     }
 


### PR DESCRIPTION
## Summary

- Removes 3 `@ts-ignore` comments that suppressed TypeScript errors for the native Popover API methods (`showPopover`, `hidePopover`)
- TypeScript 5.2+ includes built-in types for the Popover API — these suppression comments are no longer needed (we're on TS 5.9)

### Files changed

- `packages/uui-base/lib/mixins/PopoverTargetMixin.ts` — 2 comments removed
- `packages/uui-popover-container/lib/uui-popover-container.element.ts` — 1 comment removed

## Test plan

- [x] Pre-commit `tsc-files` type-check passes (confirms TS recognizes the Popover API)
- [ ] `npm run build` succeeds
- [ ] `npm run test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)