### PR TITLE
fix(button): remove requestSubmit fallback

### DIFF
--- a/packages/uui-button/lib/uui-button.element.ts
+++ b/packages/uui-button/lib/uui-button.element.ts
@@ -186,11 +186,7 @@ export class UUIButtonElement extends UUIFormControlMixin(
         case 'button':
           break;
         default:
-          if (this._internals.form.requestSubmit) {
-            this._internals.form.requestSubmit();
-          } else {
-            this._internals.form.dispatchEvent(new SubmitEvent('submit'));
-          }
+          this._internals.form.requestSubmit();
           break;
       }
     }


### PR DESCRIPTION
## Summary

- Removes the `requestSubmit` feature-detection guard and the `SubmitEvent` dispatch fallback in uui-button
- `requestSubmit()` is supported in all modern browsers (Chrome 76+, Firefox 75+, Safari 16+), making the fallback dead code

## Test plan

- [ ] `npm run test:coverage-for uui-button` passes
- [ ] `npm run build` succeeds
- [ ] Form submission via uui-button still works in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)