### PR TITLE
feat!: replace --uui-show-focus-outline JS with :focus-visible CSS

### DIFF
--- a/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
+++ b/packages/uui-boolean-input/lib/uui-boolean-input.element.ts
@@ -130,30 +130,6 @@ export abstract class UUIBooleanInputElement extends UUIFormControlMixin(
     this.checked = this.hasAttribute('checked');
   }
 
-  protected firstUpdated(
-    _changedProperties: Map<string | number | symbol, unknown>,
-  ): void {
-    super.firstUpdated(_changedProperties);
-
-    const labelEl = this.shadowRoot?.querySelector('label') as HTMLLabelElement;
-
-    // hide outline if mouse-interaction:
-    let hadMouseDown = false;
-    this._input.addEventListener('blur', () => {
-      if (hadMouseDown === false) {
-        this.style.setProperty('--uui-show-focus-outline', '1');
-      }
-      hadMouseDown = false;
-    });
-    labelEl.addEventListener('mousedown', () => {
-      this.style.setProperty('--uui-show-focus-outline', '0');
-      hadMouseDown = true;
-    });
-    labelEl.addEventListener('mouseup', () => {
-      hadMouseDown = false;
-    });
-  }
-
   /**
    * This method enables <label for="..."> to focus the input
    */

--- a/packages/uui-checkbox/lib/uui-checkbox.element.ts
+++ b/packages/uui-checkbox/lib/uui-checkbox.element.ts
@@ -152,9 +152,8 @@ export class UUICheckboxElement extends UUIBooleanInputElement {
         background-color: var(--uui-color-selected-emphasis);
       }
 
-      input:focus + #ticker {
-        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
-          var(--uui-color-focus);
+      input:focus-visible + #ticker {
+        outline: 2px solid var(--uui-color-focus);
       }
 
       :host(:not([disabled], [readonly]))

--- a/packages/uui-select/lib/uui-select.element.ts
+++ b/packages/uui-select/lib/uui-select.element.ts
@@ -113,13 +113,6 @@ export class UUISelectElement extends UUIFormControlMixin(LitElement, '') {
 
   constructor() {
     super();
-
-    this.addEventListener('mousedown', () => {
-      this.style.setProperty('--uui-show-focus-outline', '0');
-    });
-    this.addEventListener('blur', () => {
-      this.style.setProperty('--uui-show-focus-outline', '');
-    });
   }
 
   /**
@@ -297,8 +290,8 @@ export class UUISelectElement extends UUIFormControlMixin(LitElement, '') {
         );
       }
 
-      #native:focus {
-        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+      #native:focus-visible {
+        outline: 2px solid
           var(--uui-select-outline-color, var(--uui-color-focus));
       }
 

--- a/packages/uui-slider/lib/uui-slider.element.ts
+++ b/packages/uui-slider/lib/uui-slider.element.ts
@@ -154,12 +154,6 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
 
   constructor() {
     super();
-    this.addEventListener('mousedown', () => {
-      this.style.setProperty('--uui-show-focus-outline', '0');
-    });
-    this.addEventListener('blur', () => {
-      this.style.setProperty('--uui-show-focus-outline', '');
-    });
     this.addEventListener('keydown', this.#onKeyDown);
   }
 
@@ -368,9 +362,8 @@ export class UUISliderElement extends UUIFormControlMixin(LitElement, '') {
         fill: var(--uui-color-border-emphasis);
       }
 
-      input:focus ~ #track #thumb {
-        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
-          var(--uui-color-focus);
+      input:focus-visible ~ #track #thumb {
+        outline: 2px solid var(--uui-color-focus);
       }
 
       .track-step {

--- a/packages/uui-textarea/lib/uui-textarea.element.ts
+++ b/packages/uui-textarea/lib/uui-textarea.element.ts
@@ -155,13 +155,6 @@ export class UUITextareaElement extends UUIFormControlMixin(LitElement, '') {
   constructor() {
     super();
 
-    this.addEventListener('mousedown', () => {
-      this.style.setProperty('--uui-show-focus-outline', '0');
-    });
-    this.addEventListener('blur', () => {
-      this.style.setProperty('--uui-show-focus-outline', '');
-    });
-
     this.addValidator(
       'tooShort',
       () => {
@@ -388,9 +381,8 @@ export class UUITextareaElement extends UUIFormControlMixin(LitElement, '') {
           var(--uui-color-border-emphasis)
         );
       }
-      textarea:focus {
-        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
-          var(--uui-color-focus);
+      textarea:focus-visible {
+        outline: 2px solid var(--uui-color-focus);
       }
     `,
   ];

--- a/packages/uui-toggle/lib/uui-toggle.element.ts
+++ b/packages/uui-toggle/lib/uui-toggle.element.ts
@@ -164,9 +164,8 @@ export class UUIToggleElement extends UUIBooleanInputElement {
         transform: translateX(-100%);
       }
 
-      input:focus ~ #toggle {
-        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
-          var(--uui-color-focus);
+      input:focus-visible ~ #toggle {
+        outline: 2px solid var(--uui-color-focus);
       }
 
       :host(:not([disabled], [readonly])) label:active #toggle::after {

--- a/src/components/input/uui-input.element.ts
+++ b/src/components/input/uui-input.element.ts
@@ -231,12 +231,6 @@ export class UUIInputElement extends UUIFormControlMixin(
   constructor() {
     super();
 
-    this.addEventListener('mousedown', () => {
-      this.style.setProperty('--uui-show-focus-outline', '0');
-    });
-    this.addEventListener('blur', () => {
-      this.style.setProperty('--uui-show-focus-outline', '');
-    });
     this.addEventListener('keydown', this.#onKeyDown);
 
     this.addValidator(
@@ -438,8 +432,7 @@ export class UUIInputElement extends UUIFormControlMixin(
           --uui-input-border-color-focus,
           var(--uui-color-border-emphasis)
         );
-        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
-          var(--uui-color-focus);
+        outline: 2px solid var(--uui-color-focus);
       }
       :host(:focus) {
         border-color: var(

--- a/src/components/table/uui-table-row.element.ts
+++ b/src/components/table/uui-table-row.element.ts
@@ -15,22 +15,6 @@ export class UUITableRowElement extends SelectOnlyMixin(
 ) {
   constructor() {
     super();
-
-    // hide outline if mouse-interaction:
-    let hadMouseDown = false;
-    this.addEventListener('blur', () => {
-      if (hadMouseDown === false) {
-        this.style.setProperty('--uui-show-focus-outline', '1');
-      }
-      hadMouseDown = false;
-    });
-    this.addEventListener('mousedown', () => {
-      this.style.setProperty('--uui-show-focus-outline', '0');
-      hadMouseDown = true;
-    });
-    this.addEventListener('mouseup', () => {
-      hadMouseDown = false;
-    });
   }
 
   connectedCallback() {
@@ -77,9 +61,8 @@ export class UUITableRowElement extends SelectOnlyMixin(
         cursor: pointer;
       }
 
-      :host(:focus) {
-        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
-          var(--uui-color-focus);
+      :host(:focus-visible) {
+        outline: 2px solid var(--uui-color-focus);
       }
       :host([selected]) {
         outline: 2px solid


### PR DESCRIPTION
## Summary

- Removes JS mousedown/blur/mouseup event listeners from 6 components that toggled the `--uui-show-focus-outline` CSS custom property to hide focus outlines on mouse interaction
- Replaces the `calc(2px * var(--uui-show-focus-outline, 1))` CSS pattern with `:focus-visible` and a simple `2px solid` outline
- The native `:focus-visible` pseudo-class achieves the same "keyboard-only focus ring" behavior without JavaScript

### Components changed

| Component | JS removed | CSS updated |
|-----------|-----------|-------------|
| uui-boolean-input | mousedown/blur/mouseup listeners + empty `firstUpdated` | — |
| uui-checkbox | — | `input:focus` → `input:focus-visible` |
| uui-toggle | — | `input:focus` → `input:focus-visible` |
| uui-input | mousedown/blur listeners | outline simplified |
| uui-select | mousedown/blur listeners | `#native:focus` → `#native:focus-visible` |
| uui-slider | mousedown/blur listeners | `input:focus` → `input:focus-visible` |
| uui-textarea | mousedown/blur listeners | `textarea:focus` → `textarea:focus-visible` |
| uui-table-row | mousedown/blur/mouseup listeners | `:host(:focus)` → `:host(:focus-visible)` |

## BREAKING CHANGE

The `--uui-show-focus-outline` CSS custom property is no longer used. Consumers who relied on it to control focus outline visibility should use `:focus-visible` in their styles instead.

## Test plan

- [ ] `npm run test` passes
- [ ] `npm run build` succeeds
- [ ] Verify in Storybook: keyboard Tab shows focus outlines, mouse click does not (for checkboxes, toggles, table rows, sliders)
- [ ] Verify text inputs/textarea/select show focus outline on all focus (standard behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)