### PR TITLE
fix: Incomplete string escaping or encoding

### DIFF
--- a/src/components/file-dropzone/file-dropzone.element.ts
+++ b/src/components/file-dropzone/file-dropzone.element.ts
@@ -257,7 +257,7 @@ export class UUIFileDropzoneElement extends LabelMixin('', LitElement) {
         return true;
       } else if (
         mimeType.endsWith('/*') &&
-        fileType.startsWith(mimeType.slice(0, -2))
+        fileType.startsWith(mimeType.slice(0, -1))
       ) {
         return true;
       }

--- a/src/components/file-dropzone/file-dropzone.test.ts
+++ b/src/components/file-dropzone/file-dropzone.test.ts
@@ -256,6 +256,30 @@ describe('UUIFileDropzoneElement', () => {
       }
     });
 
+    it('does not accept a MIME type that only shares a prefix with a wildcard category (e.g. image2/png should not match image/*)', async () => {
+      const dt = new DataTransfer();
+      if ('items' in dt) {
+        const file1 = new File([''], 'file1.png', { type: 'image2/png' });
+        dt.items.add(file1);
+
+        element.accept = 'image/*';
+
+        const pending = new Promise<void>(resolve => {
+          element.addEventListener('reject', e => {
+            const { files } = (e as UUIFileDropzoneEvent).detail;
+            expect(files.length).toBe(1);
+            expect(files[0].name).toBe('file1.png');
+            resolve();
+          });
+        });
+
+        innerElement.files = dt.files;
+        innerElement.dispatchEvent(new Event('change'));
+
+        await pending;
+      }
+    });
+
     it('does not emit reject event when multiple=false and an accepted file is found', async () => {
       const dt = new DataTransfer();
       if ('items' in dt) {


### PR DESCRIPTION
Potential fix for [https://github.com/umbraco/Umbraco.UI/security/code-scanning/11](https://github.com/umbraco/Umbraco.UI/security/code-scanning/11)

General approach: Avoid using `String.prototype.replace` with a plain string when the intent is to remove wildcard markers; either (a) use a regular expression with the `g` flag to remove all `*` characters, or (b) more explicitly strip the trailing `/*` since we already check `endsWith('/*')`. Both options fix the incomplete escaping/encoding pattern.

Best concrete fix here: Since we know `mimeType.endsWith('/*')` is true in this branch, the simplest and clearest behavior is to remove just the trailing `/*` and use the remaining prefix. Replace `mimeType.replace('*', '')` with `mimeType.slice(0, -2)`, which removes the last two characters (`/` and `*`). This:

- Avoids misuse of `replace`.
- Exactly matches the semantics implied by `endsWith('/*')`.
- Does not change existing functionality for valid MIME wildcards.
- Needs no new imports or helpers.

Change location: In `src/components/file-dropzone/file-dropzone.element.ts`, in method `_isAccepted`, within the `else if` block starting at line 258, change the `fileType.startsWith(mimeType.replace('*', ''))` expression to `fileType.startsWith(mimeType.slice(0, -2))`. No other lines need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
