### PR TITLE
fix(a11y): Add aria-hidden attribute to svg icon when creating a new element

### DIFF
--- a/src/components/button-inline-create/button-inline-create.element.ts
+++ b/src/components/button-inline-create/button-inline-create.element.ts
@@ -89,6 +89,7 @@ export class UUIButtonInlineCreateElement extends LitElement {
         })}>
         <svg
           id="plus-icon"
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 512 512">
           <path


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I've added the `aria-hidden` attribute to the plus icon inside the button that is used to create a new element.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

This fixed my own created issue in the Umbraco CMS repo https://github.com/umbraco/Umbraco-CMS/issues/21943

## How to test?
- Using a screen reader navigate to the part of the UI where you'll be able to add a new component to the page and listen for only the aria-label of the button being announced and the image being skipped.
- Inspect the button using the accessibility inspector (Firefox, Chrome) to check if the graphics element is no longer present. 

## Checklist
- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [] I have added tests to cover my changes.
