### PR TITLE
feat(storybook): add runtime theme switcher

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,12 +1,48 @@
+/// <reference types="vite/client" />
 import {
   setCustomElementsManifest,
   type Preview,
 } from '@storybook/web-components-vite';
-import '../src/themes/light.css';
+import lightCss from '../src/themes/light.css?inline';
+import darkCss from '../src/themes/dark.css?inline';
+import highContrastCss from '../src/themes/high-contrast.css?inline';
 import customElements from '../custom-elements.json';
 import { html } from 'lit';
 
 import '../src/components/icon-registry-essential/icon-registry-essential.js';
+
+const themes: Record<string, string> = {
+  light: lightCss,
+  dark: darkCss,
+  'high-contrast': highContrastCss,
+};
+
+let themeStyleEl: HTMLStyleElement | null = null;
+
+function applyTheme(theme: string) {
+  if (!themeStyleEl) {
+    themeStyleEl = document.createElement('style');
+    themeStyleEl.id = 'uui-theme';
+    document.head.appendChild(themeStyleEl);
+  }
+  themeStyleEl.textContent = themes[theme] ?? lightCss;
+}
+
+export const globalTypes = {
+  theme: {
+    name: 'Theme',
+    defaultValue: 'light',
+    toolbar: {
+      icon: 'paintbrush',
+      items: [
+        { value: 'light', title: 'Light' },
+        { value: 'dark', title: 'Dark' },
+        { value: 'high-contrast', title: 'High Contrast' },
+      ],
+      dynamicTitle: true,
+    },
+  },
+};
 
 const preview: Preview = {
   parameters: {
@@ -25,6 +61,10 @@ const preview: Preview = {
   tags: ['autodocs'],
 
   decorators: [
+    (story, context) => {
+      applyTheme(context.globals['theme'] ?? 'light');
+      return story();
+    },
     story => {
       return html`<uui-icon-registry-essential class="uui-font uui-text"
         >${story()}</uui-icon-registry-essential


### PR DESCRIPTION
## Summary

- Replaces the static `import '../src/themes/light.css'` with `?inline` imports for all three themes (light, dark, high-contrast)
- Adds a Storybook toolbar button (paintbrush icon) via `globalTypes` for switching themes at runtime — no page reload required
- Theme is applied by writing to a managed `<style id="uui-theme">` tag in `<head>` via a decorator that runs before each story renders
- Theme selection persists when navigating between stories (Storybook globals are session-scoped)

## Test Plan

- [ ] `npm run storybook` — toolbar shows paintbrush icon with Light / Dark / High Contrast items
- [ ] Switching to Dark applies dark CSS custom properties visually across all stories
- [ ] Switching to High Contrast applies high-contrast theme
- [ ] Switching back to Light reverts correctly
- [ ] No flash of unstyled content on initial load (light is applied synchronously via decorator before render)