### PR TITLE
fix(combobox): space key no longer triggers selection or opens dropdown

### DIFF
--- a/packages/uui-combobox-list/lib/uui-combobox-list.element.ts
+++ b/packages/uui-combobox-list/lib/uui-combobox-list.element.ts
@@ -239,14 +239,6 @@ export class UUIComboboxListElement extends LitElement {
         break;
       }
 
-      //Space key
-      case 'Space': {
-        e.preventDefault();
-        e.stopPropagation();
-        this._getActiveElement?.click();
-        break;
-      }
-
       case 'End': {
         e.preventDefault();
         this._goToIndex(this._options.length - 1);

--- a/packages/uui-combobox/lib/uui-combobox.element.ts
+++ b/packages/uui-combobox/lib/uui-combobox.element.ts
@@ -301,6 +301,7 @@ export class UUIComboboxElement extends UUIFormControlMixin(LitElement, '') {
     if (this.open === false && e.code === 'Enter') {
       e.preventDefault(); // TODO: could we avoid this.
       e.stopImmediatePropagation(); // TODO: could we avoid this.
+      this.#onOpen();
     }
 
     if (e.code === 'ArrowUp' || e.code === 'ArrowDown') {

--- a/packages/uui-combobox/lib/uui-combobox.element.ts
+++ b/packages/uui-combobox/lib/uui-combobox.element.ts
@@ -307,13 +307,6 @@ export class UUIComboboxElement extends UUIFormControlMixin(LitElement, '') {
       this.#onOpen();
     }
 
-    if (e.code === 'Space') {
-      if (this._isOpen) return;
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      this.#onOpen();
-    }
-
     if (e.code === 'Escape') {
       this.#onClose();
     }


### PR DESCRIPTION
## Description

Space was incorrectly treated as Enter in the combobox, making it impossible to search for multi-word terms. Removed Space as a selection key and as a dropdown trigger, use Arrow keys to open and Enter to select. 

Fixed: https://github.com/umbraco/Umbraco.UI/issues/1370
Target: v1