### PR TITLE
feat(breadcrumbs): make breadcrumb items without href interactive

### DIFF
--- a/packages/uui-breadcrumbs/lib/uui-breadcrumb-item.element.ts
+++ b/packages/uui-breadcrumbs/lib/uui-breadcrumb-item.element.ts
@@ -36,7 +36,7 @@ export class UUIBreadcrumbItemElement extends LitElement {
   renderLinkAndSeparator() {
     const item = this.href
       ? html`<a id="link" href=${this.href}><slot></slot></a>`
-      : html`<span id="link"><slot></slot></span>`;
+      : html`<a id="link" tabindex="0"><slot></slot></a>`;
 
     return html`${item}<span part="separator"></span>`;
   }
@@ -61,6 +61,7 @@ export class UUIBreadcrumbItemElement extends LitElement {
       a,
       a:visited {
         color: currentColor;
+        cursor: pointer;
       }
       a:hover {
         color: var(--uui-color-interactive-emphasis);

--- a/packages/uui-breadcrumbs/lib/uui-breadcrumb-item.element.ts
+++ b/packages/uui-breadcrumbs/lib/uui-breadcrumb-item.element.ts
@@ -33,10 +33,22 @@ export class UUIBreadcrumbItemElement extends LitElement {
   @property({ type: Boolean, attribute: 'last-item' })
   lastItem = false;
 
+  private _onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      (e.currentTarget as HTMLElement).click();
+    }
+  }
+
   renderLinkAndSeparator() {
     const item = this.href
       ? html`<a id="link" href=${this.href}><slot></slot></a>`
-      : html`<a id="link" tabindex="0"><slot></slot></a>`;
+      : html`<span
+          id="link"
+          tabindex="0"
+          role="link"
+          @keydown=${this._onKeydown}
+          ><slot></slot
+        ></span>`;
 
     return html`${item}<span part="separator"></span>`;
   }
@@ -59,18 +71,23 @@ export class UUIBreadcrumbItemElement extends LitElement {
       }
 
       a,
-      a:visited {
+      a:visited,
+      span#link {
         color: currentColor;
         cursor: pointer;
+        text-decoration: underline;
       }
-      a:hover {
+      a:hover,
+      span#link:hover {
         color: var(--uui-color-interactive-emphasis);
       }
-      a:focus {
+      a:focus,
+      span#link:focus {
         color: var(--uui-color-focus);
       }
 
-      a:focus-visible {
+      a:focus-visible,
+      span#link:focus-visible {
         border-radius: var(--uui-border-radius);
         outline: 2px solid var(--uui-color-focus);
       }

--- a/packages/uui-breadcrumbs/lib/uui-breadcrumbs.story.ts
+++ b/packages/uui-breadcrumbs/lib/uui-breadcrumbs.story.ts
@@ -30,3 +30,38 @@ export default meta;
 type Story = StoryObj;
 
 export const Default: Story = {};
+
+export const ClickRouting: Story = {
+  render: () => html`
+    <uui-breadcrumbs>
+      <uui-breadcrumb-item @click=${() => alert('Home')}
+        >Home</uui-breadcrumb-item
+      >
+      <uui-breadcrumb-item @click=${() => alert('Category')}
+        >Category</uui-breadcrumb-item
+      >
+      <uui-breadcrumb-item @click=${() => alert('Subcategory')}
+        >Subcategory</uui-breadcrumb-item
+      >
+      <uui-breadcrumb-item @click=${() => alert('Section')}
+        >Section</uui-breadcrumb-item
+      >
+      <uui-breadcrumb-item @click=${() => alert('Subsection')}
+        >Subsection</uui-breadcrumb-item
+      >
+      <uui-breadcrumb-item @click=${() => alert('Topic')}
+        >Topic</uui-breadcrumb-item
+      >
+      <uui-breadcrumb-item @click=${() => alert('Subtopic')}
+        >Subtopic</uui-breadcrumb-item
+      >
+      <uui-breadcrumb-item @click=${() => alert('Article')}
+        >Article</uui-breadcrumb-item
+      >
+      <uui-breadcrumb-item @click=${() => alert('Detail')}
+        >Detail</uui-breadcrumb-item
+      >
+      <uui-breadcrumb-item>Current</uui-breadcrumb-item>
+    </uui-breadcrumbs>
+  `,
+};


### PR DESCRIPTION
## Summary
`uui-breadcrumb-item` now makes the `<span>` interactive when no href is provided and the item is not the last item. It gets `tabindex="0"`, `role="link"`, an Enter key handler, and link styling (underline, pointer cursor, hover/focus colors). This made it impossible to support client-side routing without sacrificing accessibility.

 ## Behaviour                                                                                                                                                             
                  
  - With href — renders `<a href="...">`  as before, no change                                                                                                             
  - Without href — renders an interactive <span role="link" tabindex="0"> that fires click on Enter, so consumers can handle routing via a click listener
  - Last item — still renders as an inert <span> (current page, not navigable)