### PR TITLE
V2.0: pagination and table styling

### DIFF
--- a/src/components/pagination/pagination.element.ts
+++ b/src/components/pagination/pagination.element.ts
@@ -348,6 +348,7 @@ export class UUIPaginationElement extends LitElement {
       }
       uui-button-group {
         flex-grow: 1;
+        justify-content: center;
       }
 
       uui-button-group uui-button {

--- a/src/components/table/table-row.element.ts
+++ b/src/components/table/table-row.element.ts
@@ -50,8 +50,8 @@ export class UUITableRowElement extends SelectOnlyMixin(
       :host {
         display: table-row;
         position: relative;
-        outline-offset: -3px;
-        border-radius: var(--uui-border-radius);
+        outline-offset: -4px;
+        border-radius: var(--uui-border-radius-3);
       }
 
       :host([selectable]) {

--- a/src/components/table/table.element.ts
+++ b/src/components/table/table.element.ts
@@ -23,8 +23,8 @@ export class UUITableElement extends LitElement {
         display: table;
         width: 100%;
         background-color: var(--uui-color-surface);
-        cursor: default;
 
+        overflow: clip;
         border-radius: var(--uui-border-radius-3);
         border-width: var(--uui-box-border-width, 1px);
         border-style: solid;


### PR DESCRIPTION
Should target v.2.0 so it takes part in the final build.

Adjusting how pagination scales and a few details on tables to make it all look nice( Header gets the right border radius and selection is rounded accordingly)

<img width="1675" height="527" alt="image" src="https://github.com/user-attachments/assets/e2fcc9d6-c198-4201-8e45-5182ca004ba1" />
