### PR TITLE
UUITabGroup: Prevent active tab switching when ctrl clicking on a tab with a href

### DIFF
--- a/src/components/tabs/tab-group.element.ts
+++ b/src/components/tabs/tab-group.element.ts
@@ -117,6 +117,13 @@ export class UUITabGroupElement extends LitElement {
 
   readonly #onTabClicked = (e: MouseEvent) => {
     const selectedElement = e.currentTarget as HTMLElement;
+
+    // Don't switch active tabs when a href is being opened in a new browser tab
+    const isCtrlClick = e.ctrlKey || e.metaKey;
+    if (this.#isElementHrefLike(selectedElement) && isCtrlClick) {
+      return;
+    }
+
     if (this.#isElementTabLike(selectedElement)) {
       selectedElement.active = true;
       const linkedElement = this.#hiddenTabElementsMap.get(selectedElement);
@@ -260,6 +267,15 @@ export class UUITabGroupElement extends LitElement {
   #isElementTabLike(el: any): el is UUITabElement {
     return (
       typeof el === 'object' && 'active' in el && typeof el.active === 'boolean'
+    );
+  }
+
+  #isElementHrefLike(el: any): el is UUITabElement {
+    return (
+      typeof el === 'object' &&
+      'href' in el &&
+      typeof el.href === 'string' &&
+      el.href
     );
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe the changes in detail -->
When a tab has a href value and is Ctrl clicked, the expected behaviour is to open the href target in a new browser tab. Currently, the logic for setting this tab as active still runs. This PR prevents this logic running when the tab has a href and is ctrl clicked.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This is currently an issue in UmbracoCMS main backoffice header, referenced here: https://github.com/umbraco/Umbraco-CMS/issues/21040 

If a tab has a href value, then it should be treated as a link and active state remain unaffected.

## How to test?
Run the umbraco UI storybook. Ctrl click on tabs with and without href values. Tabs without a href should be unaffected, tabs with a href should have the new behaviour.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
