### PR TITLE
Ensure prepend and append in input is rounded

### DIFF
--- a/src/components/input/input.element.ts
+++ b/src/components/input/input.element.ts
@@ -393,6 +393,7 @@ export class UUIInputElement extends UUIFormControlWithBasicsMixin(
           var(--uui-input-border-color, var(--uui-color-border));
         border-radius: var(--uui-input-border-radius, var(--uui-border-radius));
         min-width: 0;
+        overflow: hidden;
 
         --uui-input-padding: 1px var(--uui-size-space-3) 3px
           var(--uui-size-space-3);

--- a/src/components/input/input.element.ts
+++ b/src/components/input/input.element.ts
@@ -395,7 +395,8 @@ export class UUIInputElement extends UUIFormControlWithBasicsMixin(
         min-width: 0;
         overflow: hidden;
 
-        --uui-input-padding: var(--uui-size-space-1) var(--uui-size-space-3);
+        --uui-input-padding: var(--uui-size-space-1) var(--uui-size-space-3)
+          var(--uui-size-space-2) var(--uui-size-space-3);
         --uui-button-height: 100%;
         --uui-button-border-radius: var(
           --uui-input-border-radius,

--- a/src/components/input/input.element.ts
+++ b/src/components/input/input.element.ts
@@ -395,8 +395,7 @@ export class UUIInputElement extends UUIFormControlWithBasicsMixin(
         min-width: 0;
         overflow: hidden;
 
-        --uui-input-padding: 1px var(--uui-size-space-3) 3px
-          var(--uui-size-space-3);
+        --uui-input-padding: var(--uui-size-space-1) var(--uui-size-space-3);
         --uui-button-height: 100%;
         --uui-button-border-radius: var(
           --uui-input-border-radius,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe the changes in detail -->
The new styling we more rounding cause issues with different component, e.g. with prepend/append:
https://uui.umbraco.com/?path=/story/uui-input--prepend-and-append

Also not sure why the input need to have a different top/bottom padding, which in general don't align label in center of input.

**Before**

<img width="333" height="60" alt="image" src="https://github.com/user-attachments/assets/fcb689fa-87e0-4f6b-9876-67110c34c1d4" />


**After**

<img width="337" height="57" alt="image" src="https://github.com/user-attachments/assets/992e8911-9a1e-464d-a445-15f9efb88bb5" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
