### PR TITLE
fix(tab-group): forward clicks from collapsed hidden tabs to originals and reflect href on clones

### DIFF
--- a/packages/uui-tabs/lib/uui-tab-group.element.ts
+++ b/packages/uui-tabs/lib/uui-tab-group.element.ts
@@ -120,6 +120,21 @@ export class UUITabGroupElement extends LitElement {
 
   #onTabClicked = (e: MouseEvent) => {
     const selectedElement = e.currentTarget as HTMLElement;
+
+    // If hidden, forward to the original — external listeners fire there
+    if (
+      selectedElement.classList.contains('hidden-tab') &&
+      this.#isElementTabLike(selectedElement)
+    ) {
+      const original = this.#hiddenTabElementsMap.get(selectedElement);
+      if (original) {
+        original.click();
+        this._moreButtonElement.classList.add('active-inside');
+        this._popoverContainerElement.hidePopover();
+      }
+      return;
+    }
+
     if (this.#isElementTabLike(selectedElement)) {
       selectedElement.active = true;
       const linkedElement = this.#hiddenTabElementsMap.get(selectedElement);

--- a/packages/uui-tabs/lib/uui-tab.element.ts
+++ b/packages/uui-tabs/lib/uui-tab.element.ts
@@ -34,7 +34,7 @@ export class UUITabElement extends ActiveMixin(LabelMixin('', LitElement)) {
    * @attr
    * @default undefined
    */
-  @property({ type: String })
+  @property({ type: String, reflect: true })
   public href?: string;
 
   /**
@@ -43,7 +43,7 @@ export class UUITabElement extends ActiveMixin(LabelMixin('', LitElement)) {
    * @attr
    * @default undefined
    */
-  @property({ type: String })
+  @property({ type: String, reflect: true })
   public target?: '_blank' | '_parent' | '_self' | '_top';
 
   /**
@@ -52,7 +52,7 @@ export class UUITabElement extends ActiveMixin(LabelMixin('', LitElement)) {
    * @attr
    * @default undefined
    */
-  @property({ type: String })
+  @property({ type: String, reflect: true })
   public rel?: string;
 
   /**

--- a/packages/uui-tabs/lib/uui-tabs.story.ts
+++ b/packages/uui-tabs/lib/uui-tabs.story.ts
@@ -245,3 +245,43 @@ export const RightAlign: Story = {
     </div>
   `,
 };
+
+export const CollapsedTabClickForwarding: Story = {
+  render: () => {
+    const updateLog = (msg: string) => {
+      const el = document.getElementById('proxy-log');
+      if (el) el.textContent = msg;
+    };
+
+    requestAnimationFrame(() => {
+      document
+        .querySelectorAll<HTMLElement>('#proxy-demo uui-tab')
+        .forEach(tab => {
+          tab.addEventListener('click', () => {
+            updateLog(`Original tab clicked: "${tab.getAttribute('label')}"`);
+          });
+        });
+    });
+
+    return html`
+      <div
+        id="proxy-demo"
+        style="max-width: 250px; display: flex; flex-direction: column; gap: 8px;">
+        <uui-tab-group>
+          <uui-tab label="Content">Content</uui-tab>
+          <uui-tab label="Packages">Packages</uui-tab>
+          <uui-tab label="Media">Media</uui-tab>
+          <uui-tab label="Settings">Settings</uui-tab>
+          <uui-tab label="Translations">Translations</uui-tab>
+          <uui-tab label="Users">Users</uui-tab>
+        </uui-tab-group>
+        <p
+          id="proxy-log"
+          style="font-size: 0.875rem; color: var(--uui-color-text-alt); margin: 0">
+          Click a tab from the "more" dropdown — the log here confirms the click
+          reached the original (hidden) tab element.
+        </p>
+      </div>
+    `;
+  },
+};


### PR DESCRIPTION
  ## Problem                                                                                                                          
  When tabs collapse into the dropdown, proxies are created with `cloneNode(true)`. This misses JS-set properties (e.g. `href` set via Lit binding) and programmatic event listeners, so clicking a collapsed tab did nothing in the backoffice.
                                          
  ## Fix                                                                                                                              
  - Forward proxy clicks to the original element so external listeners fire                                                           
  - Add `reflect: true` to `href`, `target`, `rel` on `uui-tab` so clones get the attribute                                           
  - Close the popover when a collapsed tab is selected           