### PR TITLE
fix(popover-container): follow trigger when slotted into shadow-root scroll containers

### DIFF
--- a/packages/uui-popover-container/lib/uui-popover-container-nestedslottester.element.ts
+++ b/packages/uui-popover-container/lib/uui-popover-container-nestedslottester.element.ts
@@ -1,0 +1,89 @@
+import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
+import { css, html, LitElement } from 'lit';
+
+/**
+ * Outermost scroll level — blue outline.
+ * @element uui-popover-container-scroll-level-1
+ */
+@defineElement('uui-popover-container-scroll-level-1')
+export class UUIPopoverContainerScrollLevel1Element extends LitElement {
+  render() {
+    return html`
+      <div class="scroll-host">
+        <div class="spacer"></div>
+        <slot></slot>
+        <div class="spacer"></div>
+      </div>
+    `;
+  }
+
+  static styles = css`
+    .scroll-host {
+      height: 200px;
+      overflow: auto;
+      outline: 2px dashed royalblue;
+      width: 320px;
+    }
+    .spacer {
+      height: 140px;
+    }
+  `;
+}
+
+/**
+ * Middle scroll level — orange outline.
+ * @element uui-popover-container-scroll-level-2
+ */
+@defineElement('uui-popover-container-scroll-level-2')
+export class UUIPopoverContainerScrollLevel2Element extends LitElement {
+  render() {
+    return html`
+      <div class="scroll-host">
+        <div class="spacer"></div>
+        <slot></slot>
+        <div class="spacer"></div>
+      </div>
+    `;
+  }
+
+  static styles = css`
+    .scroll-host {
+      height: 180px;
+      overflow: auto;
+      outline: 2px dashed darkorange;
+      width: 290px;
+    }
+    .spacer {
+      height: 120px;
+    }
+  `;
+}
+
+/**
+ * Innermost scroll level — green outline.
+ * @element uui-popover-container-scroll-level-3
+ */
+@defineElement('uui-popover-container-scroll-level-3')
+export class UUIPopoverContainerScrollLevel3Element extends LitElement {
+  render() {
+    return html`
+      <div class="scroll-host">
+        <div class="spacer"></div>
+        <slot></slot>
+        <div class="spacer"></div>
+      </div>
+    `;
+  }
+
+  static styles = css`
+    .scroll-host {
+      height: 160px;
+      overflow: auto;
+      outline: 2px dashed green;
+      width: 260px;
+    }
+    .spacer {
+      height: 100px;
+    }
+  `;
+}

--- a/packages/uui-popover-container/lib/uui-popover-container.element.ts
+++ b/packages/uui-popover-container/lib/uui-popover-container.element.ts
@@ -410,6 +410,9 @@ export class UUIPopoverContainerElement extends LitElement {
   }
 
   #getAncestorElement(el: HTMLElement | null): HTMLElement | null {
+    if (el?.assignedSlot) {
+      return el.assignedSlot;
+    }
     if (el?.parentElement) {
       return el.parentElement;
     }

--- a/packages/uui-popover-container/lib/uui-popover-container.story.ts
+++ b/packages/uui-popover-container/lib/uui-popover-container.story.ts
@@ -6,6 +6,7 @@ import { html } from 'lit';
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
 import { UUIPopoverContainerElement } from '.';
 import './uui-popover-container-shadowdomtester.element.js';
+import './uui-popover-container-nestedslottester.element.js';
 
 const meta: Meta<UUIPopoverContainerElement> = {
   id: 'uui-popover-container',
@@ -191,6 +192,43 @@ export const InsideShadowDOMScrollContainer: Story = {
       </div>
       <div style="height: 400px"></div>
     </div>
+  `,
+};
+
+export const DeeplyNestedSlottedScrollContainers: Story = {
+  args: {
+    placement: 'bottom-start',
+    margin: 0,
+  },
+  render: args => html`
+    <p style="max-width: 420px; font-size: 0.9rem; margin-bottom: 1rem;">
+      Each box (blue → orange → green) is a separate component with a scroll
+      container in its shadow root. Open the popover, then scroll any box — the
+      popover should follow the button.
+    </p>
+    <uui-popover-container-scroll-level-1>
+      <uui-popover-container-scroll-level-2>
+        <uui-popover-container-scroll-level-3>
+          <uui-button
+            popovertarget="popover-container-nested"
+            look="primary"
+            label="Open popover">
+            Open popover
+          </uui-button>
+          <uui-popover-container
+            id="popover-container-nested"
+            popover
+            placement=${args.placement}
+            margin=${args.margin}>
+            <div
+              style="background-color: var(--uui-color-surface); max-width: 200px; box-shadow: var(--uui-shadow-depth-4); padding: var(--uui-size-space-4); border-radius: var(--uui-border-radius); font-size: 0.9rem;">
+              Scroll the blue, orange, or green box — the popover should stay
+              anchored to the button.
+            </div>
+          </uui-popover-container>
+        </uui-popover-container-scroll-level-3>
+      </uui-popover-container-scroll-level-2>
+    </uui-popover-container-scroll-level-1>
   `,
 };
 

--- a/packages/uui-popover-container/lib/uui-popover-container.test.ts
+++ b/packages/uui-popover-container/lib/uui-popover-container.test.ts
@@ -74,7 +74,7 @@ describe('UUIPopoverContainerElement', () => {
       const scrollParents = popover._getScrollParents();
 
       // Should find all scroll containers
-      expect(scrollParents.length).to.be.equal(3); // outer-scroll, inner-scroll, document.body
+      expect(scrollParents.length).to.be.equal(4); // inner-scroll, scrollable-div, outer-scroll, document.body
 
       // Should include the document.body as the last element
       expect(scrollParents[scrollParents.length - 1]).to.equal(document.body);

--- a/packages/uui-popover-container/tsconfig.json
+++ b/packages/uui-popover-container/tsconfig.json
@@ -12,6 +12,9 @@
   "references": [
     {
       "path": "../uui-base"
+    },
+    {
+      "path": "../uui-scroll-container"
     }
   ]
 }


### PR DESCRIPTION
Closes #1388
                            
  ## Problem                                                                                                                             
                                                                                                                                      
  When a trigger button is slotted into a host component whose shadow root contains a scroll container, the popover does not reposition on scroll. calculateScrollParents walks the parentElement chain from the trigger. In slot composition, parentElement jumps directly to the host element, never entering its shadow root, so the scroll container is never found and no scroll listener is attached.

 ## Fix                                                                                                                                 
   
  In #getAncestorElement, check assignedSlot before parentElement. Returning the <slot> element instead of the host enters the shadow root, allowing the traversal to find the scroll container normally.

```
  #getAncestorElement(el: HTMLElement | null): HTMLElement | null {                                                                   
    if (el?.assignedSlot) {
      return el.assignedSlot;                                                                                                         
    }                                         
    if (el?.parentElement) {              
      return el.parentElement;
    }                                                                                                                                 
    return (el?.getRootNode() as any)?.host;
  }    
```                                                                                                                               
 ## Testing
   Open the DeeplyNestedSlottedScrollContainers story in Storybook. Three nested components (blue → orange → green) each have a scroll container in their shadow root. Open the popover and scroll any box, it should stay anchored to the button.                        
                  
  To verify the fix is what makes it work, remove the assignedSlot check from #getAncestorElement and repeat, the popover will stay in the wrong position regardless of which box you scroll.                 
