### PR TITLE
feat(card): add icon slot, has-children state and double-click support

### DIFF
--- a/packages/uui-card-content-node/lib/uui-card-content-node.element.ts
+++ b/packages/uui-card-content-node/lib/uui-card-content-node.element.ts
@@ -4,6 +4,7 @@ import { UUICardElement } from '@umbraco-ui/uui-card/lib';
 import { css, html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import '@umbraco-ui/uui-symbol-expand/lib';
 
 /**
  *  @element uui-card-content-node
@@ -70,6 +71,11 @@ export class UUICardContentNodeElement extends UUICardElement {
     return html`
       <span id="content" class="uui-text">
         <span id="item">
+          ${this.hasChildren
+            ? html`<uui-symbol-expand
+                id="children-indicator"
+                aria-hidden="true"></uui-symbol-expand>`
+            : nothing}
           <span id="icon">
             <slot name="icon" @slotchange=${this._onSlotIconChange}></slot>
             ${this._iconSlotHasContent === false
@@ -203,7 +209,14 @@ export class UUICardContentNodeElement extends UUICardElement {
 
       #icon {
         font-size: 1.2em;
-        margin-right: var(--uui-size-1);
+        margin-right: var(--uui-size-2);
+        transition: opacity 120ms;
+      }
+
+      :host([selectable]:not([has-children]):hover) #icon,
+      :host([selectable]:not([has-children]):focus-within) #icon,
+      :host([selectable]:not([has-children])[selected]) #icon {
+        opacity: 0;
       }
 
       :host([selectable]) #open-part {
@@ -232,6 +245,12 @@ export class UUICardContentNodeElement extends UUICardElement {
       #select-checkbox {
         top: var(--uui-size-5);
         left: var(--uui-size-6);
+      }
+
+      #children-indicator {
+        opacity: 0.5;
+        flex-shrink: 0;
+        margin-right: var(--uui-size-space-2);
       }
     `,
   ];

--- a/packages/uui-card-content-node/lib/uui-card-content-node.story.ts
+++ b/packages/uui-card-content-node/lib/uui-card-content-node.story.ts
@@ -89,3 +89,11 @@ export const OnlySelectable: Story = {
     selectOnly: true,
   },
 };
+
+export const WithChildrenAndIcon: Story = {
+  args: {
+    hasChildren: true,
+    selectable: true,
+    'icon slot': html`<uui-icon slot="icon" name="wand"></uui-icon>`,
+  },
+};

--- a/packages/uui-card-media/lib/uui-card-media.element.ts
+++ b/packages/uui-card-media/lib/uui-card-media.element.ts
@@ -228,12 +228,8 @@ export class UUICardMediaElement extends UUICardElement {
         opacity: 0.5;
         flex-shrink: 0;
         margin-left: calc(
-          (var(--uui-size-space-1) - var(--uui-size-space-2)) * -1
+          (var(--uui-size-space-1) - var(--uui-size-space-1)) * -1
         );
-      }
-
-      slot[name='icon'] {
-        padding-left: 0;
       }
 
       :host([image]:not([image=''])) #open-part {
@@ -266,7 +262,7 @@ export class UUICardMediaElement extends UUICardElement {
 
       #icon {
         display: inline-flex;
-        margin-right: var(--uui-size-2);
+        margin-right: var(--uui-size-1);
       }
 
       #detail {

--- a/packages/uui-card-media/lib/uui-card-media.element.ts
+++ b/packages/uui-card-media/lib/uui-card-media.element.ts
@@ -4,6 +4,7 @@ import { UUICardElement } from '@umbraco-ui/uui-card/lib';
 import { css, html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import '@umbraco-ui/uui-symbol-expand/lib';
 
 /**
  *  @element uui-card-media
@@ -11,6 +12,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
  *  @slot tag - slot for the tag with support for `<uui-tag>` elements
  *  @slot actions - slot for the actions with support for the `<uui-action-bar>` element
  *  @slot - slot for the default content area
+ *  @slot icon - slot for the icon with support for `<uui-icon>` elements
  */
 @defineElement('uui-card-media')
 export class UUICardMediaElement extends UUICardElement {
@@ -40,6 +42,14 @@ export class UUICardMediaElement extends UUICardElement {
    */
   @property({ type: String, attribute: 'file-ext' })
   fileExt = '';
+
+  @state()
+  private _iconSlotHasContent = false;
+
+  private _iconSlotChanged = (e: Event): void => {
+    this._iconSlotHasContent =
+      (e.target as HTMLSlotElement).assignedNodes({ flatten: true }).length > 0;
+  };
 
   @state()
   protected hasPreview = false;
@@ -101,10 +111,19 @@ export class UUICardMediaElement extends UUICardElement {
   #renderContent() {
     return html`
       <div id="content" class="uui-text">
-        <!--
-        TODO: Implement info box when pop-out is ready
-        -->
-        <span id="name" title="${this.name}">${this.name}</span>
+        <span id="name" title="${this.name}">
+          <slot
+            name="icon"
+            id="icon"
+            style=${this._iconSlotHasContent ? '' : 'display: none;'}
+            @slotchange=${this._iconSlotChanged}></slot
+          ><span class="label">${this.name}</span>
+          ${this.hasChildren
+            ? html`<uui-symbol-expand
+                id="children-indicator"
+                aria-hidden="true"></uui-symbol-expand>`
+            : nothing}
+        </span>
         <small id="detail">${this.detail}<slot name="detail"></slot></small>
       </div>
     `;
@@ -190,12 +209,24 @@ export class UUICardMediaElement extends UUICardElement {
       }
 
       #open-part #name {
+        display: flex;
+        align-items: center;
+        gap: var(--uui-size-space-1);
+      }
+
+      #open-part #name .label {
         display: -webkit-box;
         -webkit-line-clamp: 1;
         -webkit-box-orient: vertical;
         overflow: hidden;
         text-overflow: ellipsis;
         overflow-wrap: anywhere;
+      }
+
+      #children-indicator {
+        margin-left: auto;
+        opacity: 0.5;
+        flex-shrink: 0;
       }
 
       :host([image]:not([image=''])) #open-part {
@@ -226,6 +257,11 @@ export class UUICardMediaElement extends UUICardElement {
         opacity: 0.96;
       }
 
+      #icon {
+        display: inline-flex;
+        margin-right: var(--uui-size-2);
+      }
+
       #detail {
         opacity: 0.6;
       }
@@ -253,6 +289,14 @@ export class UUICardMediaElement extends UUICardElement {
         inset: calc(var(--uui-size-space-3) * -1)
           calc(var(--uui-size-space-4) * -1);
         top: 0;
+      }
+
+      :host([active]) {
+        background-color: var(--uui-color-surface);
+      }
+
+      :host([active]) #content::before {
+        background-color: var(--uui-color-current);
       }
 
       /*

--- a/packages/uui-card-media/lib/uui-card-media.element.ts
+++ b/packages/uui-card-media/lib/uui-card-media.element.ts
@@ -87,6 +87,7 @@ export class UUICardMediaElement extends UUICardElement {
         id="open-part"
         tabindex=${ifDefined(tabIndex)}
         @click=${this.handleOpenClick}
+        @dblclick=${this.handleOpenDblClick}
         @keydown=${this.handleOpenKeydown}>
         ${this.#renderContent()}
       </button>
@@ -112,17 +113,17 @@ export class UUICardMediaElement extends UUICardElement {
     return html`
       <div id="content" class="uui-text">
         <span id="name" title="${this.name}">
+          ${this.hasChildren
+            ? html`<uui-symbol-expand
+                id="children-indicator"
+                aria-hidden="true"></uui-symbol-expand>`
+            : nothing}
           <slot
             name="icon"
             id="icon"
             style=${this._iconSlotHasContent ? '' : 'display: none;'}
             @slotchange=${this._iconSlotChanged}></slot
           ><span class="label">${this.name}</span>
-          ${this.hasChildren
-            ? html`<uui-symbol-expand
-                id="children-indicator"
-                aria-hidden="true"></uui-symbol-expand>`
-            : nothing}
         </span>
         <small id="detail">${this.detail}<slot name="detail"></slot></small>
       </div>
@@ -224,9 +225,15 @@ export class UUICardMediaElement extends UUICardElement {
       }
 
       #children-indicator {
-        margin-left: auto;
         opacity: 0.5;
         flex-shrink: 0;
+        margin-left: calc(
+          (var(--uui-size-space-1) - var(--uui-size-space-2)) * -1
+        );
+      }
+
+      slot[name='icon'] {
+        padding-left: 0;
       }
 
       :host([image]:not([image=''])) #open-part {
@@ -297,6 +304,7 @@ export class UUICardMediaElement extends UUICardElement {
 
       :host([active]) #content::before {
         background-color: var(--uui-color-current);
+        bottom: -1px;
       }
 
       /*

--- a/packages/uui-card-media/lib/uui-card-media.story.ts
+++ b/packages/uui-card-media/lib/uui-card-media.story.ts
@@ -7,6 +7,7 @@ import '@umbraco-ui/uui-symbol-folder/lib/index';
 import { html } from 'lit';
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
 import { spread, renderSlots } from '../../../storyhelpers';
+import '@umbraco-ui/uui-icon/lib/index';
 
 /**
  * For more styling options see the [base card](/docs/uui-card--docs) component.
@@ -104,4 +105,12 @@ export const OnlySelectable: Story = {
     selectable: true,
     selectOnly: true,
   },
+};
+
+export const WithIconActiveAndChildren: Story = {
+  render: () => html`
+    <uui-card-media name="The card" file-ext="jpg" active has-children>
+      <uui-icon slot="icon" name="picture"></uui-icon>
+    </uui-card-media>
+  `,
 };

--- a/packages/uui-card/lib/uui-card.element.ts
+++ b/packages/uui-card/lib/uui-card.element.ts
@@ -95,6 +95,12 @@ export class UUICardElement extends SelectOnlyMixin(
     this.dispatchEvent(new UUICardEvent(UUICardEvent.OPEN));
   }
 
+  protected handleOpenDblClick(e: Event) {
+    if (this.disabled) return;
+    e.stopPropagation();
+    this.dispatchEvent(new UUICardEvent(UUICardEvent.OPEN));
+  }
+
   protected renderCheckbox() {
     if (!this.selectable) return;
     return html`

--- a/packages/uui-card/lib/uui-card.element.ts
+++ b/packages/uui-card/lib/uui-card.element.ts
@@ -4,7 +4,7 @@ import {
 } from '@umbraco-ui/uui-base/lib/mixins';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
-import { css, html, LitElement, nothing } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
 
 import { UUICardEvent } from './UUICardEvent';
@@ -117,13 +117,8 @@ export class UUICardElement extends SelectOnlyMixin(
 
   protected render() {
     return html`
-      <slot name="icon"></slot> <slot id="open-part"></slot>
+      <slot id="open-part"></slot>
       <div id="select-border"></div>
-      ${this.hasChildren
-        ? html`<uui-symbol-expand
-            id="children-indicator"
-            aria-hidden="true"></uui-symbol-expand>`
-        : nothing}
     `;
   }
 
@@ -292,18 +287,6 @@ export class UUICardElement extends SelectOnlyMixin(
         opacity: 1;
       }
 
-      #children-indicator {
-        margin-left: auto;
-        align-self: center;
-        opacity: 0.5;
-        padding-right: var(--uui-size-space-3);
-      }
-
-      slot[name='icon'] {
-        display: flex;
-        align-items: center;
-        padding-left: var(--uui-size-space-4);
-      }
       :host([active]) {
         background-color: var(--uui-color-current, #f5c1bc);
       }

--- a/packages/uui-card/lib/uui-card.element.ts
+++ b/packages/uui-card/lib/uui-card.element.ts
@@ -4,12 +4,13 @@ import {
 } from '@umbraco-ui/uui-base/lib/mixins';
 import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
 
 import { UUICardEvent } from './UUICardEvent';
 
 import '@umbraco-ui/uui-checkbox/lib';
+import '@umbraco-ui/uui-symbol-expand/lib';
 
 /**
  *  Card is a Component that provides the basics for a Card component. This can be extended in code to match a certain need.
@@ -68,6 +69,15 @@ export class UUICardElement extends SelectOnlyMixin(
   @property({ type: String })
   public rel?: string;
 
+  /**
+   * Set to true to indicate this item has children.
+   * @type {boolean}
+   * @attr has-children
+   * @default false
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'has-children' })
+  hasChildren = false;
+
   // This is deprecated - use href instead
   protected handleOpenClick(e: Event) {
     if (this.disabled) return;
@@ -100,8 +110,15 @@ export class UUICardElement extends SelectOnlyMixin(
   }
 
   protected render() {
-    return html`<slot id="open-part"></slot>
-      <div id="select-border"></div>`;
+    return html`
+      <slot name="icon"></slot> <slot id="open-part"></slot>
+      <div id="select-border"></div>
+      ${this.hasChildren
+        ? html`<uui-symbol-expand
+            id="children-indicator"
+            aria-hidden="true"></uui-symbol-expand>`
+        : nothing}
+    `;
   }
 
   static styles = [
@@ -267,6 +284,22 @@ export class UUICardElement extends SelectOnlyMixin(
       :host(:hover) #select-checkbox,
       #select-checkbox[checked] {
         opacity: 1;
+      }
+
+      #children-indicator {
+        margin-left: auto;
+        align-self: center;
+        opacity: 0.5;
+        padding-right: var(--uui-size-space-3);
+      }
+
+      slot[name='icon'] {
+        display: flex;
+        align-items: center;
+        padding-left: var(--uui-size-space-4);
+      }
+      :host([active]) {
+        background-color: var(--uui-color-current, #f5c1bc);
       }
     `,
   ];

--- a/packages/uui-card/lib/uui-card.story.ts
+++ b/packages/uui-card/lib/uui-card.story.ts
@@ -4,6 +4,8 @@ import { html } from 'lit';
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
 import { renderSlots, spread } from '../../../storyhelpers';
 
+import '@umbraco-ui/uui-icon-registry-essential/lib';
+
 const meta: Meta = {
   id: 'uui-card',
   component: 'uui-card',
@@ -49,4 +51,41 @@ export const Selectable: Story = {
   args: {
     selectable: true,
   },
+};
+
+export const HasChildren: Story = {
+  args: {
+    hasChildren: true,
+  },
+};
+
+export const TreeView: Story = {
+  render: () => html`
+    <div
+      style="display: flex; flex-direction: column; gap: var(--uui-size-space-3);">
+      <uui-card has-children active>
+        <uui-icon slot="icon" name="document"></uui-icon>
+        <div style="margin: var(--uui-size-space-4)">Item 1</div>
+      </uui-card>
+      <uui-card has-children>
+        <uui-icon slot="icon" name="document"></uui-icon>
+        <div style="margin: var(--uui-size-space-4)">Item 2</div>
+      </uui-card>
+      <uui-card>
+        <uui-icon slot="icon" name="document"></uui-icon>
+        <div style="margin: var(--uui-size-space-4)">Item 3</div>
+      </uui-card>
+      <uui-card>
+        <uui-icon slot="icon" name="document"></uui-icon>
+        <div style="margin: var(--uui-size-space-4)">Item 4</div>
+      </uui-card>
+      <uui-card>
+        <uui-icon slot="icon" name="document"></uui-icon>
+        <div style="margin: var(--uui-size-space-4)">Item 5</div>
+      </uui-card>
+      <uui-card>
+        <div style="margin: var(--uui-size-space-4)">Item 6</div>
+      </uui-card>
+    </div>
+  `,
 };

--- a/packages/uui-card/lib/uui-card.story.ts
+++ b/packages/uui-card/lib/uui-card.story.ts
@@ -52,9 +52,3 @@ export const Selectable: Story = {
     selectable: true,
   },
 };
-
-export const HasChildren: Story = {
-  args: {
-    hasChildren: true,
-  },
-};

--- a/packages/uui-card/lib/uui-card.story.ts
+++ b/packages/uui-card/lib/uui-card.story.ts
@@ -58,34 +58,3 @@ export const HasChildren: Story = {
     hasChildren: true,
   },
 };
-
-export const TreeView: Story = {
-  render: () => html`
-    <div
-      style="display: flex; flex-direction: column; gap: var(--uui-size-space-3);">
-      <uui-card has-children active>
-        <uui-icon slot="icon" name="document"></uui-icon>
-        <div style="margin: var(--uui-size-space-4)">Item 1</div>
-      </uui-card>
-      <uui-card has-children>
-        <uui-icon slot="icon" name="document"></uui-icon>
-        <div style="margin: var(--uui-size-space-4)">Item 2</div>
-      </uui-card>
-      <uui-card>
-        <uui-icon slot="icon" name="document"></uui-icon>
-        <div style="margin: var(--uui-size-space-4)">Item 3</div>
-      </uui-card>
-      <uui-card>
-        <uui-icon slot="icon" name="document"></uui-icon>
-        <div style="margin: var(--uui-size-space-4)">Item 4</div>
-      </uui-card>
-      <uui-card>
-        <uui-icon slot="icon" name="document"></uui-icon>
-        <div style="margin: var(--uui-size-space-4)">Item 5</div>
-      </uui-card>
-      <uui-card>
-        <div style="margin: var(--uui-size-space-4)">Item 6</div>
-      </uui-card>
-    </div>
-  `,
-};


### PR DESCRIPTION
## Summary

  Adds a shared `has-children` property to the base card and implements the visual indicator (`uui-symbol-expand`) in `uui-card-media` and `uui-card-content-node`, appearing before the icon in the name row. Both cards also get an `icon` slot following the `uui-menu-item` pattern, hidden when empty. `uui-card-media` gets an active state override so the current color only shows on the content bar, and both cards get double-click support that dispatches the existing `open` event.  