### PR TITLE
Build: Remove broken SonarCloud projectVersion step from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,34 +46,3 @@ jobs:
         run: npm run build && lerna publish from-package --yes
         env:
           NPM_CONFIG_PROVENANCE: true
-
-      - name: Update SonarCloud new code baseline
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
-        continue-on-error: true
-        env:
-          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
-          SONAR_PROJECT: ${{ vars.SONARCLOUD_PROJECT_KEY }}
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          echo "Setting SonarCloud new code baseline to version: $VERSION"
-
-          # Update project version for future analyses
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST 'https://sonarcloud.io/api/settings/set' \
-            -H "Authorization: Bearer $SONAR_TOKEN" \
-            -d "component=$SONAR_PROJECT&key=sonar.projectVersion&value=$VERSION")
-          echo "Set projectVersion: HTTP $HTTP_CODE"
-          [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ] || echo "::warning::Failed to set sonar.projectVersion (HTTP $HTTP_CODE)"
-
-          # Find the latest analysis and create a VERSION event
-          ANALYSIS_KEY=$(curl -s "https://sonarcloud.io/api/project_analyses/search?project=$SONAR_PROJECT&ps=1" \
-            -H "Authorization: Bearer $SONAR_TOKEN" | python3 -c "import json,sys; print(json.load(sys.stdin)['analyses'][0]['key'])")
-          echo "Latest analysis: $ANALYSIS_KEY"
-
-          if [ -n "$ANALYSIS_KEY" ]; then
-            RESPONSE=$(curl -s -w "\n%{http_code}" -X POST 'https://sonarcloud.io/api/project_analyses/create_event' \
-              -H "Authorization: Bearer $SONAR_TOKEN" \
-              -d "analysis=$ANALYSIS_KEY&category=VERSION&name=$VERSION")
-            HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-            echo "Create VERSION event: HTTP $HTTP_CODE"
-            [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ] || echo "::warning::Failed to create VERSION event (HTTP $HTTP_CODE)"
-          fi


### PR DESCRIPTION
## What

Removes the **Update SonarCloud new code baseline** step from `.github/workflows/publish.yml`.

## Why

The step called SonarCloud admin APIs (`/api/settings/set` and `/api/project_analyses/create_event`) authenticated with a user-PAT `SONARCLOUD_TOKEN`. SonarCloud user PATs now expire (60-day max), so the token lapsed and **every tagged release since 1.17.0 failed this step with HTTP 401** (the subsequent `json.load` of the empty 401 body then threw and exited 1).

This project uses SonarCloud **Automatic Analysis**, which cannot set `sonar.projectVersion` itself, so the admin-API call was the only mechanism to advance the version — and it has been non-functional. Rather than keep rotating an expiring admin token in CI, we remove the step.

## Follow-up (done out-of-band, not in this PR)

- `sonar.projectVersion` set to `2.0.0` directly via the API.
- The stale **manual new-code baseline** (pinned to 2024-06-24) on `main` was unset, so the project's **New Code = "Previous version"** definition now applies. This recomputes on the next `main` analysis.

`v1/dev` never had this step, so no change is needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)