### PR TITLE
Prevent long names from pushing action buttons out of view

### DIFF
--- a/packages/uui-ref-node/lib/uui-ref-node.element.ts
+++ b/packages/uui-ref-node/lib/uui-ref-node.element.ts
@@ -206,7 +206,7 @@ export class UUIRefNodeElement extends UUIRefElement {
         cursor: pointer;
         display: flex;
         flex-grow: 1;
-        width: calc(100%);
+        min-width: 0;
         margin: 0 0 1px 0;
       }
 
@@ -224,6 +224,7 @@ export class UUIRefNodeElement extends UUIRefElement {
         align-items: start;
         justify-content: center;
         height: 100%;
+        min-width: 0;
         padding-left: var(--uui-size-2);
         max-width: calc(100% - 2 * var(--uui-size-3) - var(--uui-size-2));
         margin-top: 1px;
@@ -232,6 +233,13 @@ export class UUIRefNodeElement extends UUIRefElement {
       #detail {
         opacity: 0.6;
         line-height: 1.2em;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+        max-width: calc(100%);
+      }
+
+      #name {
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;


### PR DESCRIPTION
## Description

Update `uui-ref-node` so long, unbroken names/URLs truncate correctly without pushing the actions slot outside the component bounds.

The fix removes the forced full-width behavior from the main open area and allows the flex layout to shrink properly by adding `min-width: 0` where needed. This makes `text-overflow: ellipsis` work as intended for long node names while preserving the action button layout.

**Related CMS issue:** https://github.com/umbraco/Umbraco-CMS/issues/23088

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

When a `uui-ref-node` name contains a long string without spaces, such as a URL, the text does not truncate properly in the flex layout. As a result, the content area expands to the full width of the row and pushes the action button out of view.

Adding truncation styles alone is not enough in a flex container: the flex item itself must also be allowed to shrink. This change ensures the name stays on a single line, truncates with ellipsis, and leaves the actions slot visible and usable.

## How to test?

1. Run `npm install && npm run storybook`
2. Open the `uui-ref-node` long-link story:
   `http://localhost:6006/?path=/story/uui-ref-node--long-link`
3. Verify that the long name/url truncates with an ellipsis
4. Verify that the Remove/action button remains visible inside the component
5. Resize the browser window and confirm the layout still behaves correctly

## Screenshots (if appropriate)

**Before:**
<img width="460" height="126" alt="image" src="https://github.com/user-attachments/assets/09b2c429-232f-48dc-a505-4fb3c637d47c" />

**After:**

<img width="466" height="111" alt="image" src="https://github.com/user-attachments/assets/e3e5243d-d5d1-4b99-b733-dedfc8501884" />


Or see the `uui-ref-node -- long-link` story in Storybook.

## Checklist

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.