### PR TITLE
fix(button): prevent click handler from firing when disabled

### DIFF
--- a/packages/uui-button/lib/uui-button.element.ts
+++ b/packages/uui-button/lib/uui-button.element.ts
@@ -151,7 +151,7 @@ export class UUIButtonElement extends UUIFormControlMixin(
 
   constructor() {
     super();
-    this.addEventListener('click', this._onHostClick);
+    this.addEventListener('click', this._onHostClick, { capture: true });
   }
 
   protected getFormElement(): HTMLElement {

--- a/packages/uui-button/lib/uui-button.story.ts
+++ b/packages/uui-button/lib/uui-button.story.ts
@@ -69,6 +69,28 @@ export const Disabled: Story = {
   },
 };
 
+export const DisabledClickTest: Story = {
+  render: () => {
+    const handleClick = () => {
+      alert('Button was clicked!');
+    };
+    return html`
+      <div style="display: flex; gap: 1rem;">
+        <uui-button
+          label="Disabled"
+          look="primary"
+          disabled
+          @click=${handleClick}>
+          Disabled (no alert)
+        </uui-button>
+        <uui-button label="Enabled" look="primary" @click=${handleClick}>
+          Enabled (shows alert)
+        </uui-button>
+      </div>
+    `;
+  },
+};
+
 export const Compact: Story = {
   args: {
     compact: true,

--- a/packages/uui-button/lib/uui-button.test.ts
+++ b/packages/uui-button/lib/uui-button.test.ts
@@ -234,6 +234,45 @@ describe('UuiButton', () => {
       await element.click();
       expect(wasClicked).to.false;
     });
+
+    it('does not fire click handler when disabled and handler is added via template', async () => {
+      let templateHandlerCalled = false;
+
+      const disabledButton: UUIButtonElement = await fixture(
+        html`<uui-button
+          label="Test"
+          disabled
+          @click=${() => {
+            templateHandlerCalled = true;
+          }}>
+          Click me
+        </uui-button>`,
+      );
+
+      const innerButton = disabledButton.shadowRoot!.querySelector('#button');
+      innerButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+      expect(templateHandlerCalled).to.be.false;
+    });
+
+    it('does not fire click handler when disabled and clicked directly on host', async () => {
+      let templateHandlerCalled = false;
+
+      const disabledButton: UUIButtonElement = await fixture(
+        html`<uui-button
+          label="Test"
+          disabled
+          @click=${() => {
+            templateHandlerCalled = true;
+          }}>
+          Click me
+        </uui-button>`,
+      );
+
+      disabledButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+      expect(templateHandlerCalled).to.be.false;
+    });
   });
 
   describe('HREF', () => {

--- a/src/components/button/button.test.ts
+++ b/src/components/button/button.test.ts
@@ -238,7 +238,7 @@ describe('UuiButton', () => {
     it('does not fire click handler when disabled and handler is added via template', async () => {
       let templateHandlerCalled = false;
 
-      const disabledButton: UUIButtonElement = await fixture(
+      const screen = render(
         html`<uui-button
           label="Test"
           disabled
@@ -249,16 +249,17 @@ describe('UuiButton', () => {
         </uui-button>`,
       );
 
+      const disabledButton = screen.container.querySelector('uui-button')!;
       const innerButton = disabledButton.shadowRoot!.querySelector('#button');
       innerButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
-      expect(templateHandlerCalled).to.be.false;
+      expect(templateHandlerCalled).toBe(false);
     });
 
     it('does not fire click handler when disabled and clicked directly on host', async () => {
       let templateHandlerCalled = false;
 
-      const disabledButton: UUIButtonElement = await fixture(
+      const screen = render(
         html`<uui-button
           label="Test"
           disabled
@@ -269,9 +270,10 @@ describe('UuiButton', () => {
         </uui-button>`,
       );
 
+      const disabledButton = screen.container.querySelector('uui-button')!;
       disabledButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
-      expect(templateHandlerCalled).to.be.false;
+      expect(templateHandlerCalled).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Description

Fix `uui-button` to ensure `@click` handlers never fire when the button is disabled. The component now uses the capturing phase for its internal click listener, guaranteeing the disabled check runs before any consumer-added click handlers regardless of listener registration order.

Closes #1409

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

When using `?disabled=${this._disabled}` on a `<uui-button>` with an `@click` handler, there are scenarios where the click handler can fire even when disabled. This happens because `stopImmediatePropagation()` only prevents listeners added *after* the one calling it.

The fix uses `{ capture: true }` on the component's internal click listener. Capture phase listeners run before bubbling phase listeners, so the disabled check is guaranteed to run first and can block all subsequent handlers.

## How to test?

1. Run `npm install && npm run storybook`
2. Navigate to **Buttons → Button → Disabled Click Test**
3. Click the "Disabled (no alert)" button → should see NO alert
4. Click the "Enabled (shows alert)" button → should see alert popup
5. Run `npm run test:coverage-for uui-button` → all tests pass

## Checklist

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
