### PR TITLE
Combobox: Clear three SonarCloud maintainability smells

### DIFF
--- a/src/components/combobox-list/combobox-list-option.element.ts
+++ b/src/components/combobox-list/combobox-list-option.element.ts
@@ -78,8 +78,10 @@ export class UUIComboboxListOptionElement extends SelectableMixin(
   }
 
   render() {
-    return html`${this.multiple ? html`<span id="checkbox"></span>` : nothing}
-      <slot></slot>`;
+    const checkbox = this.multiple
+      ? html`<span id="checkbox"></span>`
+      : nothing;
+    return html`${checkbox} <slot></slot>`;
   }
 
   static override readonly styles = [

--- a/src/components/combobox-list/combobox-list.element.ts
+++ b/src/components/combobox-list/combobox-list.element.ts
@@ -204,12 +204,10 @@ export class UUIComboboxListElement extends LitElement {
       this._selectedValues = this._selectedValues.filter(
         v => v !== (el.value || ''),
       );
-    } else {
+    } else if (this._selectedElement === el) {
       // Existing single-select logic
-      if (this._selectedElement === el) {
-        this.value = '';
-        this.displayValue = '';
-      }
+      this.value = '';
+      this.displayValue = '';
     }
 
     this.dispatchEvent(new UUIComboboxListEvent(UUIComboboxListEvent.CHANGE));

--- a/src/components/combobox/combobox.element.ts
+++ b/src/components/combobox/combobox.element.ts
@@ -333,8 +333,8 @@ export class UUIComboboxElement extends UUIFormControlWithBasicsMixin(
       this._selectedItems.length > 0 &&
       this.search === ''
     ) {
-      const lastItem = this._selectedItems[this._selectedItems.length - 1];
-      this.#onRemoveTag(e, lastItem.value);
+      const lastItem = this._selectedItems.at(-1);
+      if (lastItem) this.#onRemoveTag(e, lastItem.value);
       return;
     }
     if (this.open === false && e.code === 'Enter') {


### PR DESCRIPTION
## What

Resolves the three remaining non-TODO SonarCloud maintainability issues, all in the combobox components:

| Rule | File | Fix |
|------|------|-----|
| `typescript:S4624` (nested template literal) | `combobox-list-option.element.ts` | Extract the conditional checkbox markup to a `const` before the outer `html` template. |
| `typescript:S7755` (prefer `.at()`) | `combobox.element.ts` | `this._selectedItems.at(-1)` instead of `[length - 1]`, guarding the now-optional result. |
| `typescript:S6660` (if-only in else) | `combobox-list.element.ts` | Collapse `else { if (...) }` into `else if`. |

## Notes

- **No behavioural change.** The `S4624` fix is markup-equivalent (the template whitespace collapses identically); the `.at(-1)` path is reached only when `length > 0`, so the guard is always true there; the `else if` is a straight equivalence.
- Verified locally: `eslint`, prettier, and the `tsc-files` type-check (pre-commit hook) all pass on the three element files.

After this merges, the only SonarCloud open issues left are the `S1135` TODO-comment markers (the tracked TODO-cleanup backlog) — 0 security, 0 reliability, gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)