### PR TITLE
Tag in picker search results wrap on multiple lines

### DIFF
--- a/src/components/ref/ref.element.ts
+++ b/src/components/ref/ref.element.ts
@@ -231,6 +231,7 @@ export class UUIRefElement extends SelectOnlyMixin(
         display: flex;
         justify-content: flex-end;
         align-items: center;
+        flex-shrink: 0;
       }
     `,
   ];


### PR DESCRIPTION
## Description
https://github.com/umbraco/Umbraco-CMS/issues/23185 as this bug issuse says. After invenstigation the Umbraco CMS UmbRefItemElement use a elementMix off UUIRefNodeElement where we have the styles. Therefor the bugfix it says belog to the UUI project.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and context
This change ensure the neccarcy space not to wrap on multiple lines. But stay in one line as excepted. 