### PR TITLE
Fix jump in draggable handle when color updates

### DIFF
--- a/src/components/color-area/color-area.element.ts
+++ b/src/components/color-area/color-area.element.ts
@@ -116,6 +116,10 @@ export class UUIColorAreaElement extends LitElement {
     this._value = newVal;
     this.requestUpdate('value', oldVal);
 
+    // Avoid re-parsing parent-provided formatted values during active drag.
+    // This prevents tiny precision shifts that can make the handle appear to jump.
+    if (this.isDraggingGridHandle) return;
+
     try {
       const parsed = parseColor(newVal);
 

--- a/src/components/color-area/color-area.test.ts
+++ b/src/components/color-area/color-area.test.ts
@@ -9,9 +9,9 @@ describe('UUIColorAreaElement', () => {
   let element: UUIColorAreaElement;
 
   beforeEach(async () => {
-    element = render(
-      html` <uui-color-area></uui-color-area> `,
-    ).container.querySelector('uui-color-area')!;
+    element = render(html`
+      <uui-color-area></uui-color-area>
+    `).container.querySelector('uui-color-area')!;
 
     await element.updateComplete;
   });
@@ -25,6 +25,18 @@ describe('UUIColorAreaElement', () => {
   });
 
   describe('value setter', () => {
+    it('does not overwrite drag state while dragging', async () => {
+      (element as any).isDraggingGridHandle = true;
+      element.saturation = 62;
+      element.brightness = 41;
+
+      element.value = '#00ff00';
+      await element.updateComplete;
+
+      expect(element.saturation).toBe(62);
+      expect(element.brightness).toBe(41);
+    });
+
     it('parses hex color and updates saturation', async () => {
       element.value = '#00ff00'; // green: h=120, s=100, l=50
       await element.updateComplete;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Dragging color in standalone `uui-color-area` works fine, but inside `uui-color-picker` dragging the handle at some colors, mainly black, it cause the handle to flicker/jump a bit.



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

**Before**

**After**

https://github.com/user-attachments/assets/7ed3cda0-96de-499b-9209-10e1cd521b07


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
