### PR TITLE
Round hue value for color input

### DIFF
--- a/src/components/color-picker/color-picker.element.ts
+++ b/src/components/color-picker/color-picker.element.ts
@@ -352,14 +352,14 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
 
     const { h, s, l, a } = parsed;
 
-    this.hue = h;
+    this.hue = Math.round(h);
     this.saturation = Math.round(s);
     this.lightness = Math.round(l);
     this.alpha = this.opacity ? a * 100 : 100; // Convert to 0-100 range, and set alpha to 100 if opacity is disabled
 
     // Workaround as hue isn't correct after changing hue slider, but parseColor returns hue as zero when color is black.
     if (typeof colorString !== 'string' && colorString.h) {
-      this.hue = colorString.h;
+      this.hue = Math.round(colorString.h);
     }
 
     this._color = {

--- a/src/components/color-picker/color-picker.test.ts
+++ b/src/components/color-picker/color-picker.test.ts
@@ -45,6 +45,31 @@ describe('UUIColorPickerElement', () => {
   });
 
   describe('float precision', () => {
+    it('stores hue as an integer in component state', async () => {
+      element.setColor({ h: 120.6, s: 50, l: 40, a: 1 });
+      await element.updateComplete;
+
+      expect((element as any).hue).toBe(121);
+    });
+
+    it('rounds hue to integer in HSL formatted output', async () => {
+      element.setColor({ h: 120.6, s: 50, l: 40, a: 1 });
+      await element.updateComplete;
+      const formatted = element.getFormattedValue('hsl');
+
+      expect(formatted).toMatch(/^hsl\(121\s/);
+      expect(formatted).not.toMatch(/^hsl\(\d+\.\d+/);
+    });
+
+    it('rounds hue to integer in HSV formatted output', async () => {
+      element.setColor({ h: 120.6, s: 50, l: 40, a: 1 });
+      await element.updateComplete;
+      const formatted = element.getFormattedValue('hsv');
+
+      expect(formatted).toMatch(/^hsv\(121,/);
+      expect(formatted).not.toMatch(/^hsv\(\d+\.\d+/);
+    });
+
     it('rounds saturation and lightness to integers in formatted output', async () => {
       // Simulates a value produced by the color area with raw float coordinates
       element.setColor('hsl(353, 74.70982142857143%, 30.571292986188617%)');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When dragging hue slider in color picker, it was showing a lot it decimals in color input field for HSL and HSV mode.

Fixes https://github.com/umbraco/Umbraco.UI/issues/1420

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

**Before**

https://github.com/user-attachments/assets/640ed36a-2334-4a35-953e-c589079deacf

**After**

https://github.com/user-attachments/assets/6b9cf890-ef24-46b4-add1-91a12084b929

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
