### PR TITLE
Make elements overflow specific in color picker popover

### DIFF
--- a/src/components/color-picker/color-picker.element.ts
+++ b/src/components/color-picker/color-picker.element.ts
@@ -558,6 +558,11 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
       }
       uui-popover-container {
         width: inherit;
+        overflow: visible;
+      }
+
+      uui-popover-container::part(scroll-container) {
+        overflow: visible;
       }
       .color-picker {
         width: 100%;

--- a/src/components/color-picker/color-picker.element.ts
+++ b/src/components/color-picker/color-picker.element.ts
@@ -530,7 +530,7 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
         aria-haspopup="true"
         aria-expanded="false"
         popovertarget="color-picker-popover"></button>
-      <uui-popover-container id="color-picker-popover">
+      <uui-popover-container id="color-picker-popover" no-scroll>
         ${this._renderColorPicker()}
       </uui-popover-container>`;
   }
@@ -558,11 +558,6 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
       }
       uui-popover-container {
         width: inherit;
-        overflow: visible;
-      }
-
-      uui-popover-container::part(scroll-container) {
-        overflow: visible;
       }
       .color-picker {
         width: 100%;

--- a/src/components/popover-container/popover-container.element.ts
+++ b/src/components/popover-container/popover-container.element.ts
@@ -59,6 +59,9 @@ export class UUIPopoverContainerElement extends LitElement {
     this.#initUpdate();
   }
 
+  @property({ type: Boolean, reflect: true, attribute: 'no-scroll' })
+  noScroll = false;
+
   @state()
   _placement: PopoverContainerPlacement = 'bottom-start';
 
@@ -417,9 +420,10 @@ export class UUIPopoverContainerElement extends LitElement {
   }
 
   render() {
-    return html`<uui-scroll-container part="scroll-container"
-      ><slot></slot
-    ></uui-scroll-container>`;
+    if (this.noScroll) {
+      return html`<slot></slot>`;
+    }
+    return html`<uui-scroll-container><slot></slot></uui-scroll-container>`;
   }
 
   static override readonly styles = [
@@ -435,6 +439,9 @@ export class UUIPopoverContainerElement extends LitElement {
         color: var(--uui-color-text);
         box-shadow: var(--uui-shadow-depth-4);
         border-radius: var(--uui-border-radius);
+      }
+      :host([no-scroll]) {
+        overflow: visible;
       }
 
       uui-scroll-container {

--- a/src/components/popover-container/popover-container.element.ts
+++ b/src/components/popover-container/popover-container.element.ts
@@ -417,7 +417,9 @@ export class UUIPopoverContainerElement extends LitElement {
   }
 
   render() {
-    return html`<uui-scroll-container><slot></slot></uui-scroll-container>`;
+    return html`<uui-scroll-container part="scroll-container"
+      ><slot></slot
+    ></uui-scroll-container>`;
   }
 
   static override readonly styles = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The replacement of the previously container to use `uui-popover-container` caused scrollbar + drag handle in color area was allowed to overflow at edges as previously.

`uui-popover-container` use an inner `uui-scroll-container` and the addition of `part` attribute allows to target CSS for this inner element.

Fixes https://github.com/umbraco/Umbraco.UI/issues/1419

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

**Before**

<img width="674" height="625" alt="image" src="https://github.com/user-attachments/assets/ca38637f-e4d7-42d0-9549-f027cdac15f2" />


**After**

<img width="706" height="622" alt="image" src="https://github.com/user-attachments/assets/b639e5e7-dbf2-4447-aba0-9c054e63f00f" />


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
