### PR TITLE
Adjust readonly styling of color swatch

### DIFF
--- a/src/components/checkbox/checkbox.element.ts
+++ b/src/components/checkbox/checkbox.element.ts
@@ -3,11 +3,11 @@ import {
   UUIHorizontalShakeKeyframes,
 } from '../../internal/animations/index.js';
 import { UUIBooleanInputElement } from '../boolean-input/boolean-input.js';
-import { css, html, svg } from 'lit';
-
-// Custom SVG for the checkbox, as this is smaller in size than the icon registry version: [NL]
-const check = svg`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 10 17 4 12" /></svg>`;
-const subtract = svg`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 12.25h14" /></svg>`;
+import { css, html } from 'lit';
+import {
+  iconCheck,
+  iconSubtract,
+} from '../icon-registry-essential/svgs/index.js';
 
 /**
  *  Umbraco checkbox, toggles between checked and uncheck
@@ -26,7 +26,9 @@ export class UUICheckboxElement extends UUIBooleanInputElement {
   renderCheckbox() {
     return html`
       <div id="ticker">
-        <div id="icon-check">${this.indeterminate ? subtract : check}</div>
+        <div id="icon-check">
+          ${this.indeterminate ? iconSubtract : iconCheck}
+        </div>
       </div>
     `;
   }
@@ -111,6 +113,10 @@ export class UUICheckboxElement extends UUIBooleanInputElement {
           opacity 120ms;
         color: var(--uui-color-selected-contrast);
         opacity: 0;
+      }
+
+      #icon-check > svg {
+        stroke-width: 2.5;
       }
 
       #ticker::before {

--- a/src/components/color-swatch/color-swatch.element.ts
+++ b/src/components/color-swatch/color-swatch.element.ts
@@ -327,9 +327,33 @@ export class UUIColorSwatchElement extends LabelMixin(
       .color-swatch__color {
         width: 100%;
         height: 100%;
+        position: relative;
+        overflow: hidden;
         border: 1px solid rgba(0, 0, 0, 0.125);
         border-radius: inherit;
         box-sizing: border-box;
+      }
+
+      :host([readonly]:not([disabled])) .color-swatch__color::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        background-image:
+          linear-gradient(
+            -45deg,
+            transparent calc(50% - 2px),
+            rgba(0, 0, 0, 0.5) calc(50% - 2px),
+            rgba(0, 0, 0, 0.5) calc(50% - 1px),
+            transparent calc(50% - 1px)
+          ),
+          linear-gradient(
+            -45deg,
+            transparent calc(50% + 1px),
+            rgba(255, 255, 255, 0.5) calc(50% + 1px),
+            rgba(255, 255, 255, 0.5) calc(50% + 2px),
+            transparent calc(50% + 2px)
+          );
       }
 
       :host([show-label]) .color-swatch__color {

--- a/src/components/color-swatch/color-swatch.element.ts
+++ b/src/components/color-swatch/color-swatch.element.ts
@@ -1,5 +1,5 @@
 import { property, state } from 'lit/decorators.js';
-import { css, html, LitElement, nothing, svg } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { ref } from 'lit/directives/ref.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
@@ -8,9 +8,8 @@ import {
   LabelMixin,
   SelectableMixin,
 } from '../../internal/mixins/index.js';
+import { iconCheck } from '../icon-registry-essential/svgs/iconCheck.js';
 
-// Custom SVG for the checkbox, as this is smaller in size than the icon registry version: [NL]
-const check = svg`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 10 17 4 12" /></svg>`;
 /**
  * Color swatch, can have label and be selectable, disabled or readonly.
  *
@@ -194,7 +193,7 @@ export class UUIColorSwatchElement extends LabelMixin(
           <div
             class="color-swatch__check"
             style=${styleMap({ color: colorStr })}>
-            ${check}
+            ${iconCheck}
           </div>
         </div>
         ${this._renderWithLabel()}
@@ -394,6 +393,10 @@ export class UUIColorSwatchElement extends LabelMixin(
 
       :host([selected]) .color-swatch__check {
         opacity: 1;
+      }
+
+      .color-swatch__check > svg {
+        stroke-width: 2.5;
       }
 
       slot[name='label']::slotted(*),

--- a/src/components/color-swatch/color-swatch.element.ts
+++ b/src/components/color-swatch/color-swatch.element.ts
@@ -343,15 +343,15 @@ export class UUIColorSwatchElement extends LabelMixin(
           linear-gradient(
             -45deg,
             transparent calc(50% - 2px),
-            rgba(0, 0, 0, 0.5) calc(50% - 2px),
-            rgba(0, 0, 0, 0.5) calc(50% - 1px),
+            rgba(0, 0, 0, 0.25) calc(50% - 2px),
+            rgba(0, 0, 0, 0.25) calc(50% - 1px),
             transparent calc(50% - 1px)
           ),
           linear-gradient(
             -45deg,
             transparent calc(50% + 1px),
-            rgba(255, 255, 255, 0.5) calc(50% + 1px),
-            rgba(255, 255, 255, 0.5) calc(50% + 2px),
+            rgba(255, 255, 255, 0.25) calc(50% + 1px),
+            rgba(255, 255, 255, 0.25) calc(50% + 2px),
             transparent calc(50% + 2px)
           );
       }

--- a/src/components/color-swatch/color-swatch.element.ts
+++ b/src/components/color-swatch/color-swatch.element.ts
@@ -1,15 +1,16 @@
 import { property, state } from 'lit/decorators.js';
-import { css, html, LitElement, nothing } from 'lit';
+import { css, html, LitElement, nothing, svg } from 'lit';
 import { ref } from 'lit/directives/ref.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
-import { iconCheck } from '../icon-registry-essential/svgs/index.js';
 import {
   ActiveMixin,
   LabelMixin,
   SelectableMixin,
 } from '../../internal/mixins/index.js';
 
+// Custom SVG for the checkbox, as this is smaller in size than the icon registry version: [NL]
+const check = svg`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 10 17 4 12" /></svg>`;
 /**
  * Color swatch, can have label and be selectable, disabled or readonly.
  *
@@ -193,7 +194,7 @@ export class UUIColorSwatchElement extends LabelMixin(
           <div
             class="color-swatch__check"
             style=${styleMap({ color: colorStr })}>
-            ${iconCheck}
+            ${check}
           </div>
         </div>
         ${this._renderWithLabel()}
@@ -217,7 +218,6 @@ export class UUIColorSwatchElement extends LabelMixin(
         align-items: center;
         justify-content: center;
         box-sizing: border-box;
-        transition: box-shadow 100ms ease-out;
         flex-direction: column;
       }
 
@@ -245,7 +245,6 @@ export class UUIColorSwatchElement extends LabelMixin(
 
       :host([disabled]) {
         cursor: not-allowed;
-        opacity: 0.5;
       }
 
       :host([readonly]) {
@@ -260,12 +259,24 @@ export class UUIColorSwatchElement extends LabelMixin(
         padding: 0;
         margin: 0;
         text-align: left;
-        border: 1px solid #ccc;
-        border-radius: var(--uui-size-4);
+        border-radius: var(--uui-border-radius-2);
+        overflow: hidden;
+      }
+      :host(:not([show-label])) #swatch {
+        border-radius: var(--uui-size-5);
+        border: 1px solid var(--uui-color-border);
       }
 
       :host(:not([selectable])) #swatch:focus {
         outline: none;
+      }
+
+      :host([readonly]) #swatch,
+      :host([disabled]) #swatch {
+        background-color: var(--uui-color-disabled-standalone);
+      }
+      :host([readonly]:not([disabled]):hover) #swatch {
+        background-color: var(--uui-color-disabled);
       }
 
       :host([selectable]) #swatch::after {
@@ -279,10 +290,13 @@ export class UUIColorSwatchElement extends LabelMixin(
         border: var(--uui-swatch-border-width, 2px) solid
           var(--uui-color-selected);
         border-radius: calc(
-          var(--uui-border-radius) + var(--uui-swatch-border-width, 1px)
+          var(--uui-size-5) + var(--uui-swatch-border-width, 1px)
         );
         transition: opacity 100ms ease-out;
         opacity: 0;
+      }
+      :host([selectable][show-label]) #swatch::after {
+        border-radius: var(--uui-border-radius-2);
       }
       :host([selectable]:not([disabled]):hover) #swatch::after {
         opacity: 0.33;
@@ -309,6 +323,7 @@ export class UUIColorSwatchElement extends LabelMixin(
       :host([show-label]) .color-swatch {
         width: 120px;
         height: 50px;
+        margin: 0;
       }
 
       .color-swatch.color-swatch--transparent-bg {
@@ -334,30 +349,25 @@ export class UUIColorSwatchElement extends LabelMixin(
         box-sizing: border-box;
       }
 
-      :host([readonly]:not([disabled])) .color-swatch__color::after {
-        content: '';
-        position: absolute;
-        inset: 0;
-        pointer-events: none;
-        background-image:
-          linear-gradient(
-            -45deg,
-            transparent calc(50% - 2px),
-            rgba(0, 0, 0, 0.25) calc(50% - 2px),
-            rgba(0, 0, 0, 0.25) calc(50% - 1px),
-            transparent calc(50% - 1px)
-          ),
-          linear-gradient(
-            -45deg,
-            transparent calc(50% + 1px),
-            rgba(255, 255, 255, 0.25) calc(50% + 1px),
-            rgba(255, 255, 255, 0.25) calc(50% + 2px),
-            transparent calc(50% + 2px)
-          );
+      :host([show-label]) .color-swatch__color {
+        border-radius: var(--uui-border-radius-2) var(--uui-border-radius-2) 0 0;
+      }
+      :host([show-label][selectable][selected]:not([disabled]))
+        .color-swatch__color {
+        border-top: 2px solid rgba(255, 255, 255, 0.25);
+        border-left: 2px solid rgba(255, 255, 255, 0.25);
+        border-right: 2px solid rgba(255, 255, 255, 0.25);
       }
 
-      :host([show-label]) .color-swatch__color {
-        border-radius: 3px 3px 0 0;
+      :host([readonly]:not([disabled])) .color-swatch__color {
+        border-color: transparent;
+      }
+      :host([disabled]) .color-swatch__color {
+        opacity: 0.6;
+      }
+      :host([disabled]) .color-swatch.color-swatch--transparent-bg {
+        background-image: none;
+        background-color: var(--uui-color-border-standalone);
       }
 
       .color-swatch__check {
@@ -400,7 +410,8 @@ export class UUIColorSwatchElement extends LabelMixin(
         flex-direction: column;
         background: white;
         border: 1px solid var(--uui-color-border);
-        border-radius: 0 0 3px 3px;
+        border-top: none;
+        border-radius: 0 0 var(--uui-border-radius-2) var(--uui-border-radius-2);
         font-size: var(--uui-size-4, 12px);
       }
 

--- a/src/components/color-swatch/color-swatch.element.ts
+++ b/src/components/color-swatch/color-swatch.element.ts
@@ -242,6 +242,10 @@ export class UUIColorSwatchElement extends LabelMixin(
         cursor: pointer;
       }
 
+      :host(:not([selectable]):not([readonly]):not([disabled])) #swatch {
+        cursor: pointer;
+      }
+
       :host([disabled]) {
         cursor: not-allowed;
       }
@@ -269,13 +273,13 @@ export class UUIColorSwatchElement extends LabelMixin(
       :host(:not([selectable])) #swatch:focus {
         outline: none;
       }
+      :host(:not([selectable]):not([readonly]):not([disabled])) #swatch:hover {
+        border-color: var(--uui-color-border-standalone);
+      }
 
       :host([readonly]) #swatch,
       :host([disabled]) #swatch {
         background-color: var(--uui-color-disabled-standalone);
-      }
-      :host([readonly]:not([disabled]):hover) #swatch {
-        background-color: var(--uui-color-disabled);
       }
 
       :host([selectable]) #swatch::after {
@@ -351,11 +355,14 @@ export class UUIColorSwatchElement extends LabelMixin(
       :host([show-label]) .color-swatch__color {
         border-radius: var(--uui-border-radius-2) var(--uui-border-radius-2) 0 0;
       }
-      :host([show-label][selectable][selected]:not([disabled]))
+      :host([show-label][selectable][selected]:not([disabled]):not([readonly]))
         .color-swatch__color {
         border-top: 2px solid rgba(255, 255, 255, 0.25);
         border-left: 2px solid rgba(255, 255, 255, 0.25);
         border-right: 2px solid rgba(255, 255, 255, 0.25);
+      }
+      :host([show-label][readonly]:not([disabled])) .color-swatch__color {
+        border: 2px solid var(--uui-color-border-standalone);
       }
 
       :host([readonly]:not([disabled])) .color-swatch__color {
@@ -416,6 +423,16 @@ export class UUIColorSwatchElement extends LabelMixin(
         border-top: none;
         border-radius: 0 0 var(--uui-border-radius-2) var(--uui-border-radius-2);
         font-size: var(--uui-size-4, 12px);
+      }
+
+      :host(:not([selectable]):not([readonly]):not([disabled]))
+        .color-swatch__label {
+        color: var(--uui-color-interactive);
+      }
+      :host(:not([selectable]):not([readonly]):not([disabled]):hover)
+        .color-swatch__label {
+        color: var(--uui-color-interactive-emphasis);
+        border-color: var(--uui-color-border-standalone);
       }
 
       .color-swatch__label strong {

--- a/src/components/color-swatch/color-swatch.story.ts
+++ b/src/components/color-swatch/color-swatch.story.ts
@@ -70,7 +70,7 @@ export const DisabledSelected: Story = {
 export const Readonly: Story = {
   args: {
     readonly: true,
-    selectable: true,
+    selectable: false,
   },
   parameters: {
     docs: {
@@ -145,7 +145,8 @@ export const Palette: Story = {
     const [selected, setSelected] = useState<string | null>(null);
 
     return html`
-      <div style="display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 12px;">
+      <div
+        style="display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 12px;">
         ${palette.map(
           ({ value, label }) => html`
             <uui-color-swatch

--- a/src/components/color-swatches/color-swatches.story.ts
+++ b/src/components/color-swatches/color-swatches.story.ts
@@ -99,7 +99,10 @@ const meta: Meta = {
     label="${label}"
     .showLabel=${args.showLabel}
     .color="${color}"
-    .value=${value}>
+    .value=${value}
+    .readonly=${args.readonly}
+    .disabled=${args.disabled}
+    .selected=${args.value === value}>
   </uui-color-swatch>`;
   })}
 </uui-color-swatches>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I had a look at different web component libraries to get inspiration for read only state of a swatch, but mostly if was same as disabled r didn't have impact on swatch visually besides e.g. cursor style.

AI has different suggestions, but mainly slightly changes to border, hover, etc. which visually didn't really differ much from the other variants.
Another suggestion was to add read-only icon, but in the case perhaps in one on the corners.

For example something like this:

<img width="352" height="53" alt="image" src="https://github.com/user-attachments/assets/f69b1c61-a3e1-4e2e-bc3f-c410983bdc5b" />

<img width="1220" height="125" alt="image" src="https://github.com/user-attachments/assets/c746a560-6cc5-4f2d-b5cf-1c78536a6f25" />


I found a bit inspiration from this variant with two borders:
https://sky-ui.cf.sky.com/components/swatch

Fixes https://github.com/umbraco/Umbraco.UI/issues/1366

Note other PRs fixes other part of styling in swatches.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

<img width="365" height="63" alt="image" src="https://github.com/user-attachments/assets/23eb3fd4-d50e-4e0a-93bc-e0264f0d79a4" />

<img width="353" height="58" alt="image" src="https://github.com/user-attachments/assets/f0c759f4-84e6-4658-bd84-8ddb1b13e3ce" />

<img width="1215" height="125" alt="image" src="https://github.com/user-attachments/assets/31eec221-2c2a-4173-9c03-2f20d9b23949" />

<img width="1214" height="134" alt="image" src="https://github.com/user-attachments/assets/ccb308b8-ec67-4b55-8c5b-7776b4e8048f" />


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
