### PR TITLE
General: show focus outline programmatically

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -28,6 +28,31 @@ function applyTheme(theme: string) {
   themeStyleEl.textContent = themes[theme] ?? lightCss;
 }
 
+let outlineHandlingScript: HTMLScriptElement | null = null;
+
+function applyOutlineHandling() {
+  if (!outlineHandlingScript) {
+    outlineHandlingScript = document.createElement('script');
+    outlineHandlingScript.textContent = `
+      let hadMouseDown = false;
+    this.addEventListener('focusout', () => {
+      if (hadMouseDown === false) {
+        document.body.style.setProperty('--uui-show-focus-outline', '1');
+      }
+      hadMouseDown = false;
+    });
+    this.addEventListener('mousedown', () => {
+      document.body.style.setProperty('--uui-show-focus-outline', '0');
+      hadMouseDown = true;
+    });
+    this.addEventListener('mouseup', () => {
+      hadMouseDown = false;
+    });
+    `;
+    document.head.appendChild(outlineHandlingScript);
+  }
+}
+
 export const globalTypes = {
   theme: {
     name: 'Theme',
@@ -63,6 +88,7 @@ const preview: Preview = {
   decorators: [
     (story, context) => {
       applyTheme(context.globals['theme'] ?? 'light');
+      applyOutlineHandling();
       return story();
     },
     story => {

--- a/src/components/breadcrumbs/breadcrumb-item.element.ts
+++ b/src/components/breadcrumbs/breadcrumb-item.element.ts
@@ -85,7 +85,8 @@ export class UUIBreadcrumbItemElement extends LitElement {
       a:focus-visible,
       span#link:focus-visible {
         border-radius: var(--uui-border-radius);
-        outline: 2px solid var(--uui-color-focus);
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+          var(--uui-color-focus);
       }
 
       [part='separator']::after {

--- a/src/components/button/button.element.ts
+++ b/src/components/button/button.element.ts
@@ -372,7 +372,7 @@ export class UUIButtonElement extends UUIFormControlWithBasicsMixin(
       }
 
       #button:focus-visible {
-        outline: 2px solid
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
           var(
             --uui-focus-outline-color,
             var(--color-emphasis, var(--uui-color-focus))

--- a/src/components/checkbox/checkbox.element.ts
+++ b/src/components/checkbox/checkbox.element.ts
@@ -148,7 +148,8 @@ export class UUICheckboxElement extends UUIBooleanInputElement {
       }
 
       input:focus-visible + #ticker {
-        outline: 2px solid var(--uui-color-focus);
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+          var(--uui-color-focus);
       }
 
       :host(:not([disabled], [readonly]))

--- a/src/components/color-picker/color-picker.element.ts
+++ b/src/components/color-picker/color-picker.element.ts
@@ -689,7 +689,8 @@ export class UUIColorPickerElement extends LabelMixin('label', LitElement) {
       }
 
       button.color-picker__trigger:focus-visible {
-        outline: 2px solid var(--uui-color-focus);
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+          var(--uui-color-focus);
       }
 
       uui-color-area {

--- a/src/components/input/input.element.ts
+++ b/src/components/input/input.element.ts
@@ -439,7 +439,8 @@ export class UUIInputElement extends UUIFormControlWithBasicsMixin(
           --uui-input-border-color-focus,
           var(--uui-color-border-emphasis)
         );
-        outline: 2px solid var(--uui-color-focus);
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+          var(--uui-color-focus);
       }
       :host(:focus) {
         border-color: var(

--- a/src/components/menu-item/menu-item.element.ts
+++ b/src/components/menu-item/menu-item.element.ts
@@ -591,7 +591,8 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         border-radius: calc(var(--uui-border-radius) - 1px);
         position: absolute;
         inset: 3px 3px 3px -5px;
-        outline: 2px solid var(--uui-color-focus);
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+          var(--uui-color-focus);
       }
 
       :host([select-mode='highlight']) #caret-button:focus-visible {
@@ -604,7 +605,8 @@ export class UUIMenuItemElement extends SelectOnlyMixin(
         position: absolute;
         inset: 3px;
         border-radius: calc(var(--uui-border-radius) - 1px);
-        outline: 2px solid var(--uui-color-focus);
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+          var(--uui-color-focus);
       }
 
       /** Slots */

--- a/src/components/radio/radio.element.ts
+++ b/src/components/radio/radio.element.ts
@@ -218,7 +218,8 @@ export class UUIRadioElement extends LitElement {
         outline: none;
       }
       :host(:focus-within) input:focus-visible + #button {
-        outline: 2px solid var(--uui-color-focus);
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+          var(--uui-color-focus);
       }
 
       :host(:not([disabled]):not([readonly]):hover) input ~ #button::after {

--- a/src/components/range-slider/range-slider.element.ts
+++ b/src/components/range-slider/range-slider.element.ts
@@ -989,7 +989,8 @@ export class UUIRangeSliderElement extends UUIFormControlWithBasicsMixin(
       input:focus-within::-webkit-slider-thumb,
       input.focus::-webkit-slider-thumb {
         border-color: var(--color-focus);
-        outline: 2px solid var(--color-focus);
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+          var(--uui-color-focus);
         outline-offset: 1px;
       }
       :host(:not([disabled]):not([readonly]))
@@ -1028,7 +1029,8 @@ export class UUIRangeSliderElement extends UUIFormControlWithBasicsMixin(
       input:focus-within::-moz-range-thumb,
       input.focus::-moz-range-thumb {
         border-color: var(--color-focus);
-        outline: 2px solid var(--color-focus);
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+          var(--uui-color-focus);
         outline-offset: 1px;
       }
       :host(:not([disabled]):not([readonly])) input::-moz-range-thumb:hover {

--- a/src/components/ref/ref.element.ts
+++ b/src/components/ref/ref.element.ts
@@ -185,7 +185,8 @@ export class UUIRefElement extends SelectOnlyMixin(
       a:focus {
         outline-offset: var(--uui-card-border-width);
         border-radius: var(--uui-border-radius);
-        outline: 2px solid var(--uui-color-focus);
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+          var(--uui-color-focus);
       }
 
       slot[name='actions']::slotted(*) {

--- a/src/components/select/select.element.ts
+++ b/src/components/select/select.element.ts
@@ -275,7 +275,7 @@ export class UUISelectElement extends UUIFormControlWithBasicsMixin(
       }
 
       #native:focus-visible {
-        outline: 2px solid
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
           var(--uui-select-outline-color, var(--uui-color-focus));
       }
 

--- a/src/components/slider/slider.element.ts
+++ b/src/components/slider/slider.element.ts
@@ -364,7 +364,8 @@ export class UUISliderElement extends UUIFormControlWithBasicsMixin(
       }
 
       input:focus-visible ~ #track #thumb {
-        outline: 2px solid var(--uui-color-focus);
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+          var(--uui-color-focus);
       }
 
       .track-step {

--- a/src/components/table/table-row.element.ts
+++ b/src/components/table/table-row.element.ts
@@ -59,7 +59,8 @@ export class UUITableRowElement extends SelectOnlyMixin(
       }
 
       :host(:focus-visible) {
-        outline: 2px solid var(--uui-color-focus);
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+          var(--uui-color-focus);
       }
       :host([selected]) {
         outline: 2px solid

--- a/src/components/textarea/textarea.element.ts
+++ b/src/components/textarea/textarea.element.ts
@@ -371,7 +371,8 @@ export class UUITextareaElement extends UUIFormControlWithBasicsMixin(
         );
       }
       textarea:focus-visible {
-        outline: 2px solid var(--uui-color-focus);
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+          var(--uui-color-focus);
       }
     `,
   ];

--- a/src/components/toggle/toggle.element.ts
+++ b/src/components/toggle/toggle.element.ts
@@ -167,7 +167,8 @@ export class UUIToggleElement extends UUIBooleanInputElement {
       }
 
       input:focus-visible ~ #toggle {
-        outline: 2px solid var(--uui-color-focus);
+        outline: calc(2px * var(--uui-show-focus-outline, 1)) solid
+          var(--uui-color-focus);
       }
 
       :host(:not([disabled], [readonly])) label:active #toggle::after {


### PR DESCRIPTION
Enables controlling when focus outlines are shown, so we can control that outline are hidden when using mouse navigation