### PR TITLE
fix(slider): forward the autocomplete attribute to the native input

### DIFF
--- a/src/components/slider/slider.element.ts
+++ b/src/components/slider/slider.element.ts
@@ -3,6 +3,7 @@ import { UUIFormControlWithBasicsMixin } from '../../internal/mixins/index.js';
 import { css, html, LitElement, nothing, svg } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { nativeInputStyles } from './native-input.styles.js';
 import { UUISliderEvent } from './UUISliderEvent.js';
@@ -146,6 +147,15 @@ export class UUISliderElement extends UUIFormControlWithBasicsMixin(
    */
   @property({ type: String })
   public label!: string;
+
+  /**
+   * Defines the autocomplete attribute, forwarded to the native input. A slider rarely wants autofill; set to "off" to discourage password managers from attaching to it.
+   * @type {string}
+   * @attr
+   * @default undefined
+   */
+  @property()
+  autocomplete?: string;
 
   @query('#input')
   private readonly _input!: HTMLInputElement;
@@ -302,6 +312,7 @@ export class UUISliderElement extends UUIFormControlWithBasicsMixin(
         max="${this.max}"
         .value="${this.value}"
         aria-label="${this.label}"
+        autocomplete=${ifDefined(this.autocomplete as any)}
         step="${+this.step}"
         ?disabled=${this.disabled || this.readonly}
         ?readonly=${this.readonly}

--- a/src/components/slider/slider.test.ts
+++ b/src/components/slider/slider.test.ts
@@ -57,6 +57,14 @@ describe('UuiSlider', () => {
     it('has a hideStepValues property', () => {
       expect(element).toHaveProperty('hideStepValues');
     });
+    it('has an autocomplete property', () => {
+      expect(element).toHaveProperty('autocomplete');
+    });
+    it('forwards the autocomplete property to the native input', async () => {
+      element.autocomplete = 'off';
+      await element.updateComplete;
+      expect(input.getAttribute('autocomplete')).toBe('off');
+    });
   });
 
   describe('methods', () => {


### PR DESCRIPTION
## What

Adds an `autocomplete` property to `uui-slider` that forwards to the underlying native `<input type="range">`, mirroring `uui-input`.

## Why

`uui-slider` is a form-associated control but never exposed `autocomplete`, so consumers had no way to set it on the inner input — and setting the attribute on the host doesn't cross the shadow boundary. That left no way to tell a slider to opt out of password-manager autofill.

Motivated by an Umbraco CMS issue (AB#68794) where a password manager (LastPass) attaches autofill UI to the telemetry slider in the installer. The CMS side already declares `autocomplete="off"` on that slider (umbraco/Umbraco-CMS#23235); once this lands and is consumed, the hint will take effect.

## Notes

- `autocomplete="off"` is honoured by the browser's native autofill; some password managers (e.g. LastPass) are known to ignore it on certain fields, so this is a best-effort improvement. A follow-up could add support for vendor opt-out attributes (`data-lpignore`, `data-1p-ignore`, …) on form controls.
- Added a test asserting the property forwards to the native input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
