### PR TITLE
fix funky styling

### DIFF
--- a/src/components/color-swatch/color-swatch.element.ts
+++ b/src/components/color-swatch/color-swatch.element.ts
@@ -332,7 +332,9 @@ export class UUIColorSwatchElement extends LabelMixin(
       }
 
       :host([show-label]) .color-swatch__color {
-        border-radius: var(--uui-size-4) var(--uui-size-4) 0 0;
+        border-radius: inherit;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
       }
 
       .color-swatch__check {
@@ -374,12 +376,12 @@ export class UUIColorSwatchElement extends LabelMixin(
         display: flex;
         flex-direction: column;
         background: white;
-        border-radius: 0 0 var(--uui-size-4) var(--uui-size-4);
+        border-radius: inherit;
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
         font-size: var(--uui-size-4, 12px);
         border: 0;
-        border-top-width: 1px;
-        border-color: var(--uui-color-border);
-        border-style: solid;
+        border-top: 1px solid var(--uui-color-border);
       }
 
       .color-swatch__label strong {

--- a/src/components/color-swatch/color-swatch.element.ts
+++ b/src/components/color-swatch/color-swatch.element.ts
@@ -303,7 +303,6 @@ export class UUIColorSwatchElement extends LabelMixin(
         flex-direction: column;
         justify-content: center;
         align-items: center;
-        margin: 2px;
       }
 
       :host([show-label]) .color-swatch {
@@ -333,7 +332,7 @@ export class UUIColorSwatchElement extends LabelMixin(
       }
 
       :host([show-label]) .color-swatch__color {
-        border-radius: 3px 3px 0 0;
+        border-radius: var(--uui-size-4) var(--uui-size-4) 0 0;
       }
 
       .color-swatch__check {
@@ -375,9 +374,12 @@ export class UUIColorSwatchElement extends LabelMixin(
         display: flex;
         flex-direction: column;
         background: white;
-        border: 1px solid var(--uui-color-border);
-        border-radius: 0 0 3px 3px;
+        border-radius: 0 0 var(--uui-size-4) var(--uui-size-4);
         font-size: var(--uui-size-4, 12px);
+        border: 0;
+        border-top-width: 1px;
+        border-color: var(--uui-color-border);
+        border-style: solid;
       }
 
       .color-swatch__label strong {


### PR DESCRIPTION
Fix styling on swatch picker

## Description
I noticed when i playarround in https://backofficepreview.umbraco.com/ that the Color Picker witch are using the uui-swatch that it was looking strangs. With a border inside a border inside a border and the radius was not align at all

I have fixed it to match more the uui libarary v1 with the v2 rounding effect we are looking for.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and context
It fix sad eyes looking at something the make a degsiner cry, to something the shines.

## How to test?
Storybook see the compoenet Swatchs

## Screenshots (if appropriate)
old picker
<img width="1377" height="302" alt="image" src="https://github.com/user-attachments/assets/044e112d-22d1-4bd4-a33b-c984d3a9c95f" />

after tweaking off design
<img width="1307" height="417" alt="image" src="https://github.com/user-attachments/assets/4715be73-08ad-4cfc-bc93-8e756d5f01c3" />
