### PR TITLE
Range slider step is 1px off

### DIFF
--- a/src/components/range-slider/range-slider.element.ts
+++ b/src/components/range-slider/range-slider.element.ts
@@ -828,7 +828,7 @@ export class UUIRangeSliderElement extends UUIFormControlWithBasicsMixin(
         position: absolute;
         left: 0;
         right: 0;
-        top: -10px;
+        top: -9px;
       }
 
       /** Step circles */


### PR DESCRIPTION
## Description
I noticed in storybook https://uui.umbraco.com/?path=/docs/uui-range-slider--docs and in https://backofficepreview.umbraco.com/section/content the the step is a little bit off, it not align on the line.

I change the position top by 1px to align the step on the line

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?
Storybook see the steps more on the line now

## Screenshots (if appropriate)
Before change
<img width="1172" height="135" alt="image" src="https://github.com/user-attachments/assets/e36bb17d-99ca-4c2c-9df9-38b764833a3d" />

After change
<img width="862" height="77" alt="image" src="https://github.com/user-attachments/assets/e81976b3-d3a1-4863-be69-e17c39554c46" />
