### PR TITLE
Build: Swap CycloneDX for Umbraco.Internal.Sbom

### DIFF
--- a/.github/workflows/dependencytrack.yml
+++ b/.github/workflows/dependencytrack.yml
@@ -7,7 +7,11 @@ on:
         description: 'Version to report to Dependency-Track (e.g. 1.16.0)'
         required: true
         type: string
+  pull_request:
   push:
+    branches:
+      - v1/dev
+      - main
     tags:
       - 'v*.*.*'
 
@@ -18,15 +22,34 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      # Node.js SBOM
-      - name: Install CycloneDX Node.js CLI
-        run: npm i -g @cyclonedx/cyclonedx-npm
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
 
-      - name: Generate SBOM for Node.js (frontend)
-        run: cyclonedx-npm --package-lock-only --omit=dev -o sbom.xml
+      # Install fresh every build so the latest central license-override rules apply.
+      - name: Install Umbraco SBOM tool
+        run: dotnet tool install -g Umbraco.Internal.Sbom
 
-      # Upload Node.js SBOM (if exists)
-      - name: Upload Node.js SBOM to Dependency-Track
+      # Runs on every trigger (PRs included) and acts as the license-policy gate:
+      # copyleft/commercial packages fail the build (exit 50). npm ecosystem is
+      # autodetected from the root package-lock.json (covers all workspaces).
+      # Exit 10 = success-with-warnings (unresolved/unknown licenses); it must NOT
+      # fail CI, so we tolerate it and surface a warning.
+      - name: Generate SBOM (enforces license policy)
+        run: |
+          umbraco-sbom . --output-file ./sbom.xml || code=$?
+          code=${code:-0}
+          if [ "$code" -eq 10 ]; then
+            echo "::warning::SBOM generated with unresolved/unknown licenses (exit 10) — treated as success"
+          elif [ "$code" -ne 0 ]; then
+            echo "::error::umbraco-sbom failed with exit code $code"
+            exit "$code"
+          fi
+
+      # Upload only on release tags or manual dispatch — never on PRs/branch pushes.
+      - name: Upload SBOM to Dependency-Track
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         env:
           DTRACK_API_URI: ${{ vars.DTRACK_API_URI }}
           DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}


### PR DESCRIPTION
## What

Replaces the `@cyclonedx/cyclonedx-npm` generator in the Dependency-Track workflow with the new [`Umbraco.Internal.Sbom`](https://github.com/umbraco/Umbraco.Internal.Sbom) global tool, per Bjarke's heads-up in #cms-group. The tool wraps CycloneDX (same output format) but adds central license-policy enforcement, as part of the dependency license tracking / ISO 27001 work to bring down the 60k+ missing licenses in [Dependency-Track](https://dependencytrack.umbraco.io/).

## How

- **Generator swapped** — `dotnet tool install -g Umbraco.Internal.Sbom` + `umbraco-sbom .` (npm ecosystem autodetected from the root `package-lock.json`, which covers all workspaces). Requires .NET 10 on the runner.
- **License gate on every build** — now runs on `pull_request` and pushes to `v1/dev` and `main`, not just release tags. Copyleft/commercial packages fail the build (exit 50).
- **Upload stays release-only** — the Dependency-Track upload is gated to tags (`v*.*.*`) + manual dispatch, matching the guidance that uploads happen on release, not per build. The curl upload itself is unchanged.
- **Exit 10 tolerated** — the tool exits `10` (success-with-warnings) when a package has no discoverable license. Since a bare `run:` step fails on any non-zero code, the step now treats `10` as a warning while still failing on `50` and other error codes.
- **Dropped `npm ci`/setup-node** — a local run showed `inPackageFile=0`; the lockfile's `license` fields resolve everything resolvable, so `node_modules` adds nothing here.

## Verification

Ran `umbraco-sbom .` locally against the current lockfile:

```
Scanned 1264 components (npm)
metadata=1262  inPackageFile=0  override=0  unknown=2  unresolved=0
Policy: permissive=7  copyleft=0  commercial=0  unknown=0  devDependency=1257  violated=0
Exit code: 10
```

- **Policy passes clean** — zero copyleft/commercial, so no `.sbom-policy.json` exceptions needed.
- The 2 unresolved packages (`format@0.2.2`, `only@0.0.2`) are transitive **dev-only** deps with no license field — no impact on the shipped artifact; they're the reason for exit 10.
- Output validated as CycloneDX 1.6.

## Notes

- Intended to merge forward to `main` for v2 as-is — same file path, root still has `package.json`/`package-lock.json`, and v2's runtime deps (Lit + culori) are permissive. The `main` push trigger is already included.
- Dev deps now appear in the DT SBOM with `scope="excluded"` (the old `--omit=dev` dropped them entirely) — more complete, harmless downstream, but component counts in DT will rise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)