### PR TITLE
fix(form-control): restore v1 UUIFormControlMixin name and surface

### DIFF
--- a/docs/MIGRATION-V1-TO-V2.md
+++ b/docs/MIGRATION-V1-TO-V2.md
@@ -148,7 +148,18 @@ The global `Option` interface (previously declared by `uui-select`) has been rep
 + const options: Array<UUISelectOption> = [{ name: 'A', value: 'a' }];
 ```
 
-### 5. Removed public methods on color components
+### 5. Form control mixins
+
+`UUIFormControlMixin` keeps its v1 surface: `name`, `required`, `requiredMessage`, `error`, `errorMessage`, `submit()` and the built-in `valueMissing`/`customError` validators are all still there. Classes extending `UUIFormControlMixin(...)` migrate without changes (only the import path changes, see step 2).
+
+v2 additionally splits the mixin in two:
+
+- `UUIFormControlBaseMixin` — the lean core (form association, `value`, `pristine`, validator machinery) without the basics above. New in v2; use it when your component wants full control over its own properties and validators.
+- `UUIFormControlWithBasicsMixin` — an alias of `UUIFormControlMixin` (base + the basics).
+
+The lean base's types are exported as `UUIFormControlBaseMixinElement`/`UUIFormControlBaseMixinInterface`; the `UUIFormControlMixinElement`/`UUIFormControlMixinInterface` names keep describing the full v1 surface.
+
+### 6. Removed public methods on color components
 
 The `getBrightness()` and `getLightness()` methods have been removed from `UUIColorAreaElement` and `UUIColorPickerElement`. These were HSB↔HSL conversion helpers that have been moved to shared utility functions.
 
@@ -166,7 +177,7 @@ If you were calling these methods on a component instance, use the standalone fu
 
 Note: the shared functions require an explicit `saturation` parameter (the old methods used `this.saturation` implicitly).
 
-### 6. Color picker: colord replaced by culori
+### 7. Color picker: colord replaced by culori
 
 v1 bundled [colord](https://github.com/omgovich/colord) internally. v2 uses [culori](https://github.com/Evercoder/culori) instead, which is an external dependency.
 
@@ -204,7 +215,7 @@ Both old and new formats are valid CSS. Any CSS parser (or `parseColor` from UUI
 + import type { HslaColor } from '@umbraco-ui/uui';
 ```
 
-### 7. Handle removed components
+### 8. Handle removed components
 
 If you used `uui-caret` or `uui-popover`, replace them:
 
@@ -216,7 +227,7 @@ If you used `uui-caret` or `uui-popover`, replace them:
 + <uui-popover-container ...>
 ```
 
-### 8. Update Lit to v3
+### 9. Update Lit to v3
 
 UUI v2 requires Lit ^3.0.0. If your project uses Lit 2, follow the [Lit 2 to 3 upgrade guide](https://lit.dev/docs/releases/upgrade/#lit-2x-to-3.0).
 

--- a/src/components/form-validation-message/form-validation-message.element.ts
+++ b/src/components/form-validation-message/form-validation-message.element.ts
@@ -1,5 +1,5 @@
 import { UUIFormControlEvent } from '../../internal/events/index.js';
-import type { UUIFormControlMixinInterface } from '../../internal/mixins/index.js';
+import type { UUIFormControlBaseMixinInterface } from '../../internal/mixins/index.js';
 import { css, html, LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
@@ -67,7 +67,7 @@ export class UUIFormValidationMessageElement extends LitElement {
   }
 
   private readonly _messages = new Map<
-    UUIFormControlMixinInterface<unknown>,
+    UUIFormControlBaseMixinInterface<unknown>,
     string
   >();
 

--- a/src/internal/events/UUIFormControlEvent.ts
+++ b/src/internal/events/UUIFormControlEvent.ts
@@ -1,9 +1,9 @@
-import type { UUIFormControlMixinInterface } from '../mixins/index.js';
+import type { UUIFormControlBaseMixinInterface } from '../mixins/index.js';
 import { UUIEvent } from './UUIEvent.js';
 
 export class UUIFormControlEvent extends UUIEvent<
   {},
-  UUIFormControlMixinInterface<unknown>
+  UUIFormControlBaseMixinInterface<unknown>
 > {
   constructor(evName: string, eventInit: any = {}) {
     super(evName, {

--- a/src/internal/mixins/FormControlMixin.mdx
+++ b/src/internal/mixins/FormControlMixin.mdx
@@ -5,3 +5,8 @@ import { Meta } from '@storybook/addon-docs/blocks';
 # FormControlMixin
 
 FormControlMixin can be used to make a web component part of a form.
+
+There are two flavours:
+
+- **`UUIFormControlMixin`** — the full mixin, matching the v1 surface. Adds `name`, `required`, `requiredMessage`, `error`, `errorMessage`, `submit()` and the built-in `valueMissing` and `customError` validators on top of the base. Also exported as `UUIFormControlWithBasicsMixin` — the two names are the same mixin.
+- **`UUIFormControlBaseMixin`** — the lean core: form association, `value`, `pristine` and the validator machinery, without the basics above. Use this when your component needs full control over its own properties and validators.

--- a/src/internal/mixins/FormControlMixin.test.ts
+++ b/src/internal/mixins/FormControlMixin.test.ts
@@ -1,0 +1,81 @@
+import { render } from 'vitest-browser-lit';
+import { unsafeStatic, html as staticHtml } from 'lit/static-html.js';
+/* eslint-disable lit/no-invalid-html */
+/* eslint-disable lit/binding-positions */
+import { html, LitElement } from 'lit';
+
+import {
+  UUIFormControlBaseMixin,
+  UUIFormControlMixin,
+  UUIFormControlWithBasicsMixin,
+} from './index.js';
+
+const tagName = 'test-form-control-mixin';
+
+customElements.define(
+  tagName,
+  class FormControlMixinTestElement extends UUIFormControlMixin(
+    LitElement,
+    '',
+  ) {
+    protected getFormElement() {
+      return undefined;
+    }
+
+    render() {
+      return html`<slot></slot>`;
+    }
+  },
+);
+
+const tag = unsafeStatic(tagName);
+
+describe('UUIFormControlMixin', () => {
+  it('is the same mixin as UUIFormControlWithBasicsMixin', () => {
+    expect(UUIFormControlMixin).toBe(UUIFormControlWithBasicsMixin);
+    expect(UUIFormControlMixin).not.toBe(UUIFormControlBaseMixin);
+  });
+
+  describe('element with v1 surface', () => {
+    let element: any;
+
+    beforeEach(async () => {
+      element = render(staticHtml`<${tag}></${tag}>`).container.querySelector(
+        tagName,
+      )!;
+      await element.updateComplete;
+    });
+
+    it('has the v1 basics properties with their defaults', () => {
+      expect(element.name).toBe('');
+      expect(element.required).toBe(false);
+      expect(element.requiredMessage).toBe('This field is required');
+      expect(element.error).toBe(false);
+      expect(element.errorMessage).toBe('This field is invalid');
+      expect(element.submit).toBeInstanceOf(Function);
+    });
+
+    it('flags valueMissing when required and empty', async () => {
+      element.required = true;
+      await element.updateComplete;
+
+      expect(element.checkValidity()).toBe(false);
+      expect(element.validity.valueMissing).toBe(true);
+      expect(element.validationMessage).toBe('This field is required');
+
+      element.value = 'no longer empty';
+      await element.updateComplete;
+
+      expect(element.checkValidity()).toBe(true);
+    });
+
+    it('flags customError when error is set', async () => {
+      element.error = true;
+      await element.updateComplete;
+
+      expect(element.checkValidity()).toBe(false);
+      expect(element.validity.customError).toBe(true);
+      expect(element.validationMessage).toBe('This field is invalid');
+    });
+  });
+});

--- a/src/internal/mixins/FormControlMixin.test.ts
+++ b/src/internal/mixins/FormControlMixin.test.ts
@@ -10,10 +10,14 @@ import {
   UUIFormControlWithBasicsMixin,
 } from './index.js';
 
-const tagName = 'test-form-control-mixin';
+let __defineCECounter = 0;
+function defineCE(klass: CustomElementConstructor): string {
+  const name = `test-${__defineCECounter++}-${Date.now()}`;
+  customElements.define(name, klass);
+  return name;
+}
 
-customElements.define(
-  tagName,
+const tagName = defineCE(
   class FormControlMixinTestElement extends UUIFormControlMixin(
     LitElement,
     '',

--- a/src/internal/mixins/FormControlMixin.ts
+++ b/src/internal/mixins/FormControlMixin.ts
@@ -44,7 +44,9 @@ interface UUIFormControlValidatorConfig {
   weight: number;
 }
 
-export interface UUIFormControlMixinInterface<ValueType> extends LitElement {
+export interface UUIFormControlBaseMixinInterface<
+  ValueType,
+> extends LitElement {
   addValidator: (
     flagKey: FlagTypes,
     getMessageMethod: () => string,
@@ -65,9 +67,9 @@ export interface UUIFormControlMixinInterface<ValueType> extends LitElement {
   pristine: boolean;
 }
 
-export declare abstract class UUIFormControlMixinElement<ValueType>
+export declare abstract class UUIFormControlBaseMixinElement<ValueType>
   extends LitElement
-  implements UUIFormControlMixinInterface<ValueType>
+  implements UUIFormControlBaseMixinInterface<ValueType>
 {
   protected _internals: ElementInternals;
   protected _runValidators(): void;
@@ -99,7 +101,7 @@ export declare abstract class UUIFormControlMixinElement<ValueType>
  * @param {Object} superClass - superclass to be extended.
  * @mixin
  */
-export const UUIFormControlMixin = <
+export const UUIFormControlBaseMixin = <
   ValueType = FormDataEntryValue | FormData,
   T extends HTMLElementConstructor<LitElement> = typeof LitElement,
   DefaultValueType = undefined,
@@ -107,7 +109,7 @@ export const UUIFormControlMixin = <
   superClass: T,
   defaultValue?: DefaultValueType,
 ) => {
-  abstract class UUIFormControlMixinClass extends superClass {
+  abstract class UUIFormControlBaseMixinClass extends superClass {
     /**
      * This is a static class field indicating that the element is can be used inside a native form and participate in its events.
      * It may require a polyfill, check support here https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/attachInternals.
@@ -471,8 +473,8 @@ export const UUIFormControlMixin = <
       return this._internals?.validationMessage;
     }
   }
-  return UUIFormControlMixinClass as unknown as HTMLElementConstructor<
-    UUIFormControlMixinElement<ValueType | DefaultValueType>
+  return UUIFormControlBaseMixinClass as unknown as HTMLElementConstructor<
+    UUIFormControlBaseMixinElement<ValueType | DefaultValueType>
   > &
     T;
 };

--- a/src/internal/mixins/FormControlWithBasicsMixin.ts
+++ b/src/internal/mixins/FormControlWithBasicsMixin.ts
@@ -1,7 +1,8 @@
 import type { LitElement } from 'lit';
 import {
-  UUIFormControlMixin,
-  type UUIFormControlMixinElement,
+  UUIFormControlBaseMixin,
+  type UUIFormControlBaseMixinElement,
+  type UUIFormControlBaseMixinInterface,
 } from './FormControlMixin.js';
 import { property } from 'lit/decorators.js';
 
@@ -10,9 +11,21 @@ type HTMLElementConstructor<T = HTMLElement> = new (...args: any[]) => T;
 /**
  * @internal
  */
+export interface UUIFormControlWithBasicsMixinInterface<
+  ValueType,
+> extends UUIFormControlBaseMixinInterface<ValueType> {
+  /**
+   * Submits the form that this element is a part of. If the element is not part of a form, or if the form has no submit button, this method does nothing.
+   */
+  submit(): void;
+}
+
+/**
+ * @internal
+ */
 export interface UUIFormControlWithBasicsMixinElement<
   ValueType,
-> extends UUIFormControlMixinElement<ValueType> {
+> extends UUIFormControlBaseMixinElement<ValueType> {
   name: string;
   required: boolean;
   requiredMessage: string;
@@ -42,7 +55,7 @@ export const UUIFormControlWithBasicsMixin = <
    * @internal
    */
   abstract class UUIFormControlWithBasicsMixinClass
-    extends UUIFormControlMixin<ValueType, T, DefaultValueType>(
+    extends UUIFormControlBaseMixin<ValueType, T, DefaultValueType>(
       superClass,
       defaultValue,
     )
@@ -114,4 +127,17 @@ export const UUIFormControlWithBasicsMixin = <
     UUIFormControlWithBasicsMixinElement<ValueType | DefaultValueType>
   > &
     T;
+};
+
+/**
+ * The v1 names for this mixin and its types. `UUIFormControlMixin` has the
+ * same surface as it had in v1 (`name`, `required`, `requiredMessage`,
+ * `error`, `errorMessage`, `submit()` and the built-in `valueMissing` and
+ * `customError` validators). The lean core it builds on is exported as
+ * `UUIFormControlBaseMixin`.
+ */
+export {
+  UUIFormControlWithBasicsMixin as UUIFormControlMixin,
+  type UUIFormControlWithBasicsMixinElement as UUIFormControlMixinElement,
+  type UUIFormControlWithBasicsMixinInterface as UUIFormControlMixinInterface,
 };


### PR DESCRIPTION
## Description

For Umbraco CMS 17.6 to move to UUI 2.x, consumers that extend `UUIFormControlMixin` directly must keep the v1 surface. The lean form control mixin ported from the backoffice (#1287) moved the "basics" (`name`, `required`, `requiredMessage`, `error`, `errorMessage`, `submit()` and the built-in `valueMissing`/`customError` validators) into `UUIFormControlWithBasicsMixin`, which changed what the `UUIFormControlMixin` name means compared to v1.

This PR restores the v1 name to the v1 surface:

- The lean core is renamed `UUIFormControlBaseMixin` (+ `UUIFormControlBaseMixinElement`/`UUIFormControlBaseMixinInterface`)
- `UUIFormControlWithBasicsMixin` is now also exported as `UUIFormControlMixin`, including its `Element`/`Interface` types — both names are first-class
- `UUIFormControlEvent` and `uui-form-validation-message` now reference the Base interface (they are driven by the base mixin, which has no basics)
- Adds a contract test asserting the alias identity and the restored v1 surface (basics properties, `valueMissing`, `customError`)
- Documents the split in `FormControlMixin.mdx` and the v1→v2 migration guide

No behavioural change for the UUI components themselves — all 10 form controls already extend `UUIFormControlWithBasicsMixin`.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)