### PR TITLE
Form control mixin: handle late changed value

### DIFF
--- a/src/internal/mixins/FormControlMixin.ts
+++ b/src/internal/mixins/FormControlMixin.ts
@@ -426,9 +426,9 @@ export const UUIFormControlBaseMixin = <
       changedProperties: Map<string | number | symbol, unknown>,
     ) {
       super.updated(changedProperties);
-      // If still pristine and the input had focus and the value has changed, then we need to check validity, as the value might have been changed after focus was left. [NL]
+      // If still pristine and the control has been blurred while pristine, a later value change should trigger validation (e.g. value changed after blur). [NL]
       if (this.pristine && this.#hadFocus && changedProperties.has('value')) {
-        // checkValidity will set pristine to false for it self and all connected form controls and then run validators, hence not running _runValidators() below. [NL]
+        // checkValidity will set pristine to false for itself and all connected form controls and then run validators, so we skip _runValidators() below. [NL]
         this.checkValidity();
       } else {
         this._runValidators();

--- a/src/internal/mixins/FormControlMixin.ts
+++ b/src/internal/mixins/FormControlMixin.ts
@@ -165,6 +165,8 @@ export const UUIFormControlBaseMixin = <
       defaultValue as unknown as DefaultValueType;
     #valueOnFocus: ValueType | DefaultValueType =
       undefined as unknown as DefaultValueType;
+    // A state to capture late edits to the value after focus has been lost, so we can trigger validation for late value changes. [NL]
+    #hadFocus?: boolean;
     protected _internals: ElementInternals;
     #form: HTMLFormElement | null = null;
     readonly #validators: UUIFormControlValidatorConfig[] = [];
@@ -178,8 +180,11 @@ export const UUIFormControlBaseMixin = <
         this.#valueOnFocus = this.value;
       });
       this.addEventListener('blur', () => {
-        if (this.#valueOnFocus !== this.value) {
-          this.checkValidity();
+        if (this.pristine) {
+          this.#hadFocus = true;
+          if (this.#valueOnFocus !== this.value) {
+            this.checkValidity();
+          }
         }
         this.#valueOnFocus = undefined as unknown as
           | ValueType
@@ -421,6 +426,10 @@ export const UUIFormControlBaseMixin = <
 
     updated(changedProperties: Map<string | number | symbol, unknown>) {
       super.updated(changedProperties);
+      // If still pristine and the input had focus and the value has changed, then we need to check validity, as the value might have been changed after focus was left. [NL]
+      if (this.pristine && this.#hadFocus && changedProperties.has('value')) {
+        this.checkValidity();
+      }
       this._runValidators();
     }
 

--- a/src/internal/mixins/FormControlMixin.ts
+++ b/src/internal/mixins/FormControlMixin.ts
@@ -163,8 +163,7 @@ export const UUIFormControlBaseMixin = <
 
     #value: ValueType | DefaultValueType =
       defaultValue as unknown as DefaultValueType;
-    #valueOnFocus: ValueType | DefaultValueType =
-      undefined as unknown as DefaultValueType;
+    #valueOnFocus: ValueType | DefaultValueType | undefined = undefined;
     // A state to capture late edits to the value after focus has been lost, so we can trigger validation for late value changes. [NL]
     #hadFocus?: boolean;
     protected _internals: ElementInternals;
@@ -178,6 +177,7 @@ export const UUIFormControlBaseMixin = <
 
       this.addEventListener('focus', () => {
         this.#valueOnFocus = this.value;
+        this.#hadFocus = false;
       });
       this.addEventListener('blur', () => {
         if (this.pristine) {
@@ -186,9 +186,7 @@ export const UUIFormControlBaseMixin = <
             this.checkValidity();
           }
         }
-        this.#valueOnFocus = undefined as unknown as
-          | ValueType
-          | DefaultValueType;
+        this.#valueOnFocus = undefined;
       });
     }
 
@@ -424,13 +422,17 @@ export const UUIFormControlBaseMixin = <
       }
     }
 
-    updated(changedProperties: Map<string | number | symbol, unknown>) {
+    override updated(
+      changedProperties: Map<string | number | symbol, unknown>,
+    ) {
       super.updated(changedProperties);
       // If still pristine and the input had focus and the value has changed, then we need to check validity, as the value might have been changed after focus was left. [NL]
       if (this.pristine && this.#hadFocus && changedProperties.has('value')) {
+        // checkValidity will set pristine to false for it self and all connected form controls and then run validators, hence not running _runValidators() below. [NL]
         this.checkValidity();
+      } else {
+        this._runValidators();
       }
-      this._runValidators();
     }
 
     readonly #onFormSubmit = () => {
@@ -450,7 +452,9 @@ export const UUIFormControlBaseMixin = <
     }
     public formResetCallback() {
       this.pristine = true;
+      this.#hadFocus = false;
       this.value = this.getInitialValue() ?? this.getDefaultValue();
+      this.#valueOnFocus = undefined;
     }
 
     protected getDefaultValue(): DefaultValueType {

--- a/src/internal/mixins/FormControlMixin.ts
+++ b/src/internal/mixins/FormControlMixin.ts
@@ -165,7 +165,7 @@ export const UUIFormControlBaseMixin = <
       defaultValue as unknown as DefaultValueType;
     #valueOnFocus: ValueType | DefaultValueType | undefined = undefined;
     // A state to capture late edits to the value after focus has been lost, so we can trigger validation for late value changes. [NL]
-    #hadFocus?: boolean;
+    #hadFocus = false;
     protected _internals: ElementInternals;
     #form: HTMLFormElement | null = null;
     readonly #validators: UUIFormControlValidatorConfig[] = [];


### PR DESCRIPTION
In v.2 a component only goes into unpristine mode if the value was changed while the component had focus.

This is a problem.
Example: This surfaced if a Block Editor had a minimum requirement of example 1 Block:
When clicking delete on a block, then input loses focus, and the change happens afterwards via a confirm dialog. This means the component stays in pristine mode and does not show the potential validation feedback.

Solution:
By capturing whether the component has had focus, we can use that to make a later value change trigger unpristine mode.
— Potential downside: if the value got updated by other means (not user interaction), then that would also result in unpristine.
But overall, that is still better than the experience of v.1 where any focus means going into unpristine mode.