### PR TITLE
fix(form-validation-message): clear messages when controls return to pristine

### DIFF
--- a/src/components/form-validation-message/form-validation-message.element.ts
+++ b/src/components/form-validation-message/form-validation-message.element.ts
@@ -71,7 +71,10 @@ export class UUIFormValidationMessageElement extends LitElement {
     string
   >();
 
-  // Controls only dispatch validation events while they are not pristine, so a control going back to pristine (e.g. on form reset) would leave its message behind. The `pristine` property is reflected, so we observe the attribute on the controls we currently show messages for and remove them when they become pristine again. [JOV]
+  // Controls only dispatch validation events while they are not pristine, so a control going
+  // back to pristine (e.g. on form reset) would leave its message behind. The `pristine`
+  // property is reflected, so we observe the attribute on controls we currently show
+  // messages for and remove them when they become pristine again.
   private readonly _pristineObserver = new MutationObserver(entries => {
     let changed = false;
     for (const entry of entries) {

--- a/src/components/form-validation-message/form-validation-message.element.ts
+++ b/src/components/form-validation-message/form-validation-message.element.ts
@@ -71,6 +71,42 @@ export class UUIFormValidationMessageElement extends LitElement {
     string
   >();
 
+  // Controls only dispatch validation events while they are not pristine, so a control going back to pristine (e.g. on form reset) would leave its message behind. The `pristine` property is reflected, so we observe the attribute on the controls we currently show messages for and remove them when they become pristine again. [JOV]
+  private readonly _pristineObserver = new MutationObserver(entries => {
+    let changed = false;
+    for (const entry of entries) {
+      const ctrl = entry.target as UUIFormControlBaseMixinInterface<unknown>;
+      if (ctrl.pristine && this._messages.has(ctrl)) {
+        this._messages.delete(ctrl);
+        changed = true;
+      }
+    }
+    if (changed) {
+      this._observeMessageControls();
+      this.requestUpdate('_messages');
+    }
+  });
+
+  private _observeMessageControls() {
+    this._pristineObserver.disconnect();
+    for (const ctrl of this._messages.keys()) {
+      this._pristineObserver.observe(ctrl, {
+        attributes: true,
+        attributeFilter: ['pristine'],
+      });
+    }
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._pristineObserver.disconnect();
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this._observeMessageControls();
+  }
+
   private readonly _onControlInvalid = (e: UUIFormControlEvent) => {
     const ctrl = (e as any).composedPath()[0];
     if (ctrl.pristine === false) {
@@ -79,12 +115,14 @@ export class UUIFormValidationMessageElement extends LitElement {
     } else {
       this._messages.delete(ctrl);
     }
+    this._observeMessageControls();
     this.requestUpdate('_messages');
   };
 
   private readonly _onControlValid = (e: UUIFormControlEvent) => {
     const ctrl = (e as any).composedPath()[0];
     this._messages.delete(ctrl);
+    this._observeMessageControls();
     this.requestUpdate('_messages');
   };
 

--- a/src/components/form-validation-message/form-validation-message.test.ts
+++ b/src/components/form-validation-message/form-validation-message.test.ts
@@ -12,7 +12,9 @@ describe('UUIFormValidationMessageElement', () => {
   let element: UUIFormValidationMessageElement;
 
   beforeEach(async () => {
-    element = render(html` <uui-form-validation-message></uui-form-validation-message>`).container.querySelector('uui-form-validation-message')!;
+    element = render(
+      html` <uui-form-validation-message></uui-form-validation-message>`,
+    ).container.querySelector('uui-form-validation-message')!;
 
     await element.updateComplete;
   });
@@ -78,6 +80,42 @@ describe('UUIFormValidationMessageElement', () => {
       const regex = /MyRequiredMessage/;
       expect(regex.test(messagesCon.innerHTML)).toBe(true);
     });
+
+    it('clears the validation message when the form is reset', async () => {
+      input.pristine = false;
+      input.checkValidity();
+      await input.updateComplete;
+      await validationEl.updateComplete;
+
+      const messagesCon = validationEl.shadowRoot!.querySelector('#messages')!;
+      expect(/MyRequiredMessage/.test(messagesCon.innerHTML)).toBe(true);
+
+      element.reset();
+      await input.updateComplete;
+      // Wait a tick for the MutationObserver to deliver the pristine attribute change.
+      await new Promise(resolve => setTimeout(resolve, 0));
+      await validationEl.updateComplete;
+
+      expect(input.pristine).toBe(true);
+      expect(/MyRequiredMessage/.test(messagesCon.innerHTML)).toBe(false);
+    });
+
+    it('clears the validation message when the control is set back to pristine', async () => {
+      input.pristine = false;
+      input.checkValidity();
+      await input.updateComplete;
+      await validationEl.updateComplete;
+
+      const messagesCon = validationEl.shadowRoot!.querySelector('#messages')!;
+      expect(/MyRequiredMessage/.test(messagesCon.innerHTML)).toBe(true);
+
+      input.pristine = true;
+      await input.updateComplete;
+      await new Promise(resolve => setTimeout(resolve, 0));
+      await validationEl.updateComplete;
+
+      expect(/MyRequiredMessage/.test(messagesCon.innerHTML)).toBe(false);
+    });
   });
 
   describe('Using for property', () => {
@@ -112,8 +150,7 @@ describe('UUIFormValidationMessageElement', () => {
       await input.updateComplete;
       await validationEl.updateComplete;
 
-      const messagesCon =
-        validationEl.shadowRoot!.querySelector('#messages')!;
+      const messagesCon = validationEl.shadowRoot!.querySelector('#messages')!;
       const regex = /MyRequiredMessage/;
 
       expect(regex.test(messagesCon.innerHTML)).toBe(true);


### PR DESCRIPTION
## Summary

- `uui-form-validation-message` builds its message list from VALID/INVALID events, but form controls only dispatch those while **not pristine** — so a control returning to pristine (via `form.reset()` or programmatically) left its validation message on screen forever
- Since `pristine` is a reflected attribute, the component now observes it (`MutationObserver`, filtered to the `pristine` attribute, only on controls it currently shows messages for) and removes the message when a control becomes pristine again
- No change to the FormControlMixin event contract — dispatching events while pristine would ripple into every consumer, so the fix stays local to the message component
- Pre-existing behaviour since v1; found during a holistic review of `UUIFormControlMixin`

## How to test

1. Create a `uui-form` wrapping a `<form>` with a required `uui-input`, a `uui-form-validation-message`, plus submit and reset buttons
2. Submit the empty form — the required message appears
3. Press reset — before this fix the message stayed; now it clears

## Test plan

- [x] Two new tests: message clears on `form.reset()` and on programmatic `pristine = true` — both fail without the fix, pass with it
- [x] All 9 `form-validation-message` tests pass
- [ ] Full CI suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)