### PR TITLE
fix(uui-table): add box-sizing so width:100% + border doesn't overflow

### DIFF
--- a/src/components/table/table.element.ts
+++ b/src/components/table/table.element.ts
@@ -23,6 +23,7 @@ export class UUITableElement extends LitElement {
     css`
       :host {
         display: block;
+        box-sizing: border-box;
         width: 100%;
         background-color: var(--uui-color-surface);
 

--- a/src/components/table/table.test.ts
+++ b/src/components/table/table.test.ts
@@ -71,6 +71,29 @@ describe('UuiTable', () => {
     expect(row.selected).toBe(false);
   });
 
+  it('does not render wider than its container (box-sizing)', async () => {
+    // Regression: the host sets `width: 100%` and a 1px border, so without
+    // `box-sizing: border-box` the border is added outside the width and the
+    // element renders 2px wider than its container.
+    const wrapper = render(html`
+      <div style="width: 400px; padding: 0; border: 0">
+        <uui-table>
+          <uui-table-head>
+            <uui-table-head-cell>A</uui-table-head-cell>
+            <uui-table-head-cell>B</uui-table-head-cell>
+          </uui-table-head>
+          <uui-table-row>
+            <uui-table-cell>1</uui-table-cell>
+            <uui-table-cell>2</uui-table-cell>
+          </uui-table-row>
+        </uui-table>
+      </div>
+    `).container.firstElementChild as HTMLElement;
+    const constrained = wrapper.querySelector('uui-table') as UUITableElement;
+    await constrained.updateComplete;
+    expect(constrained.offsetWidth).toBe(wrapper.clientWidth);
+  });
+
   it('passes the a11y audit', async () => {
     expect(await axeRun(table)).toHaveNoViolations();
   });


### PR DESCRIPTION
## Description

`uui-table`'s `:host` sets `display: block; width: 100%` together with a 1px border, but does not set `box-sizing`. Custom elements default to `content-box`, so the border is added *outside* the 100% width — the element renders 2px wider than its container.

This one-line change adds `box-sizing: border-box` to the host so the border is included within `width: 100%`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and context

When `uui-table` is placed in a width-constrained container (e.g. a backoffice collection view whose scroll area is exactly the content width), the extra 2px pushes past the container and triggers a spurious horizontal scrollbar. The table also can't be sized predictably because its rendered width is `100% + 2px`.

`box-sizing: border-box` is the conventional fix for a `width: 100%` + border element and matches the expectation that a full-width component fits its container.

## How to test?

1. Put `<uui-table>` inside a container that is exactly as wide as the table (no horizontal padding).
2. Before: the container shows a ~2px horizontal scrollbar; `table.offsetWidth` is `containerWidth + 2`.
3. After: no scrollbar; `offsetWidth === containerWidth`.

## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
