### PR TITLE
Add aria attributes to progress bar

### DIFF
--- a/src/components/progress-bar/progress-bar.element.ts
+++ b/src/components/progress-bar/progress-bar.element.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import { property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 const clamp = (num: number, min: number, max: number) =>
@@ -10,6 +11,16 @@ const clamp = (num: number, min: number, max: number) =>
  */
 export class UUIProgressBarElement extends LitElement {
   private _progress = 0;
+
+  /**
+   * Accessible label for the progress bar.
+   * @type {string}
+   * @attr label
+   * @default undefined
+   */
+  @property({ type: String })
+  label?: string;
+
   /**
    * Set this to a number between 0 and 100 to reflect the progress of some operation.
    * @type {number}
@@ -33,7 +44,20 @@ export class UUIProgressBarElement extends LitElement {
 
   render() {
     return html`
-      <div id="bar" style=${styleMap(this._getProgressStyle())}></div>
+      <progress
+        id="bar"
+        aria-label=${ifDefined(
+          this.getAttribute('aria-label') || this.label || undefined,
+        )}
+        aria-labelledby=${ifDefined(
+          this.getAttribute('aria-labelledby') || undefined,
+        )}
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow=${this._progress}
+        value=${this._progress}
+        max="100"
+        style=${styleMap(this._getProgressStyle())}></progress>
     `;
   }
 

--- a/src/components/progress-bar/progress-bar.element.ts
+++ b/src/components/progress-bar/progress-bar.element.ts
@@ -151,11 +151,11 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
         animation: progress-bar-loading 1s infinite linear;
       }
 
-      :host([status='finished']) #bar {
+      :host([status='finished']:not([indeterminate])) #bar {
         background: var(--uui-color-positive);
       }
 
-      :host([status='error']) #bar {
+      :host([status='error']:not([indeterminate])) #bar {
         background: var(--uui-color-invalid);
       }
 

--- a/src/components/progress-bar/progress-bar.element.ts
+++ b/src/components/progress-bar/progress-bar.element.ts
@@ -63,8 +63,9 @@ export class UUIProgressBarElement extends LitElement {
 
   render() {
     return html`
-      <progress
+      <div
         id="bar"
+        role="progressbar"
         aria-label=${ifDefined(
           this.getAttribute('aria-label') || this.label || undefined,
         )}
@@ -76,7 +77,7 @@ export class UUIProgressBarElement extends LitElement {
         aria-valuenow=${this._progress}
         value=${this._progress}
         max=${this._max}
-        style=${styleMap(this._getProgressStyle())}></progress>
+        style=${styleMap(this._getProgressStyle())}></div>
     `;
   }
 

--- a/src/components/progress-bar/progress-bar.element.ts
+++ b/src/components/progress-bar/progress-bar.element.ts
@@ -2,25 +2,15 @@ import { LitElement, html, css } from 'lit';
 import { property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
-
-const clamp = (num: number, min: number, max: number) =>
-  Math.min(Math.max(num, min), max);
+import { LabelMixin } from '../../internal/mixins/index.js';
+import { clamp } from './math.js';
 
 /**
  * @element uui-progress-bar
  */
-export class UUIProgressBarElement extends LitElement {
+export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
   private _progress = 0;
   private _max = 100;
-
-  /**
-   * Accessible label for the progress bar.
-   * @type {string}
-   * @attr label
-   * @default undefined
-   */
-  @property({ type: String })
-  label?: string;
 
   /**
    * Maximum value of the progress bar.

--- a/src/components/progress-bar/progress-bar.element.ts
+++ b/src/components/progress-bar/progress-bar.element.ts
@@ -35,7 +35,8 @@ export class UUIProgressBarElement extends LitElement {
 
   set max(newVal) {
     const oldVal = this._max;
-    this._max = Math.max(newVal, 1);
+    const next = Number.isFinite(newVal) ? newVal : 1;
+    this._max = Math.max(next, 1);
     this._progress = clamp(this._progress, 0, this._max);
     this.requestUpdate('max', oldVal);
   }

--- a/src/components/progress-bar/progress-bar.element.ts
+++ b/src/components/progress-bar/progress-bar.element.ts
@@ -9,9 +9,6 @@ export type UUIProgressBarStatus = 'in-progress' | 'finished' | 'error';
 
 /**
  * @element uui-progress-bar
- * @cssprop --uui-progress-bar-color-in-progress - Bar color when status is `in-progress`.
- * @cssprop --uui-progress-bar-color-finished - Bar color when status is `finished`.
- * @cssprop --uui-progress-bar-color-error - Bar color when status is `error`.
  */
 export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
   private _progress = 0;
@@ -116,24 +113,18 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
 
       #bar {
         transition: width 250ms ease;
-        background: var(
-          --uui-progress-bar-color-in-progress,
-          var(--uui-color-positive)
-        );
+        background: var(--uui-color-default);
         height: 100%;
         border-radius: 2px;
         width: 0%;
       }
 
       :host([status='finished']) #bar {
-        background: var(
-          --uui-progress-bar-color-finished,
-          var(--uui-color-positive)
-        );
+        background: var(--uui-color-positive);
       }
 
       :host([status='error']) #bar {
-        background: var(--uui-progress-bar-color-error, var(--uui-color-danger));
+        background: var(--uui-color-invalid);
       }
     `,
   ];

--- a/src/components/progress-bar/progress-bar.element.ts
+++ b/src/components/progress-bar/progress-bar.element.ts
@@ -9,6 +9,9 @@ export type UUIProgressBarStatus = 'in-progress' | 'finished' | 'error';
 
 /**
  * @element uui-progress-bar
+ * @cssprop --uui-progress-bar-color-in-progress - Bar color when status is `in-progress`.
+ * @cssprop --uui-progress-bar-color-finished - Bar color when status is `finished`.
+ * @cssprop --uui-progress-bar-color-error - Bar color when status is `error`.
  */
 export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
   private _progress = 0;
@@ -88,7 +91,8 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
         aria-labelledby=${ifDefined(
           this.getAttribute('aria-labelledby') || undefined,
         )}
-        aria-busy=${ifDefined(indeterminate ? 'true' : undefined)}
+        aria-busy=${!isFinished}
+        aria-invalid=${isError}
         aria-valuemin=${ifDefined(indeterminate ? undefined : '0')}
         aria-valuemax=${ifDefined(indeterminate ? undefined : `${this._max}`)}
         aria-valuenow=${ifDefined(
@@ -112,10 +116,24 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
 
       #bar {
         transition: width 250ms ease;
-        background: var(--uui-color-positive);
+        background: var(
+          --uui-progress-bar-color-in-progress,
+          var(--uui-color-positive)
+        );
         height: 100%;
         border-radius: 2px;
         width: 0%;
+      }
+
+      :host([status='finished']) #bar {
+        background: var(
+          --uui-progress-bar-color-finished,
+          var(--uui-color-positive)
+        );
+      }
+
+      :host([status='error']) #bar {
+        background: var(--uui-progress-bar-color-error, var(--uui-color-danger));
       }
     `,
   ];

--- a/src/components/progress-bar/progress-bar.element.ts
+++ b/src/components/progress-bar/progress-bar.element.ts
@@ -3,7 +3,7 @@ import { property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { LabelMixin } from '../../internal/mixins/index.js';
-import { clamp } from './math.js';
+import { clamp } from '../../internal/utils/index.js';
 
 /**
  * @element uui-progress-bar

--- a/src/components/progress-bar/progress-bar.element.ts
+++ b/src/components/progress-bar/progress-bar.element.ts
@@ -69,8 +69,10 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
     this.requestUpdate('progress', oldVal);
   }
 
-  private _getProgressStyle() {
-    return { width: `${(this._progress / this._max) * 100}%` };
+  private _getProgressStyle(indeterminate: boolean) {
+    return {
+      width: indeterminate ? '100%' : `${(this._progress / this._max) * 100}%`,
+    };
   }
 
   render() {
@@ -81,6 +83,7 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
     return html`
       <div
         id="bar"
+        class=${indeterminate ? 'indeterminate' : ''}
         role="progressbar"
         aria-label=${ifDefined(
           this.getAttribute('aria-label') || this.label || undefined,
@@ -95,7 +98,7 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
         aria-valuenow=${ifDefined(
           indeterminate ? undefined : `${this._progress}`,
         )}
-        style=${styleMap(this._getProgressStyle())}></div>
+        style=${styleMap(this._getProgressStyle(indeterminate))}></div>
     `;
   }
 
@@ -112,11 +115,32 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
       }
 
       #bar {
+        position: relative;
         transition: width 250ms ease;
         background: var(--uui-color-default);
         height: 100%;
         border-radius: 2px;
         width: 0%;
+      }
+
+      #bar.indeterminate {
+        width: 100%;
+        background: transparent;
+      }
+
+      #bar.indeterminate::before {
+        content: '';
+        position: absolute;
+        display: block;
+        inset: 0;
+        background: linear-gradient(
+          -90deg,
+          var(--uui-color-default) 0%,
+          var(--uui-color-default) 25%,
+          transparent 100%
+        );
+        transform: scaleX(0.4);
+        animation: progress-bar-loading 1s infinite linear;
       }
 
       :host([status='finished']) #bar {
@@ -125,6 +149,15 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
 
       :host([status='error']) #bar {
         background: var(--uui-color-invalid);
+      }
+
+      @keyframes progress-bar-loading {
+        0% {
+          transform-origin: -175% 0%;
+        }
+        100% {
+          transform-origin: 175% 0%;
+        }
       }
     `,
   ];

--- a/src/components/progress-bar/progress-bar.element.ts
+++ b/src/components/progress-bar/progress-bar.element.ts
@@ -11,6 +11,7 @@ const clamp = (num: number, min: number, max: number) =>
  */
 export class UUIProgressBarElement extends LitElement {
   private _progress = 0;
+  private _max = 100;
 
   /**
    * Accessible label for the progress bar.
@@ -20,6 +21,24 @@ export class UUIProgressBarElement extends LitElement {
    */
   @property({ type: String })
   label?: string;
+
+  /**
+   * Maximum value of the progress bar.
+   * @type {number}
+   * @attr max
+   * @default 100
+   */
+  @property({ type: Number })
+  get max() {
+    return this._max;
+  }
+
+  set max(newVal) {
+    const oldVal = this._max;
+    this._max = Math.max(newVal, 1);
+    this._progress = clamp(this._progress, 0, this._max);
+    this.requestUpdate('max', oldVal);
+  }
 
   /**
    * Set this to a number between 0 and 100 to reflect the progress of some operation.
@@ -34,12 +53,12 @@ export class UUIProgressBarElement extends LitElement {
 
   set progress(newVal) {
     const oldVal = this._progress;
-    this._progress = clamp(newVal, 0, 100);
+    this._progress = clamp(newVal, 0, this._max);
     this.requestUpdate('progress', oldVal);
   }
 
   private _getProgressStyle() {
-    return { width: `${this._progress}%` };
+    return { width: `${(this._progress / this._max) * 100}%` };
   }
 
   render() {
@@ -53,10 +72,10 @@ export class UUIProgressBarElement extends LitElement {
           this.getAttribute('aria-labelledby') || undefined,
         )}
         aria-valuemin="0"
-        aria-valuemax="100"
+        aria-valuemax=${this._max}
         aria-valuenow=${this._progress}
         value=${this._progress}
-        max="100"
+        max=${this._max}
         style=${styleMap(this._getProgressStyle())}></progress>
     `;
   }

--- a/src/components/progress-bar/progress-bar.element.ts
+++ b/src/components/progress-bar/progress-bar.element.ts
@@ -5,12 +5,24 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { LabelMixin } from '../../internal/mixins/index.js';
 import { clamp } from '../../internal/utils/index.js';
 
+export type UUIProgressBarStatus = 'in-progress' | 'finished' | 'error';
+
 /**
  * @element uui-progress-bar
  */
 export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
   private _progress = 0;
+  private _hasProgressValue = false;
   private _max = 100;
+
+  /**
+   * Status of the tracked operation.
+   * @type {UUIProgressBarStatus}
+   * @attr
+   * @default 'in-progress'
+   */
+  @property({ type: String, reflect: true })
+  status: UUIProgressBarStatus = 'in-progress';
 
   /**
    * Maximum value of the progress bar.
@@ -27,12 +39,15 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
     const oldVal = this._max;
     const next = Number.isFinite(newVal) ? newVal : 1;
     this._max = Math.max(next, 1);
-    this._progress = clamp(this._progress, 0, this._max);
+    if (this._hasProgressValue) {
+      this._progress = clamp(this._progress, 0, this._max);
+    }
     this.requestUpdate('max', oldVal);
   }
 
   /**
    * Set this to a number between 0 and `max` to reflect the progress of some operation.
+   * Invalid or omitted values are treated as indeterminate progress.
    * @type {number}
    * @attr
    * @default 0
@@ -42,9 +57,15 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
     return this._progress;
   }
 
-  set progress(newVal) {
+  set progress(newVal: number | undefined) {
     const oldVal = this._progress;
-    this._progress = clamp(newVal, 0, this._max);
+    if (typeof newVal === 'number' && Number.isFinite(newVal)) {
+      this._hasProgressValue = true;
+      this._progress = clamp(newVal, 0, this._max);
+    } else {
+      this._hasProgressValue = false;
+      this._progress = 0;
+    }
     this.requestUpdate('progress', oldVal);
   }
 
@@ -53,6 +74,10 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
   }
 
   render() {
+    const isFinished = this.status === 'finished';
+    const isError = this.status === 'error';
+    const indeterminate = !isFinished && !isError && !this._hasProgressValue;
+
     return html`
       <div
         id="bar"
@@ -63,9 +88,12 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
         aria-labelledby=${ifDefined(
           this.getAttribute('aria-labelledby') || undefined,
         )}
-        aria-valuemin="0"
-        aria-valuemax=${this._max}
-        aria-valuenow=${this._progress}
+        aria-busy=${ifDefined(indeterminate ? 'true' : undefined)}
+        aria-valuemin=${ifDefined(indeterminate ? undefined : '0')}
+        aria-valuemax=${ifDefined(indeterminate ? undefined : `${this._max}`)}
+        aria-valuenow=${ifDefined(
+          indeterminate ? undefined : `${this._progress}`,
+        )}
         style=${styleMap(this._getProgressStyle())}></div>
     `;
   }

--- a/src/components/progress-bar/progress-bar.element.ts
+++ b/src/components/progress-bar/progress-bar.element.ts
@@ -75,8 +75,6 @@ export class UUIProgressBarElement extends LitElement {
         aria-valuemin="0"
         aria-valuemax=${this._max}
         aria-valuenow=${this._progress}
-        value=${this._progress}
-        max=${this._max}
         style=${styleMap(this._getProgressStyle())}></div>
     `;
   }

--- a/src/components/progress-bar/progress-bar.element.ts
+++ b/src/components/progress-bar/progress-bar.element.ts
@@ -41,7 +41,7 @@ export class UUIProgressBarElement extends LitElement {
   }
 
   /**
-   * Set this to a number between 0 and 100 to reflect the progress of some operation.
+   * Set this to a number between 0 and `max` to reflect the progress of some operation.
    * @type {number}
    * @attr
    * @default 0

--- a/src/components/progress-bar/progress-bar.element.ts
+++ b/src/components/progress-bar/progress-bar.element.ts
@@ -16,6 +16,15 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
   private _max = 100;
 
   /**
+   * Puts the progress bar into indeterminate mode.
+   * @type {boolean}
+   * @attr
+   * @default false
+   */
+  @property({ type: Boolean, reflect: true })
+  indeterminate = false;
+
+  /**
    * Status of the tracked operation.
    * @type {UUIProgressBarStatus}
    * @attr
@@ -47,7 +56,7 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
 
   /**
    * Set this to a number between 0 and `max` to reflect the progress of some operation.
-   * Invalid or omitted values are treated as indeterminate progress.
+   * Invalid or omitted values are treated as `0`.
    * @type {number}
    * @attr
    * @default 0
@@ -78,12 +87,11 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
   render() {
     const isFinished = this.status === 'finished';
     const isError = this.status === 'error';
-    const indeterminate = !isFinished && !isError && !this._hasProgressValue;
+    const indeterminate = this.indeterminate;
 
     return html`
       <div
         id="bar"
-        class=${indeterminate ? 'indeterminate' : ''}
         role="progressbar"
         aria-label=${ifDefined(
           this.getAttribute('aria-label') || this.label || undefined,
@@ -123,12 +131,12 @@ export class UUIProgressBarElement extends LabelMixin('label', LitElement) {
         width: 0%;
       }
 
-      #bar.indeterminate {
+      :host([indeterminate]) #bar {
         width: 100%;
         background: transparent;
       }
 
-      #bar.indeterminate::before {
+      :host([indeterminate]) #bar::before {
         content: '';
         position: absolute;
         display: block;

--- a/src/components/progress-bar/progress-bar.story.ts
+++ b/src/components/progress-bar/progress-bar.story.ts
@@ -24,3 +24,38 @@ export const Default: Story = {
     progress: 50,
   },
 };
+
+export const Fraction: Story = {
+  args: {
+    progress: 3,
+    max: 10,
+    label: 'Upload progress',
+  },
+  render: args => html`
+    <div style="display: flex; flex-direction: column; gap: 8px; width: 100%;">
+      <uui-progress-bar ${spread(args)}></uui-progress-bar>
+      <span>${args.progress}/${args.max}</span>
+    </div>
+  `,
+};
+
+export const Percentage: Story = {
+  args: {
+    progress: 35,
+    max: 100,
+    label: 'Upload progress',
+  },
+  render: args => {
+    const percentage = Math.round(
+      (Number(args.progress) / Number(args.max)) * 100,
+    );
+
+    return html`
+      <div
+        style="display: flex; flex-direction: column; gap: 8px; width: 100%;">
+        <uui-progress-bar ${spread(args)}></uui-progress-bar>
+        <span>${percentage}%</span>
+      </div>
+    `;
+  },
+};

--- a/src/components/progress-bar/progress-bar.story.ts
+++ b/src/components/progress-bar/progress-bar.story.ts
@@ -63,7 +63,8 @@ export const Percentage: Story = {
 export const Indeterminate: Story = {
   args: {
     label: 'Loading content',
-    status: 'in-progress',
+    status: 'error',
+    indeterminate: true,
   },
   render: args => html`<uui-progress-bar ${spread(args)}></uui-progress-bar>`,
 };

--- a/src/components/progress-bar/progress-bar.story.ts
+++ b/src/components/progress-bar/progress-bar.story.ts
@@ -72,28 +72,28 @@ export const Indeterminate: Story = {
 export const Status: Story = {
   render: () => html`
     <div style="display: flex; flex-direction: column; gap: 12px; width: 100%;">
-      <div style="display: flex; flex-direction: column; gap: 4px;">
-        <span>In Progress</span>
+      <div style="display: flex; flex-direction: column; gap: 8px;">
         <uui-progress-bar
           label="In progress"
           status="in-progress"
           progress="45"></uui-progress-bar>
+        <span>In Progress</span>
       </div>
 
-      <div style="display: flex; flex-direction: column; gap: 4px;">
-        <span>Finished</span>
+      <div style="display: flex; flex-direction: column; gap: 8px;">
         <uui-progress-bar
           label="Finished"
           status="finished"
           progress="100"></uui-progress-bar>
+        <span>Finished</span>
       </div>
 
-      <div style="display: flex; flex-direction: column; gap: 4px;">
-        <span>Error</span>
+      <div style="display: flex; flex-direction: column; gap: 8px;">
         <uui-progress-bar
           label="Error"
           status="error"
-          progress="45"></uui-progress-bar>
+          progress="75"></uui-progress-bar>
+        <span>Error</span>
       </div>
     </div>
   `,

--- a/src/components/progress-bar/progress-bar.story.ts
+++ b/src/components/progress-bar/progress-bar.story.ts
@@ -59,3 +59,41 @@ export const Percentage: Story = {
     `;
   },
 };
+
+export const Indeterminate: Story = {
+  args: {
+    label: 'Loading content',
+    status: 'in-progress',
+  },
+  render: args => html`<uui-progress-bar ${spread(args)}></uui-progress-bar>`,
+};
+
+export const Status: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 12px; width: 100%;">
+      <div style="display: flex; flex-direction: column; gap: 4px;">
+        <span>In Progress</span>
+        <uui-progress-bar
+          label="In progress"
+          status="in-progress"
+          progress="45"></uui-progress-bar>
+      </div>
+
+      <div style="display: flex; flex-direction: column; gap: 4px;">
+        <span>Finished</span>
+        <uui-progress-bar
+          label="Finished"
+          status="finished"
+          progress="100"></uui-progress-bar>
+      </div>
+
+      <div style="display: flex; flex-direction: column; gap: 4px;">
+        <span>Error</span>
+        <uui-progress-bar
+          label="Error"
+          status="error"
+          progress="45"></uui-progress-bar>
+      </div>
+    </div>
+  `,
+};

--- a/src/components/progress-bar/progress-bar.test.ts
+++ b/src/components/progress-bar/progress-bar.test.ts
@@ -24,7 +24,7 @@ describe('UUIProgressBarElement', () => {
     expect(element.progress).toBe(0);
   });
 
-  it('clamps the progress values greater then 100 to 100', async () => {
+  it('clamps the progress values greater than 100 to 100', async () => {
     element.progress = 200;
     expect(element.progress).toBe(100);
   });
@@ -61,5 +61,62 @@ describe('UUIProgressBarElement', () => {
     await element.updateComplete;
     const bar = element.shadowRoot?.getElementById('bar');
     expect(bar?.getAttribute('aria-valuemax')).toBe('40');
+  });
+
+  it('updates aria-valuenow when progress is clamped after lowering max', async () => {
+    element.progress = 80;
+    element.max = 40;
+    await element.updateComplete;
+
+    expect(element.progress).toBe(40);
+    expect(
+      element.shadowRoot?.getElementById('bar')?.getAttribute('aria-valuenow'),
+    ).toBe('40');
+  });
+
+  it('sets aria-valuemin and aria-valuenow from current values', async () => {
+    element.max = 40;
+    element.progress = 10;
+    await element.updateComplete;
+
+    expect(
+      element.shadowRoot?.getElementById('bar')?.getAttribute('aria-valuemin'),
+    ).toBe('0');
+    expect(
+      element.shadowRoot?.getElementById('bar')?.getAttribute('aria-valuemax'),
+    ).toBe('40');
+    expect(
+      element.shadowRoot?.getElementById('bar')?.getAttribute('aria-valuenow'),
+    ).toBe('10');
+  });
+
+  it('uses label property for aria-label when aria-label attribute is not set', async () => {
+    element.label = 'Upload progress';
+    await element.updateComplete;
+
+    expect(
+      element.shadowRoot?.getElementById('bar')?.getAttribute('aria-label'),
+    ).toBe('Upload progress');
+  });
+
+  it('prefers aria-label attribute over label property', async () => {
+    element.label = 'Property label';
+    element.setAttribute('aria-label', 'Attribute label');
+    await element.updateComplete;
+
+    expect(
+      element.shadowRoot?.getElementById('bar')?.getAttribute('aria-label'),
+    ).toBe('Attribute label');
+  });
+
+  it('forwards aria-labelledby attribute to the inner progressbar element', async () => {
+    element.setAttribute('aria-labelledby', 'progress-heading');
+    await element.updateComplete;
+
+    expect(
+      element.shadowRoot
+        ?.getElementById('bar')
+        ?.getAttribute('aria-labelledby'),
+    ).toBe('progress-heading');
   });
 });

--- a/src/components/progress-bar/progress-bar.test.ts
+++ b/src/components/progress-bar/progress-bar.test.ts
@@ -49,6 +49,7 @@ describe('UUIProgressBarElement', () => {
 
     const bar = element.shadowRoot?.getElementById('bar');
     expect(bar?.getAttribute('aria-busy')).toBe('true');
+    expect(bar?.getAttribute('aria-invalid')).toBe('false');
     expect(bar?.hasAttribute('aria-valuemin')).toBe(false);
     expect(bar?.hasAttribute('aria-valuemax')).toBe(false);
     expect(bar?.hasAttribute('aria-valuenow')).toBe(false);
@@ -59,7 +60,8 @@ describe('UUIProgressBarElement', () => {
     await element.updateComplete;
 
     const bar = element.shadowRoot?.getElementById('bar');
-    expect(bar?.hasAttribute('aria-busy')).toBe(false);
+    expect(bar?.getAttribute('aria-busy')).toBe('true');
+    expect(bar?.getAttribute('aria-invalid')).toBe('false');
     expect(bar?.getAttribute('aria-valuemin')).toBe('0');
     expect(bar?.getAttribute('aria-valuemax')).toBe('100');
     expect(bar?.getAttribute('aria-valuenow')).toBe('10');
@@ -71,10 +73,20 @@ describe('UUIProgressBarElement', () => {
     await element.updateComplete;
 
     const bar = element.shadowRoot?.getElementById('bar');
-    expect(bar?.hasAttribute('aria-busy')).toBe(false);
+    expect(bar?.getAttribute('aria-busy')).toBe('false');
+    expect(bar?.getAttribute('aria-invalid')).toBe('false');
     expect(bar?.getAttribute('aria-valuemin')).toBe('0');
     expect(bar?.getAttribute('aria-valuemax')).toBe('100');
     expect(bar?.getAttribute('aria-valuenow')).toBe('0');
+  });
+
+  it('sets aria-invalid when status is error', async () => {
+    element.status = 'error';
+    await element.updateComplete;
+
+    const bar = element.shadowRoot?.getElementById('bar');
+    expect(bar?.getAttribute('aria-busy')).toBe('true');
+    expect(bar?.getAttribute('aria-invalid')).toBe('true');
   });
 
   it('clamps existing progress when max is lowered', async () => {

--- a/src/components/progress-bar/progress-bar.test.ts
+++ b/src/components/progress-bar/progress-bar.test.ts
@@ -55,6 +55,22 @@ describe('UUIProgressBarElement', () => {
     expect(bar?.hasAttribute('aria-valuenow')).toBe(false);
   });
 
+  it('applies indeterminate animation class when progress is omitted', async () => {
+    element.progress = undefined as unknown as number;
+    await element.updateComplete;
+
+    const bar = element.shadowRoot?.getElementById('bar');
+    expect(bar?.classList.contains('indeterminate')).toBe(true);
+  });
+
+  it('removes indeterminate animation class when progress is determinate', async () => {
+    element.progress = 10;
+    await element.updateComplete;
+
+    const bar = element.shadowRoot?.getElementById('bar');
+    expect(bar?.classList.contains('indeterminate')).toBe(false);
+  });
+
   it('sets aria value attributes when progress is determinate', async () => {
     element.progress = 10;
     await element.updateComplete;

--- a/src/components/progress-bar/progress-bar.test.ts
+++ b/src/components/progress-bar/progress-bar.test.ts
@@ -44,7 +44,7 @@ describe('UUIProgressBarElement', () => {
   });
 
   it('sets aria-busy when progress is indeterminate', async () => {
-    element.progress = undefined as unknown as number;
+    element.indeterminate = true;
     await element.updateComplete;
 
     const bar = element.shadowRoot?.getElementById('bar');
@@ -55,20 +55,19 @@ describe('UUIProgressBarElement', () => {
     expect(bar?.hasAttribute('aria-valuenow')).toBe(false);
   });
 
-  it('applies indeterminate animation class when progress is omitted', async () => {
-    element.progress = undefined as unknown as number;
+  it('reflects indeterminate attribute when enabled', async () => {
+    element.indeterminate = true;
     await element.updateComplete;
 
-    const bar = element.shadowRoot?.getElementById('bar');
-    expect(bar?.classList.contains('indeterminate')).toBe(true);
+    expect(element.hasAttribute('indeterminate')).toBe(true);
   });
 
-  it('removes indeterminate animation class when progress is determinate', async () => {
+  it('removes reflected indeterminate attribute when disabled', async () => {
     element.progress = 10;
+    element.indeterminate = false;
     await element.updateComplete;
 
-    const bar = element.shadowRoot?.getElementById('bar');
-    expect(bar?.classList.contains('indeterminate')).toBe(false);
+    expect(element.hasAttribute('indeterminate')).toBe(false);
   });
 
   it('sets aria value attributes when progress is determinate', async () => {

--- a/src/components/progress-bar/progress-bar.test.ts
+++ b/src/components/progress-bar/progress-bar.test.ts
@@ -108,15 +108,4 @@ describe('UUIProgressBarElement', () => {
       element.shadowRoot?.getElementById('bar')?.getAttribute('aria-label'),
     ).toBe('Attribute label');
   });
-
-  it('forwards aria-labelledby attribute to the inner progressbar element', async () => {
-    element.setAttribute('aria-labelledby', 'progress-heading');
-    await element.updateComplete;
-
-    expect(
-      element.shadowRoot
-        ?.getElementById('bar')
-        ?.getAttribute('aria-labelledby'),
-    ).toBe('progress-heading');
-  });
 });

--- a/src/components/progress-bar/progress-bar.test.ts
+++ b/src/components/progress-bar/progress-bar.test.ts
@@ -35,6 +35,48 @@ describe('UUIProgressBarElement', () => {
     expect(element.progress).toBe(25);
   });
 
+  it('defaults progress to 0 when set to undefined', async () => {
+    element.progress = undefined as unknown as number;
+    await element.updateComplete;
+
+    expect(element.progress).toBe(0);
+    expect(element.shadowRoot?.getElementById('bar')?.style.width).toBe('0%');
+  });
+
+  it('sets aria-busy when progress is indeterminate', async () => {
+    element.progress = undefined as unknown as number;
+    await element.updateComplete;
+
+    const bar = element.shadowRoot?.getElementById('bar');
+    expect(bar?.getAttribute('aria-busy')).toBe('true');
+    expect(bar?.hasAttribute('aria-valuemin')).toBe(false);
+    expect(bar?.hasAttribute('aria-valuemax')).toBe(false);
+    expect(bar?.hasAttribute('aria-valuenow')).toBe(false);
+  });
+
+  it('sets aria value attributes when progress is determinate', async () => {
+    element.progress = 10;
+    await element.updateComplete;
+
+    const bar = element.shadowRoot?.getElementById('bar');
+    expect(bar?.hasAttribute('aria-busy')).toBe(false);
+    expect(bar?.getAttribute('aria-valuemin')).toBe('0');
+    expect(bar?.getAttribute('aria-valuemax')).toBe('100');
+    expect(bar?.getAttribute('aria-valuenow')).toBe('10');
+  });
+
+  it('sets aria value attributes when status is finished and progress is omitted', async () => {
+    element.status = 'finished';
+    element.progress = undefined as unknown as number;
+    await element.updateComplete;
+
+    const bar = element.shadowRoot?.getElementById('bar');
+    expect(bar?.hasAttribute('aria-busy')).toBe(false);
+    expect(bar?.getAttribute('aria-valuemin')).toBe('0');
+    expect(bar?.getAttribute('aria-valuemax')).toBe('100');
+    expect(bar?.getAttribute('aria-valuenow')).toBe('0');
+  });
+
   it('clamps existing progress when max is lowered', async () => {
     element.progress = 80;
     element.max = 40;

--- a/src/components/progress-bar/progress-bar.test.ts
+++ b/src/components/progress-bar/progress-bar.test.ts
@@ -8,7 +8,9 @@ describe('UUIProgressBarElement', () => {
   let element: UUIProgressBarElement;
 
   beforeEach(async () => {
-    element = render(html` <uui-progress-bar></uui-progress-bar> `).container.querySelector('uui-progress-bar')!;
+    element = render(html`
+      <uui-progress-bar></uui-progress-bar>
+    `).container.querySelector('uui-progress-bar')!;
 
     await element.updateComplete;
   });
@@ -27,10 +29,37 @@ describe('UUIProgressBarElement', () => {
     expect(element.progress).toBe(100);
   });
 
+  it('clamps the progress values greater than max to max', async () => {
+    element.max = 25;
+    element.progress = 44;
+    expect(element.progress).toBe(25);
+  });
+
+  it('clamps existing progress when max is lowered', async () => {
+    element.progress = 80;
+    element.max = 40;
+    expect(element.progress).toBe(40);
+  });
+
   it('sets the bar width corresponding to the progress', async () => {
     element.progress = 23;
     await element.updateComplete;
     const bar = element.shadowRoot?.getElementById('bar');
     expect(bar?.style.width).toBe('23%');
+  });
+
+  it('sets the bar width corresponding to max when max is not 100', async () => {
+    element.max = 40;
+    element.progress = 10;
+    await element.updateComplete;
+    const bar = element.shadowRoot?.getElementById('bar');
+    expect(bar?.style.width).toBe('25%');
+  });
+
+  it('sets aria-valuemax from max', async () => {
+    element.max = 40;
+    await element.updateComplete;
+    const bar = element.shadowRoot?.getElementById('bar');
+    expect(bar?.getAttribute('aria-valuemax')).toBe('40');
   });
 });

--- a/src/components/progress-bar/progress-bar.test.ts
+++ b/src/components/progress-bar/progress-bar.test.ts
@@ -9,7 +9,7 @@ describe('UUIProgressBarElement', () => {
 
   beforeEach(async () => {
     element = render(html`
-      <uui-progress-bar></uui-progress-bar>
+      <uui-progress-bar label="Progress"></uui-progress-bar>
     `).container.querySelector('uui-progress-bar')!;
 
     await element.updateComplete;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently `<uui-progress-bar>` doesn't include `aria-*` attributes for progress.

I also added property for `max` which native `<progress>` has, where default is 1. Perhaps we should consider consider using `label` property for this? E.g. instead of 30% it can be used as 3/10 too as shown here:
http://circuit.sumup.com/?path=/docs/components-progressbar--docs#percentage-or-fraction-label

Maybe we should also deprecate `progress` property and add a `value` property instead, which can be omitted or undefined/null, which mean the progress bar will have an `indeterminate` state as described here:
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/progress#value

Some use cases for this is a loop in progress:
https://circuit.sumup.com/?path=/docs/components-progressbar--docs#component-variations

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

To let assistive technologies know about progress.
In bulk publishing here a progress `1 / 9` could also have been used, but I think percentages is fine as well.
https://github.com/umbraco/Umbraco-CMS/pull/21215

In the linked PR above the progress bar has a different color. Should we allow to override this via a CSS variable or change the default from `--uui-color-positive`?

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
