### PR TITLE
Split button component

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -79,3 +79,4 @@ export * from './file-preview/file-preview.js';
 export * from './input-file/input-file.js';
 export * from './combobox/combobox.js';
 export * from './color-picker/color-picker.js';
+export * from './split-button/split-button.js';

--- a/src/components/split-button/README.md
+++ b/src/components/split-button/README.md
@@ -1,0 +1,13 @@
+# uui-split-button
+
+Umbraco style split-button component.
+
+## Usage
+
+```javascript
+import '@umbraco-ui/uui/components/split-button/split-button.js';
+```
+
+```html
+<uui-split-button></uui-split-button>
+```

--- a/src/components/split-button/split-button.element.ts
+++ b/src/components/split-button/split-button.element.ts
@@ -1,12 +1,16 @@
 import { css, html, LitElement } from 'lit';
-import type { UUIInterfaceColor, UUIInterfaceLook } from '../../internal/types';
 import { eventOptions, property, query } from 'lit/decorators.js';
+import { when } from 'lit/directives/when.js';
+
+import type { UUIInterfaceColor, UUIInterfaceLook } from '../../internal/types/index.js';
 import type {
   PopoverContainerPlacement,
   UUIPopoverContainerElement,
-} from '../popover-container/popover-container';
-import { when } from 'lit/directives/when.js';
+} from '../popover-container/popover-container.js';
 
+import '../button/button.js';
+import '../symbol-expand/symbol-expand.js';
+import '../popover-container/popover-container.js';
 /**
  * @element uui-split-button
  */

--- a/src/components/split-button/split-button.element.ts
+++ b/src/components/split-button/split-button.element.ts
@@ -1,0 +1,153 @@
+import { css, html, LitElement } from 'lit';
+import type { UUIInterfaceColor, UUIInterfaceLook } from '../../internal/types';
+import { eventOptions, property, query } from 'lit/decorators.js';
+import type {
+  PopoverContainerPlacement,
+  UUIPopoverContainerElement,
+} from '../popover-container/popover-container';
+import { when } from 'lit/directives/when.js';
+
+/**
+ * @element uui-split-button
+ */
+export class UUISplitButtonElement extends LitElement {
+  #open = false;
+
+  @property({ type: Boolean, reflect: true })
+  public get open() {
+    return this.#open;
+  }
+  public set open(value) {
+    this.#open = value;
+
+    if (value === true && this.popoverContainerElement) {
+      this.openDropdown();
+    } else {
+      this.closeDropdown();
+    }
+  }
+
+  @property()
+  label?: string;
+
+  @property()
+  look: UUIInterfaceLook = 'default';
+
+  @property()
+  color: UUIInterfaceColor = 'default';
+
+  @property()
+  placement: PopoverContainerPlacement = 'bottom-start';
+
+  @property({ type: Boolean })
+  compact = false;
+
+  @property({ type: Boolean, reflect: true })
+  disabled = false;
+
+  @property({ type: Boolean, attribute: 'hide-expand' })
+  hideExpand = false;
+
+  @query('#dropdown-popover')
+  popoverContainerElement?: UUIPopoverContainerElement;
+
+  openDropdown() {
+    // TODO: This ignorer is just needed for JSON SCHEMA TO WORK, As its not updated with latest TS jet.
+    // @ts-ignore
+    this.popoverContainerElement?.showPopover();
+    this.#open = true;
+  }
+
+  closeDropdown() {
+    // TODO: This ignorer is just needed for JSON SCHEMA TO WORK, As its not updated with latest TS jet.
+    // @ts-ignore
+    this.popoverContainerElement?.hidePopover();
+    this.#open = false;
+  }
+
+  #onToggle(event: ToggleEvent) {
+    // TODO: This ignorer is just needed for JSON SCHEMA TO WORK, As its not updated with latest TS jet.
+
+    // @ts-ignore
+    this.open = event.newState === 'open';
+
+    /*if (this.open) {
+      this.dispatchEvent(new UmbOpenedEvent());
+    } else {
+      this.dispatchEvent(new UmbClosedEvent());
+    }*/
+  }
+
+  // Capture phase so this runs before a menu item's action opens its modal: WebKit otherwise
+  // leaves the popovertarget toggle state "open" after the modal light-dismisses the popover,
+  // and the trigger then stops responding until the page is reloaded.
+  @eventOptions({ capture: true })
+  private _onPopoverClickCapture() {
+    if (this.#open) {
+      this.closeDropdown();
+    }
+  }
+
+  render() {
+    return html`<uui-button
+        .look=${this.look}
+        .color=${this.color}
+        .label=${this.label ?? ''}
+        .compact=${this.compact}
+        ?disabled=${this.disabled}>
+        <slot name="label"></slot>
+      </uui-button>
+      ${when(
+        !this.hideExpand,
+        () =>
+          html`<uui-button
+            .look=${this.look}
+            .color=${this.color}
+            .compact=${this.compact}
+            ?disabled=${this.disabled}
+            id="dropdown-button"
+            popovertarget="dropdown-popover"
+            data-mark="open-dropdown">
+            <uui-symbol-expand
+              id="symbol-expand"
+              .open=${this.#open}></uui-symbol-expand>
+          </uui-button>`,
+      )}
+      <uui-popover-container
+        id="dropdown-popover"
+        .placement=${this.placement}
+        @toggle=${this.#onToggle}
+        @click=${this._onPopoverClickCapture}>
+        <umb-popover-layout>
+          <slot></slot>
+        </umb-popover-layout>
+      </uui-popover-container>`;
+  }
+
+  static override styles = [
+    css`
+      :host {
+        display: inline-flex;
+        gap: 1px;
+      }
+      :host(:not([hide-expand])) uui-button:first-of-type {
+        --uui-button-border-radius: var(--uui-border-radius-3) 0 0
+          var(--uui-border-radius-3);
+      }
+      :host(:not([hide-expand])) uui-button:last-of-type {
+        --uui-button-border-radius: 0 var(--uui-border-radius-3)
+          var(--uui-border-radius-3) 0;
+      }
+
+      #dropdown-button {
+        min-width: max-content;
+        height: 100%;
+        color: inherit;
+      }
+      :host(:not([hide-expand]):not([compact])) #dropdown-button {
+        --uui-button-padding-left-factor: 2;
+        --uui-button-padding-right-factor: 2;
+      }
+    `,
+  ];
+}

--- a/src/components/split-button/split-button.story.ts
+++ b/src/components/split-button/split-button.story.ts
@@ -1,0 +1,54 @@
+import './split-button.js';
+import '../menu-item/menu-item.js';
+import readme from './README.md?raw';
+import { html } from 'lit';
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { spread } from '../../../storyhelpers';
+
+const menuItems = ['Action 1', 'Action 2', 'Action 3'];
+
+const renderSplitButton = (args: Record<string, unknown>) => html`
+  <uui-split-button ${spread(args)}>
+    <span slot="label">${args.label}</span>
+    ${menuItems.map(
+      item => html`<uui-menu-item label=${item}></uui-menu-item>`,
+    )}
+  </uui-split-button>
+`;
+
+const meta: Meta = {
+  id: 'uui-split-button',
+  component: 'uui-split-button',
+  title: 'Buttons/Split Button',
+  args: {
+    label: 'Button',
+    look: 'primary',
+  },
+  render: args => renderSplitButton(args),
+  parameters: {
+    readme: { markdown: readme },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {};
+
+export const Compact: Story = {
+  args: {
+    compact: true,
+  },
+};
+
+export const HiddenExpand: Story = {
+  args: {
+    'hide-expand': true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};

--- a/src/components/split-button/split-button.test.ts
+++ b/src/components/split-button/split-button.test.ts
@@ -1,0 +1,24 @@
+import './split-button.js';
+import { html } from 'lit';
+import { render } from 'vitest-browser-lit';
+import { axeRun } from '../../internal/test/a11y.js';
+import { UUISplitButtonElement } from './split-button.element';
+
+describe('UUISplitButtonElement', () => {
+  let element: UUISplitButtonElement;
+
+  beforeEach(async () => {
+    element = render(
+      html`<uui-split-button></uui-split-button>`,
+    ).container.querySelector('uui-split-button')!;
+    await element.updateComplete;
+  });
+
+  it('is defined with its own instance', () => {
+    expect(element).toBeInstanceOf(UUISplitButtonElement);
+  });
+
+  it('passes the a11y audit', async () => {
+    expect(await axeRun(element)).toHaveNoViolations();
+  });
+});

--- a/src/components/split-button/split-button.ts
+++ b/src/components/split-button/split-button.ts
@@ -1,0 +1,12 @@
+import { defineElement } from '../../internal/registration/index.js';
+import { UUISplitButtonElement } from './split-button.element.js';
+
+defineElement('uui-split-button', UUISplitButtonElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'uui-split-button': UUISplitButtonElement;
+  }
+}
+
+export * from './split-button.element.js';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Based on discussion: https://github.com/umbraco/Umbraco.UI/discussions/1133

Split Button seems to be a common concept throughout UI/UX, where the button has an action + additional actions via dropdown.
https://www.nngroup.com/articles/split-buttons/
https://web.dev/articles/building/a-split-button-component

Part of it based on `umb-dropdown` here, but I think the dropdown should act on a button/toggle next to a primary button as examples above.
https://github.com/umbraco/Umbraco-CMS/blob/45b4b2a132f92ad034d33e5ccc413415105b4c33/src/Umbraco.Web.UI.Client/src/packages/core/components/dropdown/dropdown.element.ts

Currently it has 1px gap, but there may be a better way to add a border/separator, so it inherits same color as text color and not rely on background color in user interface.

Using two button components ensure we can navigate these via keyboard.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

I think it would be useful in many parts of back office UI, e.g. "Save & Publish" may be primary actions, while popup/dropdown button shows more actions.

Also in collections with one or more actions. Either a regular button if only a single action of just render split button without expand options.

## How to test?

## Screenshots (if appropriate)

<img width="384" height="222" alt="image" src="https://github.com/user-attachments/assets/4c59270b-7ffa-4a3d-8148-6c1b673ea436" />

With the new rounding in UI library v2, I think the  `compact` button looks a bit too squeezed:

<img width="353" height="123" alt="image" src="https://github.com/user-attachments/assets/ff35760f-8b29-4f99-8017-6e38c60d7891" />


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
