### PR TITLE
fix(icon): remove non-standard :host-context() for cross-browser icon alignment (Closes #1459)

### DIFF
--- a/packages/uui-icon/lib/uui-icon.element.ts
+++ b/packages/uui-icon/lib/uui-icon.element.ts
@@ -156,14 +156,6 @@ export class UUIIconElement extends LitElement {
         );
         width: 100%;
       }
-
-      :host-context(div[slot='prepend']) {
-        margin-left: var(--uui-size-2, 6px);
-      }
-
-      :host-context(div[slot='append']) {
-        margin-right: var(--uui-size-2, 6px);
-      }
     `,
   ];
 }

--- a/packages/uui-input/lib/uui-input.element.ts
+++ b/packages/uui-input/lib/uui-input.element.ts
@@ -519,6 +519,14 @@ export class UUIInputElement extends UUIFormControlMixin(
         min-width: 0;
       }
 
+      slot[name='prepend']::slotted(div) {
+        margin-left: var(--uui-size-2, 6px);
+      }
+
+      slot[name='append']::slotted(div) {
+        margin-right: var(--uui-size-2, 6px);
+      }
+
       ::slotted(uui-input),
       ::slotted(uui-input-lock) {
         height: 100%;


### PR DESCRIPTION
## Description

Replace `:host-context()` with `::slotted()` for icon alignment in prepend/append slots. The `:host-context()` selector only works in Chromium and [will be deprecated](https://github.com/w3c/csswg-drafts/issues/1914#issuecomment-1765611498).

Closes #1459

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Screenshots

| Before (Firefox) | After (Firefox) |
|------------------|-----------------|
| <img width="285" height="131" alt="image" src="https://github.com/user-attachments/assets/430492b0-655d-44f0-913a-25ac5a6eb787" /> | <img width="294" height="114" alt="image" src="https://github.com/user-attachments/assets/fdb84cd9-fbe1-43ba-81bf-f36f14e47788" />|

## How to test?

1. Run `npm run storybook`
2. Open **Inputs → Input → Prepend Icon In Div** in Firefox/Safari
3. Verify the search icon has proper left margin

## Checklist

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
