### PR TITLE
fix(icon): remove non-standard :host-context() for cross-browser icon alignment (v2)

### DIFF
--- a/src/components/icon/icon.element.ts
+++ b/src/components/icon/icon.element.ts
@@ -154,14 +154,6 @@ export class UUIIconElement extends LitElement {
         );
         width: 100%;
       }
-
-      :host-context(div[slot='prepend']) {
-        margin-left: var(--uui-size-2, 6px);
-      }
-
-      :host-context(div[slot='append']) {
-        margin-right: var(--uui-size-2, 6px);
-      }
     `,
   ];
 }

--- a/src/components/input/input.element.ts
+++ b/src/components/input/input.element.ts
@@ -523,6 +523,14 @@ export class UUIInputElement extends UUIFormControlWithBasicsMixin(
         min-width: 0;
       }
 
+      slot[name='prepend']::slotted(div) {
+        margin-left: var(--uui-size-2, 6px);
+      }
+
+      slot[name='append']::slotted(div) {
+        margin-right: var(--uui-size-2, 6px);
+      }
+
       uui-input,
       uui-input-lock,
       ::slotted(uui-input),


### PR DESCRIPTION
## Description

Port of #1466 to v2.

Replace `:host-context()` with `::slotted()` for icon alignment in prepend/append slots. The `:host-context()` selector only works in Chromium and [will be deprecated](https://github.com/w3c/csswg-drafts/issues/1914#issuecomment-1765611498).

Closes #1459

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Screenshots

| Before (Firefox) | After (Firefox) |
|------------------|-----------------|
| <img width="256" height="109" alt="image" src="https://github.com/user-attachments/assets/51bcca1e-8254-4319-80aa-11e9c3ca914c" /> | <img width="268" height="118" alt="image" src="https://github.com/user-attachments/assets/ddbfc2af-ccc3-4501-98bc-f8c70e4734dd" /> |

## How to test?

1. Run `npm run storybook`
2. Open **Inputs → Input → Prepend Icon In Div** in Firefox/Safari
3. Verify the search icon has proper left margin

## Checklist

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
